### PR TITLE
Fix the [=active listeners=] syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -322,8 +322,8 @@ given |resource name|:
 To <dfn>start listening for a WebSocket connection</dfn> given a
 [=/session=] |session|:
 
- 1. If there is an existing [=WebSocket listener=] in the set of [=
-    active listeners=] which the [=remote end=] would like to reuse,
+ 1. If there is an existing [=WebSocket listener=] in the set of
+    [=active listeners=] which the [=remote end=] would like to reuse,
     let |listener| be that listener. Otherwise let |listener| be a new
     [=WebSocket listener=] with [=implementation-defined=]
     [=listener/host=], [=listener/port=], [=listener/secure flag=],


### PR DESCRIPTION
Line breaks inside these constructs are OK, but not before the first
word, apparently.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/53.html" title="Last updated on Sep 11, 2020, 1:02 PM UTC (91eff18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/53/0185f45...91eff18.html" title="Last updated on Sep 11, 2020, 1:02 PM UTC (91eff18)">Diff</a>