### PR TITLE
Define how to respond with an error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -128,6 +128,7 @@ EmptyParams = { *text }
 <pre class="cddl local-cddl">
 Message = (
   CommandResponse //
+  ErrorResponse //
   Event
 )
 
@@ -137,23 +138,15 @@ CommandResponse = {
   *text => any
 }
 
-ResponseData = (
-  Error //
-  CommandResult
-)
-
-Error = {
+ErrorResponse = {
+  id: uint / null,
   error: (
     "unknown error" /
     "unknown method" /
     "invalid argument"
   ),
   message: text,
-  stacktrace: text,
-}
-
-CommandResult = {
-  value: ResultData,
+  stacktrace?: text,
 }
 
 ResultData = (
@@ -367,9 +360,9 @@ To <dfn>process a command</dfn> given |data|:
       the <code>method</code> property of |data|.
 
    1. If |command| is not in the [=set of all command names=], return an
-      [=Error=] with [=error code=] [=unknown command=].
+      [=error=] with [=error code=] [=unknown command=].
 
-   1. Return an [=Error=] with [=error code=] [=invalid argument=].
+   1. Return an [=error=] with [=error code=] [=invalid argument=].
 </div>
 
 Transport {#transport}
@@ -543,7 +536,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     Issue: Should we instead close |connection| with [=status
     codes|status code=] 1003, or [=respond with an error=]?
 
- 2. [=Assert=]: |data| is a [=scalar value string=], because the
+ 1. [=Assert=]: |data| is a [=scalar value string=], because the
      WebSocket [=handling errors in UTF-8-encoded data=] would already
      have [=fail the WebSocket connection|failed the WebSocket
      connection=] otherwise.
@@ -551,21 +544,13 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     Issue: Nothing seems to define what [=status codes|status code=]
     is used for UTF-8 errors.
 
- 3. Let |parsed| be the result of [=parse JSON into Infra
-    values|parsing JSON into Infra values=] given |data|. If this
-    throws an exception, then [=respond with an error=] given
-    |connection| and [=error code=] [=invalid argument=], and finally
-    return.
-    <!-- corresponds to Parse error (-32700) in JSON-RPC -->
-
- 5. Let |result| be the result of [=process a command|processing a
+ 1. Let |result| be the result of [=process a command|processing a
     command=] given |data|.
 
- 6. If |result| is an [=Error=], then [=respond with an error=] given
-    |connection|, |result|, and |parsed|["<code>id</code>"], and finally
-    return.
+ 1. If |result| is an [=error=], then [=respond with an error=] given
+    |connection|, |data|, and |result|'s [=error code=], and finally return.
 
- 7. Let |response| be a new [=map=] with the following properties:
+ 1. Let |response| be a new [=map=] with the following properties:
 
    <dl>
       <dt>"id"</dt>
@@ -575,22 +560,55 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
       <dd>The value of |result|</dd>
    </dl>
 
- 8. Let |serialized| be the result of [=serialize JSON to
+ 1. Let |serialized| be the result of [=serialize JSON to
     bytes|serializing JSON to bytes=] given |response|.
 
- 9. [=Send a WebSocket message=] comprised of |serialized| over
+ 1. [=Send a WebSocket message=] comprised of |serialized| over
     |connection|.
 
 </div>
 
 <div algorithm>
 To <dfn>respond with an error</dfn> given a [=WebSocket connection=]
-|connection| and an [=error code=] |code|:
+|connection|, |data| and |error code|:
 
- 1. Issue: Form a valid JSON |errorObject| given |code|.
+ 1. Let |command id| be null.
 
- 2. [=Send a WebSocket message=] comprised of |errorObject| over
-    |connection|.
+ 1.  Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
+     into Infra values=] given |data|. If this does not throw an exception, and
+     results in a map that contains "<code>id</code>", then let |command id| be
+     |parsed|["<code>id</code>"].
+
+ 1. If |command id| is not an integer greater than or equal to zero, let
+    |command id| be null.
+
+ 1. Let |error data| be a new map matching the <code>ErrorResponse</code>
+    production in the [=local end definition=], with the <code>id</code> field
+    set to |command id|, the <code>error</code> field set to |error code|, the
+    <code>message</code> field set to an implementation-defined string
+    containing a human-readable definition of the error that occured and the
+    <code>stacktrace</code> field optionally set to an implementation-defined
+    string containing a stack trace report of the active stack frames at the
+    time when the error occurred.
+
+ 1. Let |response| be the result of [=serialize JSON to bytes|serializing JSON
+    to bytes=] given |error data|.
+
+ 1. [=Send a WebSocket message=] comprised of |response| over |connection|.
+
+</div>
+
+<div algorithm>
+To |serialize a map as JSON| given |map|
+
+1. Let |object| be a new [=Object=]
+
+1. For each |key| → |value| of |map|:
+
+  1.  [=Set=](|object|, key, value, false)
+
+1. Return the result of [=serialize JSON to bytes|serializing JSON to bytes=]
+   given |object|
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -572,8 +572,8 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
       <dd>|value|</dd>
    </dl>
 
- 1. Let |serialized| be the result of [=serialize a map as JSON=] given
-    |response|.
+ 1. Let |serialized| be the result of [=serialize an infra value to JSON
+    bytes=] given |response|.
 
  1. [=Send a WebSocket message=] comprised of |serialized| over
     |connection|.
@@ -603,26 +603,10 @@ To <dfn>respond with an error</dfn> given a [=WebSocket connection=]
     string containing a stack trace report of the active stack frames at the
     time when the error occurred.
 
- 1. Let |response| be the result of [=serialize a map as JSON=] given |error
-    data|.
+ 1. Let |response| be the result of [=serialize an infra value to JSON bytes=]
+    given |error data|.
 
  1. [=Send a WebSocket message=] comprised of |response| over |connection|.
-
-</div>
-
-<div algorithm>
-To <dfn>serialize a map as JSON</dfn> given |map|
-
-1. Let |object| be a new [=Object=]
-
-1. For each |key| → |value| of |map|:
-
-  1.  [=Set=](|object|, |key|, |value|, false)
-
-  1. Assert: The previous step does not fail for input data in this specification
-
-1. Return the result of [=serialize JSON to bytes|serializing JSON to bytes=]
-   given |object|
 
 </div>
 
@@ -701,7 +685,7 @@ This section defines data types which are common to many modules.
 
 ## Browsing Context ## {#data_types-browsing_context}
 
-[=remote end schema=] and [=local end schema=]
+[=remote end definition=] and [=local end definition=]
 ```
 BrowsingContext = text;
 ```
@@ -713,7 +697,7 @@ id=] must be the same as the [=window handle=].
 
 ## Realm ## {#data-types-realm}
 
-[=remote end schema=] and [=local end schema=]
+[=remote end definition=] and [=local end definition=]
 ```
 Realm = text;
 ```

--- a/index.bs
+++ b/index.bs
@@ -59,7 +59,10 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: window handle; url: dfn-window-handle
 spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
   type: dfn
+    text: Object; url: sec-object-objects
+    text: Set; url: sec-set
     text: realm; url: sec-code-realms
+
 </pre>
 
 <pre class="link-defaults">
@@ -340,19 +343,24 @@ To <dfn>obtain a set of event names</dfn> given an |name|:
 <div algorithm>
 To <dfn>process a command</dfn> given |data|:
 
+Issue: The way we get the matched data is a bit handwavy.
+
    1. Match |data| against the [=remote end definition=]. If this results in a
       match:
+      1. Let |parsed| be the map representing the matched data.
 
-      1. Let |result| be the result of running the [=remote end steps=]
-         for the command with [=command name=] equal to the
-         <code>method</code> property of |data| and with the [=command
-         parameters=] from the matched data.
+      1. Assert: |parsed| contains "<code>id</code>", "method", and
+         "<code>params</code>"
 
-      1. Assert: if |result| is a [=success=] its data matches the
-         definition for the [=result type=] corresponding to the command with name
-         [=command name=].
+      1. Let |value| be the result of [=trying=] to run the [=remote end steps=]
+         for the command with [=command name=] |parsed|["<code>method</code>"]
+         given [=command parameters=] |parsed|["<code>params</code>"]
 
-      1. Return <var>result</var>.
+      1. Assert: |value| matches the definition for the [=result type=]
+         corresponding to the command with name [=command name=].
+
+      1. Return [=success=] with data (|parsed|["<code>id</code>"],
+         |value|).
 
    1. Otherwise there is no match. If |data| isn't a map or is a map without a
       property named </code>method</code> return an [=error=] with error code
@@ -550,18 +558,22 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
  1. If |result| is an [=error=], then [=respond with an error=] given
     |connection|, |data|, and |result|'s [=error code=], and finally return.
 
+ 1. Assert: |result| is a [=success=]
+
+ 1. Let |command id| and |value| be the two fields |result|'s data.
+
  1. Let |response| be a new [=map=] with the following properties:
 
    <dl>
       <dt>"id"</dt>
-      <dd>The value of |parsed|["<code>id</code>"]</dd>
+      <dd>|command id|</dd>
 
-      <dt>"result"</dt>
-      <dd>The value of |result|</dd>
+      <dt>"value"</dt>
+      <dd>|value|</dd>
    </dl>
 
- 1. Let |serialized| be the result of [=serialize JSON to
-    bytes|serializing JSON to bytes=] given |response|.
+ 1. Let |serialized| be the result of [=serialize a map as JSON=] given
+    |response|.
 
  1. [=Send a WebSocket message=] comprised of |serialized| over
     |connection|.
@@ -591,21 +603,23 @@ To <dfn>respond with an error</dfn> given a [=WebSocket connection=]
     string containing a stack trace report of the active stack frames at the
     time when the error occurred.
 
- 1. Let |response| be the result of [=serialize JSON to bytes|serializing JSON
-    to bytes=] given |error data|.
+ 1. Let |response| be the result of [=serialize a map as JSON=] given |error
+    data|.
 
  1. [=Send a WebSocket message=] comprised of |response| over |connection|.
 
 </div>
 
 <div algorithm>
-To |serialize a map as JSON| given |map|
+To <dfn>serialize a map as JSON</dfn> given |map|
 
 1. Let |object| be a new [=Object=]
 
 1. For each |key| → |value| of |map|:
 
-  1.  [=Set=](|object|, key, value, false)
+  1.  [=Set=](|object|, |key|, |value|, false)
+
+  1. Assert: The previous step does not fail for input data in this specification
 
 1. Return the result of [=serialize JSON to bytes|serializing JSON to bytes=]
    given |object|


### PR DESCRIPTION
The main difficulty here is that if we get a command with an invalid id, it's
unclear what to return in the id field. This chooses to return null in that case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/56.html" title="Last updated on Oct 20, 2020, 1:54 PM UTC (03e5129)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/56/6c72ee4...03e5129.html" title="Last updated on Oct 20, 2020, 1:54 PM UTC (03e5129)">Diff</a>