### PR TITLE
Change status to Unofficial Proposal Draft

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: WebDriver BiDi
 Shortname: webdriver-bidi
 Level: 1
-Status: w3c/LD
+Status: w3c/UD
 Group: Browser Testing and Tools Working Group
 URL: https://w3c.github.io/webdriver-bidi/
 Editor: Browser Testing and Tools Working Group, https://www.w3.org/testing/browser/


### PR DESCRIPTION
LD can't be used by W3C groups. UD seems to be the most accurate for now:
https://tabatkins.github.io/bikeshed/#metadata


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 28, 2020, 2:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2F875bda0e6ad5539dee262cd905450a4f63256fdc%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Status 'LD' can't be used with the org 'w3c'. Check the docs for valid Status values.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%2310.)._
</details>
