### PR TITLE
Add initial support for subscribing to events.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -662,14 +662,14 @@ with parameters |session| and |capabilities| is:
 
 </div>
 
-Common Data Types {#data_types}
+Common Data Types {#data-types}
 ===============================
 
 This section defines data types which are common to many modules.
 
 ## Browsing Context ## {#data_types-browsing_context}
 
-[= remote end schema=] and [= local end schema=]
+[=remote end schema=] and [=local end schema=]
 ```
 BrowsingContext = text;
 ```
@@ -679,9 +679,9 @@ which is a string uniquely identifying that browsing context. For browsing
 contexts with an associated WebDriver [=window handle=] the [=/browsing context
 id=] must be the same as the [=window handle=].
 
-## Realm ## {#data_types-realm}
+## Realm ## {#data-types-realm}
 
-[= remote end schema=] and [= local end schema=]
+[=remote end schema=] and [=local end schema=]
 ```
 Realm = text;
 ```

--- a/index.bs
+++ b/index.bs
@@ -725,7 +725,7 @@ To <dfn lt="updating the event map">update the event map</dfn>, given
        the union of |event names| and the result of [=trying=] to [=obtain a set
        of event names=] with |name|.
 
-    1. If the |list of contexts| is null, run the following substeps:
+    1. If the |list of contexts| is null:
 
       1. If |enabled| is true, for each |event name| in |event names|,
          append |event name| to |global event set|. Otherwise for for each
@@ -736,7 +736,7 @@ To <dfn lt="updating the event map">update the event map</dfn>, given
 
     1. Let |targets| be an empty list.
 
-    1. For each entry |context id| in the |list of contexts|, run the following substeps:
+    1. For each entry |context id| in the |list of contexts|:
 
       1. If there is no browsing context with [=browsing context id=] |context id| return
          [=error=] with [=error code=] [=invalid argument=]
@@ -748,9 +748,9 @@ To <dfn lt="updating the event map">update the event map</dfn>, given
       1. Get the entry from the |event map| for |context| and append it to
          |targets|.
 
-    1. For each |target| in |targets|, run the following steps:
+    1. For each |target| in |targets|:
 
-      1. For each |event name| in |event names|, run the following steps:
+      1. For each |event name| in |event names|:
 
         1. Set |target|[|event name|] to |enabled|.
 

--- a/index.bs
+++ b/index.bs
@@ -37,6 +37,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: additional WebDriver capability; url: dfn-additional-webdriver-capability
     text: capability name; url: dfn-capability-name
+    text: current session; url: dfn-current-session
     text: endpoint node; url: dfn-endpoint-node
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
@@ -273,8 +274,8 @@ occurred on the [=remote end=].
     - <code>params</code> which defines a mapping containing event data. The
       populated value of this map is the <dfn export for=command>event
       parameters</code>.
- - A [=remote end event trigger=] which define when the event is triggered
-   and steps to construct the [=event type=] data.
+ - A <dfn export>remote end event trigger</dfn> which define when the event is
+   triggered and steps to construct the [=event type=] data.
 
 A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set
 containing containing the event names for events that are enabled for all
@@ -288,15 +289,16 @@ disabled for a given browsing context.
 
 <div algorithm>
 
-To determine if an <dfn export>event is enabled</dfn> given an |event name| and
-|browsing context|:
+To determine if an <dfn export>event is enabled</dfn> given |session|,
+|event name| and |browsing context|:
 
   1. While |browsing context| is not null:
 
-    1. If [=browsing context event map=] contains an entry for |browsing
-       context|, let |browsing context events| be [=browsing context event
-       map=][|browsing context|].  Otherwise let |browsing context events| be
-       null.
+    1. Let |event map| be the [=browsing context event map=] for |session|.
+
+    1. If |event map| contains an entry for |browsing context|, let |browsing
+       context events| be |event map|[|browsing context|].  Otherwise let
+       |browsing context events| be null.
 
     1. If |browsing context events| is not null, and |browsing context events|
        contains an entry for |event name| return |browsing context
@@ -305,7 +307,8 @@ To determine if an <dfn export>event is enabled</dfn> given an |event name| and
     1. Let |browsing context| be the [=parent browsing context=] of |browsing
        context|, if it has one, or null otherwise.
 
-  1. If the [=global event set=] contains |event name| return true.
+  1. If the [=global event set=] for |session| contains |event name| return
+     true.
 
   1. Return false.
 
@@ -709,8 +712,12 @@ SessionResult = (StatusResult)
 
 <div algorithm>
 
-To <dfn lt="updating the event map">update the event map</dfn>, given a |list of
-event names|, a |list of contexts|, and a |enabled|:
+To <dfn lt="updating the event map">update the event map</dfn>, given
+|session|, |list of event names|, |list of contexts|, and |enabled|:
+
+  1. Let |global event set| be the [=global event set=] for |session|.
+
+  1. Let |event map| be the [=browsing context event map=] for |session|.
 
   1. Let |event names| be an empty set.
 
@@ -721,9 +728,9 @@ event names|, a |list of contexts|, and a |enabled|:
     1. If the |list of contexts| is null, run the following substeps:
 
       1. If |enabled| is true, for each |event name| in |event names|,
-         append |event name| to the [=global event set=]. Otherwise for for each
-         |event name| in |event names|, if the [=global event set=] contains
-         |event name|, remote |event name| from the [=global event set=].
+         append |event name| to |global event set|. Otherwise for for each
+         |event name| in |event names|, if the |global event set| contains
+         |event name|, remote |event name| from the |global event set|.
 
       1. Return
 
@@ -735,11 +742,11 @@ event names|, a |list of contexts|, and a |enabled|:
          [=error=] with [=error code=] [=invalid argument=]
 
       1. Let |context| be the browsing context with id |context id|. If the
-         [=browsing context event map=] does not contain an entry for |context|,
+         |event map| does not contain an entry for |context|,
          set the value of the entry for |context| to a new empty map.
 
-      1. Get the entry from the [=browsing context event map=] for |context|
-         and append it to |targets|.
+      1. Get the entry from the |event map| for |context| and append it to
+         |targets|.
 
     1. For each |target| in |targets|, run the following steps:
 
@@ -833,8 +840,8 @@ The [=remote end steps=] with |command parameters| are:
     1. Let the |list of contexts| be the value of the <code>contexts</code>
        field of |command parameters| if it is present or null if it isn't.
 
-    1. Return the result of [=updating the event map=] with |list of event
-       names|, |list of contexts| and enabled true.
+    1. Return the result of [=updating the event map=] with [=current session=],
+       |list of event names|, |list of contexts| and enabled true.
 </div>
 
 ### Unsubscribe ### {#command-session-unsubscribe}
@@ -870,6 +877,6 @@ The [=remote end steps=] with |command parameters| are:
     1. Let the |list of contexts| be the value of the <code>contexts</code>
        field of |command parameters| if it is present or null if it isn't.
 
-    1. Return the result of [=updating the event map=] with |list of event
-       names|, |list of contexts| and enabled false.
+    1. Return the result of [=updating the event map=] with [=current session=],
+       |list of event names|, |list of contexts| and enabled false.
 </div>

--- a/index.bs
+++ b/index.bs
@@ -273,41 +273,39 @@ occurred on the [=remote end=].
     - <code>params</code> which defines a mapping containing event data. The
       populated value of this map is the <dfn export for=command>event
       parameters</code>.
- - A set of [=remote end steps=] which define how to construct the [=event
-   type=] data.
- - An <dfn export for=event>event trigger</dfn> which is a condition on which
-   the [=remote end steps=] for the event are invoked.
+ - A [=remote end event trigger=] which define when the event is triggered
+   and steps to construct the [=event type=] data.
 
 A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set
-containing containing the [=event types=] that are enabled for all browsing
-contexts. This initially contains events that are <dfn export for=event>in the
-default event set</dfn>.
+containing containing the event names for events that are enabled for all
+browsing contexts. This initially contains the [=event name=] for events that
+are <dfn export for=event>in the default event set</dfn>.
 
 A [=/session=] has a <dfn export for=event>browsing context event map</dfn>,
-which is a map with [=/browsing context=] keys and values that are maps
-from an [=event type=] to a boolean indicating whether the specified event type
-is enabled or disabled for a given browsing context.
+which is a map with [=/browsing context=] keys and values that are maps from an
+[=event name=] to a boolean indicating whether the specified event is enabled or
+disabled for a given browsing context.
 
 <div algorithm>
 
-To determine if an <dfn export>event is enabled</dfn> given an |event type| and
+To determine if an <dfn export>event is enabled</dfn> given an |event name| and
 |browsing context|:
 
   1. While |browsing context| is not null:
 
     1. If [=browsing context event map=] contains an entry for |browsing
-       context|, let |browsing context events| be the result of getting the value of an
-       entry with key |browsing context| from [=browsing context event map=],
-       otherwise let |browsing context events| be <code>undefined</code>.
+       context|, let |browsing context events| be [=browsing context event
+       map=][|browsing context|].  Otherwise let |browsing context events| be
+       null.
 
-    1. If |browsing context events| is not <code>undefined</code>, return the
-       result of getting the value of the entry with key |event type| from
-       |browsing context events|.
+    1. If |browsing context events| is not null, and |browsing context events|
+       contains an entry for |event name| return |browsing context
+       events|[|event name|].
 
     1. Let |browsing context| be the [=parent browsing context=] of |browsing
        context|, if it has one, or null otherwise.
 
-  1. If the [=global event set=] contains |event type| return true.
+  1. If the [=global event set=] contains |event name| return true.
 
   1. Return false.
 
@@ -315,22 +313,23 @@ To determine if an <dfn export>event is enabled</dfn> given an |event type| and
 
 <div algorithm>
 
-To <dfn>obtain a set of events from a name</dfn> given an |event name|:
+To <dfn>obtain a set of event names</dfn> given an |name|:
 
   1. Let |events| be an empty set.
 
-  1. If |event name| contains a U+002E (period):
+  1. If |name| contains a U+002E (period):
 
-    1. If |event name| is the [=event name=] for an event, append that event to
-       |events| and return [=success=] with data |events|.
+    1. If |name| is the [=event name=] for an event, append |name| to |events|
+       and return [=success=] with data |events|.
 
     1. Return an [=error=] with [=error code=] [=Invalid Argument=]
 
-  1. Otherwise |event name| is interpreted as representing all the events in a
-     module. If |event name| is not a [=module name=] return an [=error=] with
+  1. Otherwise |name| is interpreted as representing all the events in a
+     module. If |name| is not a [=module name=] return an [=error=] with
      [=error code=] [=Invalid Argument=].
 
-  1. Add each [=event=] in the module with name |event name| to |events|.
+  1. Append the [=event name=] for each [=event=] in the module with name |name| to
+     |events|.
 
   1. Return [=success=] with data |events|.
 </div>
@@ -711,17 +710,26 @@ SessionResult = (StatusResult)
 <div algorithm>
 
 To <dfn lt="updating the event map">update the event map</dfn>, given a |list of
-event names|, a |list of contexts|, and a |target status|:
+event names|, a |list of contexts|, and a |enabled|:
 
-  1. Let |events| be an empty set.
+  1. Let |event names| be an empty set.
 
-    1. For each entry |event name| in the |list of event names|,
-       let |events| be the union of |events| and the result of [=trying=] to
-       [=obtain a set of events from a name=] with |event name|.
+    1. For each entry |name| in the |list of event names|, let |event names| be
+       the union of |event names| and the result of [=trying=] to [=obtain a set
+       of event names=] with |name|.
 
-    1. If the |list of contexts| is null, let |targets| be a set containing the [=global
-       event set=]. Otherwise for each entry |context id| in the |list of
-       contexts|, run the following substeps:
+    1. If the |list of contexts| is null, run the following substeps:
+
+      1. If |enabled| is true, for each |event name| in |event names|,
+         append |event name| to the [=global event set=]. Otherwise for for each
+         |event name| in |event names|, if the [=global event set=] contains
+         |event name|, remote |event name| from the [=global event set=].
+
+      1. Return
+
+    1. Let |targets| be an empty list.
+
+    1. For each entry |context id| in the |list of contexts|, run the following substeps:
 
       1. If there is no browsing context with [=browsing context id=] |context id| return
          [=error=] with [=error code=] [=invalid argument=]
@@ -735,9 +743,9 @@ event names|, a |list of contexts|, and a |target status|:
 
     1. For each |target| in |targets|, run the following steps:
 
-      1. For each |event| in events, run the following steps:
+      1. For each |event name| in |event names|, run the following steps:
 
-        1. Set the value of |target| for |event| to |target status|.
+        1. Set |target|[|event name|] to |enabled|.
 
     1. Return [=success=] with data null.
 </div>
@@ -791,7 +799,7 @@ The [=remote end steps=] are:
 The <dfn export for=commands>subscribe</dfn> command enables certain events either
 globally or for a set of browsing contexts
 
-Issue: This needs to be generalised to work with realms too
+Issue: This needs to be generalized to work with realms too
 
 <dl>
    <dt>Command Type</dt>
@@ -803,7 +811,7 @@ Issue: This needs to be generalised to work with realms too
       }
 
       SubscribeParameters = {
-        events: [text],
+        events: [*text],
         contexts?: [BrowsingContext],
         * text => any,
       }
@@ -818,7 +826,7 @@ Issue: This needs to be generalised to work with realms too
 </dl>
 
 The [=remote end steps=] with |command parameters| are:
-
+<div algorithm="remote end steps for session.subscribe">
     1. Let the |list of event names| be the value of the <code>events</code> field of
        |command parameters|.
 
@@ -826,7 +834,8 @@ The [=remote end steps=] with |command parameters| are:
        field of |command parameters| if it is present or null if it isn't.
 
     1. Return the result of [=updating the event map=] with |list of event
-       names|, |list of contexts| and the target status set to true.
+       names|, |list of contexts| and enabled true.
+</div>
 
 ### Unsubscribe ### {#command-session-unsubscribe}
 
@@ -854,7 +863,7 @@ Issue: This needs to be generalised to work with realms too
 </dl>
 
 The [=remote end steps=] with |command parameters| are:
-
+<div algorithm="remote end steps for session.unsubscribe">
     1. Let the |list of event names| be the value of the <code>events</code> field of
        |command parameters|.
 
@@ -862,5 +871,5 @@ The [=remote end steps=] with |command parameters| are:
        field of |command parameters| if it is present or null if it isn't.
 
     1. Return the result of [=updating the event map=] with |list of event
-       names|, |list of contexts| and the target status set to false.
-
+       names|, |list of contexts| and enabled false.
+</div>

--- a/index.bs
+++ b/index.bs
@@ -113,6 +113,7 @@ the remainder of the specification.
 Command = {
   id: uint,
   CommandData,
+  *text => any,
 }
 
 CommandData = (
@@ -130,17 +131,18 @@ Message = (
   Event
 )
 
-CommandResponse = (
+CommandResponse = {
   id: uint,
   ResponseData,
-)
+  *text => any
+}
 
 ResponseData = (
   Error //
   CommandResult
 )
 
-Error = (
+Error = {
   error: (
     "unknown error" /
     "unknown method" /
@@ -148,7 +150,7 @@ Error = (
   ),
   message: text,
   stacktrace: text,
-)
+}
 
 CommandResult = {
   value: ResultData,
@@ -159,9 +161,11 @@ ResultData = (
   SessionResult
 )
 
-EmptyResult = { *text }
+EmptyResult = {}
 
-Event = ()
+Event = (
+  *text => any
+)
 </pre>
 
 ## Session ## {#session}
@@ -730,7 +734,7 @@ To <dfn lt="updating the event map">update the event map</dfn>, given
       1. If |enabled| is true, for each |event name| in |event names|,
          append |event name| to |global event set|. Otherwise for for each
          |event name| in |event names|, if the |global event set| contains
-         |event name|, remote |event name| from the |global event set|.
+         |event name|, remove |event name| from the |global event set|.
 
       1. Return
 
@@ -755,6 +759,12 @@ To <dfn lt="updating the event map">update the event map</dfn>, given
         1. Set |target|[|event name|] to |enabled|.
 
     1. Return [=success=] with data null.
+
+    Note: Implementations that do additional work when an event is enabled,
+    e.g. subscribing to the relevant engine-internal events, will likely perform
+    those additional steps when updating the event map. This specification uses
+    a model where hooks are always called and then the event map is used to
+    filter only those that ought to be returned to the local end.
 </div>
 
 ### Status ### {#command-session-status}
@@ -780,7 +790,6 @@ to the implementation.
       StatusResult = {
          ready: bool,
          message: text,
-         * text => any
       }
       </pre>
    </dd>
@@ -819,8 +828,7 @@ Issue: This needs to be generalized to work with realms too
 
       SubscribeParameters = {
         events: [*text],
-        contexts?: [BrowsingContext],
-        * text => any,
+        contexts?: [*BrowsingContext],
       }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,7 @@ occurred on the [=remote end=].
     - <code>params</code> which defines a mapping containing event data. The
       populated value of this map is the <dfn export for=command>event
       parameters</code>.
- - A <dfn export>remote end event trigger</dfn> which define when the event is
+ - A <dfn export>remote end event trigger</dfn> which defines when the event is
    triggered and steps to construct the [=event type=] data.
 
 A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set

--- a/index.bs
+++ b/index.bs
@@ -55,6 +55,10 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
+    text: window handle; url: dfn-window-handle
+spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
+  type: dfn
+    text: realm; url: sec-code-realms
 </pre>
 
 <pre class="link-defaults">
@@ -269,6 +273,67 @@ occurred on the [=remote end=].
     - <code>params</code> which defines a mapping containing event data. The
       populated value of this map is the <dfn export for=command>event
       parameters</code>.
+ - A set of [=remote end steps=] which define how to construct the [=event
+   type=] data.
+ - An <dfn export for=event>event trigger</dfn> which is a condition on which
+   the [=remote end steps=] for the event are invoked.
+
+A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set
+containing containing the [=event types=] that are enabled for all browsing
+contexts. This initially contains events that are <dfn export for=event>in the
+default event set</dfn>.
+
+A [=/session=] has a <dfn export for=event>browsing context event map</dfn>,
+which is a map with [=/browsing context=] keys and values that are maps
+from an [=event type=] to a boolean indicating whether the specified event type
+is enabled or disabled for a given browsing context.
+
+<div algorithm>
+
+To determine if an <dfn export>event is enabled</dfn> given an |event type| and
+|browsing context|:
+
+  1. While |browsing context| is not null:
+
+    1. If [=browsing context event map=] contains an entry for |browsing
+       context|, let |browsing context events| be the result of getting the value of an
+       entry with key |browsing context| from [=browsing context event map=],
+       otherwise let |browsing context events| be <code>undefined</code>.
+
+    1. If |browsing context events| is not <code>undefined</code>, return the
+       result of getting the value of the entry with key |event type| from
+       |browsing context events|.
+
+    1. Let |browsing context| be the [=parent browsing context=] of |browsing
+       context|, if it has one, or null otherwise.
+
+  1. If the [=global event set=] contains |event type| return true.
+
+  1. Return false.
+
+</div>
+
+<div algorithm>
+
+To <dfn>obtain a set of events from a name</dfn> given an |event name|:
+
+  1. Let |events| be an empty set.
+
+  1. If |event name| contains a U+002E (period):
+
+    1. If |event name| is the [=event name=] for an event, append that event to
+       |events| and return [=success=] with data |events|.
+
+    1. Return an [=error=] with [=error code=] [=Invalid Argument=]
+
+  1. Otherwise |event name| is interpreted as representing all the events in a
+     module. If |event name| is not a [=module name=] return an [=error=] with
+     [=error code=] [=Invalid Argument=].
+
+  1. Add each [=event=] in the module with name |event name| to |events|.
+
+  1. Return [=success=] with data |events|.
+</div>
 
 ## Processing Model ## {#processing-model}
 
@@ -591,8 +656,35 @@ with parameters |session| and |capabilities| is:
 
 </div>
 
+Common Data Types {#data_types}
+===============================
+
+This section defines data types which are common to many modules.
+
+## Browsing Context ## {#data_types-browsing_context}
+
+[= remote end schema=] and [= local end schema=]
+```
+BrowsingContext = text;
+```
+
+Each [=/browsing context=] has an associated <dfn export>browsing context id</dfn>,
+which is a string uniquely identifying that browsing context. For browsing
+contexts with an associated WebDriver [=window handle=] the [=/browsing context
+id=] must be the same as the [=window handle=].
+
+## Realm ## {#data_types-realm}
+
+[= remote end schema=] and [= local end schema=]
+```
+Realm = text;
+```
+
+Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
+uniquely identifying that realm.
+
 Modules {#modules}
-==========================
+==================
 
 ## Session ## {#module-session}
 
@@ -604,9 +696,8 @@ events for monitoring the status of the remote end.
 [=remote end definition=]
 
 <pre class="cddl remote-cddl">
-
-SessionCommand = (StatusCommand)
-
+SessionCommand = (StatusCommand //
+                  EnableEventCommand)
 </pre>
 
 [=local end definition=]
@@ -617,6 +708,39 @@ SessionResult = (StatusResult)
 
 </pre>
 
+<div algorithm>
+
+To <dfn lt="updating the event map">update the event map</dfn>, given a |list of
+event names|, a |list of contexts|, and a |target status|:
+
+  1. Let |events| be an empty set.
+
+    1. For each entry |event name| in the |list of event names|,
+       let |events| be the union of |events| and the result of [=trying=] to
+       [=obtain a set of events from a name=] with |event name|.
+
+    1. If the |list of contexts| is null, let |targets| be a set containing the [=global
+       event set=]. Otherwise for each entry |context id| in the |list of
+       contexts|, run the following substeps:
+
+      1. If there is no browsing context with [=browsing context id=] |context id| return
+         [=error=] with [=error code=] [=invalid argument=]
+
+      1. Let |context| be the browsing context with id |context id|. If the
+         [=browsing context event map=] does not contain an entry for |context|,
+         set the value of the entry for |context| to a new empty map.
+
+      1. Get the entry from the [=browsing context event map=] for |context|
+         and append it to |targets|.
+
+    1. For each |target| in |targets|, run the following steps:
+
+      1. For each |event| in events, run the following steps:
+
+        1. Set the value of |target| for |event| to |target status|.
+
+    1. Return [=success=] with data null.
+</div>
 
 ### Status ### {#command-session-status}
 
@@ -661,3 +785,82 @@ The [=remote end steps=] are:
    </dl>
 
 2. Return [=success=] with data |body|
+
+### Subscribe ### {#command-session-subscribe}
+
+The <dfn export for=commands>subscribe</dfn> command enables certain events either
+globally or for a set of browsing contexts
+
+Issue: This needs to be generalised to work with realms too
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      SubscribeCommand = {
+        method: "session.subscribe",
+        params: SubscribeParameters
+      }
+
+      SubscribeParameters = {
+        events: [text],
+        contexts?: [BrowsingContext],
+        * text => any,
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+        EmptyResult
+    </pre>
+   </dd>
+</dl>
+
+The [=remote end steps=] with |command parameters| are:
+
+    1. Let the |list of event names| be the value of the <code>events</code> field of
+       |command parameters|.
+
+    1. Let the |list of contexts| be the value of the <code>contexts</code>
+       field of |command parameters| if it is present or null if it isn't.
+
+    1. Return the result of [=updating the event map=] with |list of event
+       names|, |list of contexts| and the target status set to true.
+
+### Unsubscribe ### {#command-session-unsubscribe}
+
+The <dfn export for=commands>unsubscribe</dfn> command disables events either
+globally or for a set of browsing contexts
+
+Issue: This needs to be generalised to work with realms too
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+     <pre class="cddl remote-cddl">
+       UnsubscribeCommand = {
+         method: "session.unsubscribe",
+         params: SubscribeParameters
+       }
+     </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        EmptyResult
+      </pre>
+   </dd>
+</dl>
+
+The [=remote end steps=] with |command parameters| are:
+
+    1. Let the |list of event names| be the value of the <code>events</code> field of
+       |command parameters|.
+
+    1. Let the |list of contexts| be the value of the <code>contexts</code>
+       field of |command parameters| if it is present or null if it isn't.
+
+    1. Return the result of [=updating the event map=] with |list of event
+       names|, |list of contexts| and the target status set to false.
+

--- a/index.bs
+++ b/index.bs
@@ -699,7 +699,7 @@ events for monitoring the status of the remote end.
 
 <pre class="cddl remote-cddl">
 SessionCommand = (StatusCommand //
-                  EnableEventCommand)
+                  SubscribeCommand)
 </pre>
 
 [=local end definition=]


### PR DESCRIPTION
This adds session.subscribe and session.unsubscribe commands to
subscribe to specified events for given browsing contexts (realms are
not yet supported).

The current semantics are that if you subscribe to events for a
specified browsing context you also get all events from descendent
browsing contexts unless you specifically unsubscribe in those scopes.

This only allows a single list of events/contexts per message; the use
cases for allowing multiple lists per message with different events in
dfferent browsing contexts seems less clear and should probably be
solved with a general batching mecahnism.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/51.html" title="Last updated on Oct 2, 2020, 10:40 AM UTC (12eefe9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/51/db6776c...12eefe9.html" title="Last updated on Oct 2, 2020, 10:40 AM UTC (12eefe9)">Diff</a>