### PR TITLE
Adopt the "To <name> given <parameters>" algorithm style

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -65,8 +65,8 @@ WebSocket closing handshake is started=] an implementation must
 |connection|.
 
 <div algorithm>
-To <dfn>start listening for a WebSocket connection</dfn> for a |session|, run
-these steps:
+To <dfn>start listening for a WebSocket connection</dfn> given a
+[=session=] |session|:
 
  1. Set up a network connection that listens on an implementation-defined
     hostname |host| and port |port|. The connection may TLS encrypted, in which
@@ -90,15 +90,17 @@ websocket connection
 Note: For an [=endpoint node=] the hostname in the above steps will be
 typically be "<code>localhost</code>".
 
-<div algorithm> To <dfn>handle an incoming message</dfn> for a
-<var ignore>connection</var>, run these steps:
+<div algorithm>
+To <dfn>handle an incoming message</dfn> given a
+[=WebSocket connection=] <var ignore>connection</var>:
 
 Issue: Figure this out.
 
 </div>
 
-<div algorithm> To <dfn>close the WebSocket connection</dfn> for a
-|connection|, run these steps:
+<div algorithm>
+To <dfn>close the WebSocket connection</dfn> given a
+[=WebSocket connection=] |connection|:
 
  1. Close the underlying network connection associated with |connection|.
 


### PR DESCRIPTION
This follows @domenic's most recent style here:
https://wicg.github.io/kv-storage/
https://wicg.github.io/origin-policy/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 4, 2020, 5:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2F1b1fb01c14e76fe86b6e0d310c75181622c65bfc%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    bikeshed.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 220, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 256, in handleSpec
    doc.preprocess()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 109, in preprocess
    self.assembleDocument()
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 133, in assembleDocument
    self.md.computeImplicitMetadata(doc=self)
  File "/sites/api.csswg.org/bikeshed/bikeshed/metadata.py", line 175, in computeImplicitMetadata
    if self.repository.type == "github" and "feedback-header" in self.boilerplate and "repository-issue-tracking" in self.boilerplate:
AttributeError: 'NoneType' object has no attribute 'type'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%2327.)._
</details>
