### PR TITLE
Set the repository in Bikeshed metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,6 +5,7 @@ Level: 1
 Status: ED
 Group: browser-testing-tools
 URL: https://w3c.github.io/webdriver-bidi/
+Repository: w3c/webdriver-bidi
 No Editor: true
 Abstract: This document defines the BiDirectional WebDriver Protocol, a mechanism for remote control of user agents.
 Default Ref Status: current


### PR DESCRIPTION
This fixes PR Preview.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 5, 2020, 7:02 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2F92a94be8bed0ffbc2d87c46c578fa5795c17f9f9%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Found unmatched text macro [REPOSITORY]. Correct the macro, or escape it with a leading backslash.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%2330.)._
</details>
