### PR TITLE
Update Target Discovery & Message Routing Proposal

### DIFF
--- a/proposals/core.md
+++ b/proposals/core.md
@@ -100,7 +100,8 @@ All event messages have a "from" property indicating which object in the BiDi mo
 {
     "from": "browsingContext/333",
     "method": "logging.entryAdded",
-    "params": { "type": "info", message: "Hello World!" }
+    "params": { "type": "info", "message": "Hello World!" }
+
 }
 ```
 


### PR DESCRIPTION
This change updates the core proposal considering some feedback from active GitHub issues as well as the working group meeting. A quick summary of changes:

1. An updated Object Model that more closely reflects how browsing contexts and various worker types are specified. Also adds some new worker types that were not in the proposal initially.
2. A string ID format to address any of these objects
3. Added "to" and "from" fields in the low-level transport format to route commands to an object and know which object an event is coming from
4. A subset of events that are always enabled to assist with target discovery
5. Removed the ref-counted proposal for event subscription. Subscriptions are now simply enabled or disabled per-target. Using domains instead of individual event names.