### PR TITLE
Start to specify how to serialize a ES value.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -732,7 +732,7 @@ handle to the object, valid for its lifetime inside the engine. In this case the
 struct) itself containing further remote object values. This allows objects like
 arrays to have a single representation.
 
-DOM Nodes are also represented by <code>RemoteObject</code> instances. These
+[=Nodes=] are also represented by <code>RemoteObject</code> instances. These
 have a partial serialization of the node in the value property.
 
 Note: mirror objects do not keep the original object alive in the runtime. If an
@@ -745,7 +745,7 @@ their corresponding id.
 Issue: Should this be explicitly per realm?
 
 <div algorithm>
-To get the <dfn export>object id for an object</dfn> given an |object|:
+To get the <dfn>object id for an object</dfn> given an |object|:
 
   1. If [=object id map=] for the [=current session=] does not contain |object|
      run the following steps:
@@ -761,7 +761,7 @@ To get the <dfn export>object id for an object</dfn> given an |object|:
 </div>
 
 <div algorithm>
-To get the <dfn export>object for an object id</dfn> given an |object id|:
+To get the <dfn>object for an object id</dfn> given an |object id|:
 
   1. For each |object| → |id value| of [=object id map=]:
 
@@ -808,12 +808,10 @@ ObjectId = text;
 
 UndefinedObject = {
   type: "undefined",
-  value: null,
 }
 
 NullObject = {
   type: "null",
-  value: null,
 }
 
 StringObject = {
@@ -846,13 +844,13 @@ SymbolObject = {
 ArrayObject = {
   type: "array",
   objectId: ObjectId,
-  value?: [RemoteObject]
+  value?: [*RemoteObject]
 }
 
 ObjectObject = {
   type: "object",
   objectId: ObjectId,
-  value?: {*text: RemoteObject}
+  value?: {* text => RemoteObject}
 }
 
 FunctionObject = {
@@ -860,8 +858,8 @@ FunctionObject = {
   objectId: ObjectId,
 }
 
-RegexObject = {
-  type: "regex",
+RegExpObject = {
+  type: "regexp",
   objectId: ObjectId,
   value: text
 }
@@ -947,8 +945,6 @@ WindowProxyObject = {
   type: "window",
   objectId: ObjectId,
 }
-
-
 ```
 
 Issue: Add WASM types?

--- a/index.bs
+++ b/index.bs
@@ -718,7 +718,7 @@ Realm = text;
 Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm.
 
-## Remote Value ## {#data-types-remote-value}
+## Remote Value ## {#data-types-remote-object}
 
 Values accessible from the ECMAScript runtime are represented by a mirror
 object, specified as <code>RemoteValue</code>. The value's type is specified in
@@ -955,69 +955,69 @@ Issue: Should WindowProxy get attributes in a similar style to Node?
 
 <div algorithm>
 
-To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
+To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 |node details|, and a |set of known objects|:
 
-  1. Switch on the type of |object|:
+  1. Switch on the type of |value|:
 
     <dl>
       <dt>Undefined
-      <dd>Let |remote object| be an [=object=] matching the `UndefinedValue`
+      <dd>Let |remote value| be an [=object=] matching the `UndefinedValue`
       production in the [=local end definition=].
 
       <dt>Null
-      <dd>Let |remote object| be an [=object=] matching the `NullValue`
+      <dd>Let |remote value| be an [=object=] matching the `NullValue`
       production in the [=local end definition=].
 
       <dt>String
-      <dd>Let |remote object| be an [=object=] matching the `StringValue`
+      <dd>Let |remote value| be an [=object=] matching the `StringValue`
       production in the [=local end definition=], with the <code>value</code>
-      property set to |object|.
+      property set to |value|.
 
       <dt>Number
       <dd>
-      1. Switch on the value of |object|:
+      1. Switch on the value of |value|:
         <dl>
           <dt>NaN
-          <dt>Let |value| be <code>"NaN"</code>
+          <dt>Let |serialized| be <code>"NaN"</code>
           <dt>-0
-          <dt>Let |value| be <code>"-0"</code>
+          <dt>Let |serialized| be <code>"-0"</code>
           <dt>+Infinity
-          <dt>Let |value| be <code>"+Infinity"</code>
+          <dt>Let |serialized| be <code>"+Infinity"</code>
           <dt>-Infinity
-          <dt>Let |value| be <code>"-Infinity"</code>
+          <dt>Let |serialized| be <code>"-Infinity"</code>
           <dt>Otherwise:
-          <dt>Let |value| be |object|
+          <dt>Let |serialized| be |value|
         </dl>
-        Let |remote object| be an [=object=] matching the `NumberValue`
+        Let |remote value| be an [=object=] matching the `NumberValue`
         production in the [=local end definition=], with the <code>value</code>
-        property set to |value|.
+        property set to |serialized|.
 
       <dt>Boolean
-      <dd>Let |remote object| be an [=object=] matching the `BooleanValue`
+      <dd>Let |remote value| be an [=object=] matching the `BooleanValue`
           production in the [=local end definition=], with the <code>value</code>
-          property set to |object|.
+          property set to |value|.
 
       <dt>BigInt
-      <dd>Let |remote object| be an [=object=] matching the `BigIntValue`
+      <dd>Let |remote value| be an [=object=] matching the `BigIntValue`
           production in the [=local end definition=], with the <code>value</code>
           property set to the result of running the [=ToString=] operation on
-      |object|.
+          |value|.
 
       <dt>Symbol
-      <dd>Let |remote object| be an [=object=] matching the `SymbolValue`
+      <dd>Let |remote value| be an [=object=] matching the `SymbolValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Array
       <dd>
-      1. Let |value| be null.
+      1. Let |serialized| be null.
 
-      1. If |object| is not in the |set of known objects|, and |max depth|
+      1. If |value| is not in the |set of known objects|, and |max depth|
          is not null and greater than 0, run the following steps:
-             1. Append |object| to the |set of known objects|
+             1. Append |value| to the |set of known objects|
 
-             1. Let |value| be a new List.
+             1. Let |serialized| be a new List.
 
              1. For each integer |index| in the range 0 to
                 [=LengthOfArrayLike=](|object|), run the following steps:
@@ -1026,187 +1026,187 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
                 1. If [=HasProperty=](|index name|) is true:
 
-                  1. Let |child object| be [=Get=](|object|, |index name|)
+                  1. Let |child value| be [=Get=](|object|, |index name|)
 
-                  1. Let |child remote object| be the result of [=serialize as a
-                     remote object=] with arguments |child object|, |max
+                  1. Let |serialized child| be the result of [=serialize as a
+                     remote value=] with arguments |child value|, |max
                      depth| - 1, |node details| and |set of known objects|.
 
-                  Otherwise let |child remote object| be an [=object=] matching
+                  Otherwise let |serialized child| be an [=object=] matching
                   the `UndefinedValue` production in the [=remote end
                   definition=].
 
-                1. Append [=CreateArrayFromList=](|child remote object|) to |value|.
+                1. Append [=CreateArrayFromList=](|serialized child|) to |serialized|.
 
-      1. Let |remote object| be an [=object=] matching the `ArrayValue` production
+      1. Let |remote value| be an [=object=] matching the `ArrayValue` production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |object|, and the <code>value</code> field
-         set to |value| if it's not null, or ommitted otherwise.
+         set to |serialized| if it's not null, or ommitted otherwise.
 
       <dt>Function
-      <dd>Let |remote object| be an [=object=] matching the `FunctionValue`
+      <dd>Let |remote value| be an [=object=] matching the `FunctionValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>RegExp
       <dd>
-          1. Let |pattern| be [=ToString=]([=Get=](|object|, "source")).
+          1. Let |pattern| be [=ToString=]([=Get=](|value|, "source")).
 
-          1. Let |flags| be [=ToString=]([=Get=](|object|, "flags")).
+          1. Let |flags| be [=ToString=]([=Get=](|value|, "flags")).
 
-          1. Let |value| be the string-concatenation of "/", |pattern|, "/", and |flags|.
+          1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote object| be an [=object=] matching the `RegExpValue`
+          1. Let |remote | be an [=object=] matching the `RegExpValue`
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
-             set to |value|
+             set to |serialized|
 
       <dt>Date
       <dd>
-        1. Let |value| be [=ToDateString=]([=thisTimeValue=](|object|)).
+        1. Let |serialized| be [=ToDateString=]([=thisTimeValue=](|value|)).
 
-        1. Let |remote object| be an [=object=] matching the `DateValue`
+        1. Let |remote value| be an [=object=] matching the `DateValue`
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
-           set to |value|.
+           set to |serialized|.
 
       <dt>Map
-      <dd>Let |remote object| be an [=object=] matching the `MapValue`
+      <dd>Let |remote value| be an [=object=] matching the `MapValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Set
-      <dd>Let |remote object| be an [=object=] matching the `SetValue`
+      <dd>Let |remote value| be an [=object=] matching the `SetValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>WeakMap
-      <dd>Let |remote object| be an [=object=] matching the `WeakMapValue`
+      <dd>Let |remote value| be an [=object=] matching the `WeakMapValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>WeakSet
-      <dd>Let |remote object| be an [=object=] matching the `WeakSetValue`
+      <dd>Let |remote value| be an [=object=] matching the `WeakSetValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Iterator
-      <dd>Let |remote object| be an [=object=] matching the `IteratorValue`
+      <dd>Let |remote value| be an [=object=] matching the `IteratorValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Generator
-      <dd>Let |remote object| be an [=object=] matching the `IteratorValue`
+      <dd>Let |remote value| be an [=object=] matching the `IteratorValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Error
-      <dd>Let |remote object| be an [=object=] matching the `ErrorValue`
+      <dd>Let |remote value| be an [=object=] matching the `ErrorValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Proxy
-      <dd>Let |remote object| be an [=object=] matching the `ProxyValue`
+      <dd>Let |remote value| be an [=object=] matching the `ProxyValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Promise
-      <dd>Let |remote object| be an [=object=] matching the `PromiseValue`
+      <dd>Let |remote value| be an [=object=] matching the `PromiseValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>TypedArray
-      <dd>Let |remote object| be an [=object=] matching the `TypedArrayValue`
+      <dd>Let |remote value| be an [=object=] matching the `TypedArrayValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>ArrayBuffer
-      <dd>Let |remote object| be an [=object=] matching the `ArrayBufferValue`
+      <dd>Let |remote value| be an [=object=] matching the `ArrayBufferValue`
           production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |object|.
+          property set to the [=object id for an object=] |value|.
 
       <dt>Node
       <dd>
-        1. Let |value| be null.
+        1. Let |serialized| be null.
 
         1. If |node details| is true, run the following steps:
 
-            1. Let |value| be a new [=Object=].
+            1. Let |serialized| be a new [=Object=].
 
-            1. [=Set=](|value|, "nodeType", [=Get=](|object|, "nodeType"), false)
+            1. [=Set=](|serialized|, "nodeType", [=Get=](|value|, "nodeType"), false)
 
-            1. [=Set=](|value|, "nodeName", [=Get=](|object|, "nodeName"), false)
+            1. [=Set=](|serialized|, "nodeName", [=Get=](|value|, "nodeName"), false)
 
-            1. [=Set=](|value|, "localName", [=Get=](|object|, "localName"), false)
+            1. [=Set=](|serialized|, "localName", [=Get=](|value|, "localName"), false)
 
-            1. [=Set=](|value|, "nodeValue", [=Get=](|object|, "nodeValue"), false)
+            1. [=Set=](|serialized|, "nodeValue", [=Get=](|value|, "nodeValue"), false)
 
-            1. Let |child node count| be the size of |value|'s [=children=].
+            1. Let |child node count| be the size of |serialized|'s [=children=].
 
-            1. [=Set=](|value|, "childNodeCount", |child node count|, false)
+            1. [=Set=](|serialized|, "childNodeCount", |child node count|, false)
 
             1. If |max depth| is null and or equal to 0 let |children| be null.
                Otherwise, let |children| be an empty list and, for each node
-               |child| in the [=children=] of |object|:
+               |child| in the [=children=] of |value|:
 
-              1. Let |serialized| be the result of [=serialize as a remote object=]
+              1. Let |serialized| be the result of [=serialize as a remote value=]
                  with |child|, |max depth| - 1, |node details| and
                  |set of known objects|.
 
               1. Append |serialized| to |children|.
 
-            1. [=Set=](|value|, "children", |serialized|, false)
+            1. [=Set=](|serialized|, "children", |serialized|, false)
 
             1. Let |attributes| be a new [=Object=].
 
-            1. For each |attribute| in |object|'s <a spec=dom>attributes</a>:
+            1. For each |attribute| in |value|'s <a spec=dom>attributes</a>:
 
               1. Let |name| be |attribute|'s [=Attr/qualified name=]
 
-              1. Let |value| be |attribute|'s [=Attr/value=].
+              1. Let |serialized| be |attribute|'s [=Attr/value=].
 
-              1. [=Set=](|attributes|, |name|, |value|, false)
+              1. [=Set=](|attributes|, |name|, |serialized|, false)
 
-            1. [=Set=](|value|, "attributes", |attributes|, false)
+            1. [=Set=](|serialized|, "attributes", |attributes|, false)
 
-        1. Let |remote object| be an [=object=] matching the `NodeValue`
+        1. Let |remote value| be an [=object=] matching the `NodeValue`
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] |object|, and <code>value</code>
-           set to |value|, if |value| is not null.
+           property set to the [=object id for an object=] |value|, and <code>value</code>
+           set to |serialized|, if |serialized| is not null.
 
       <dt>WindowProxy
-      <dd>1. Let |remote object| be an [=object=] matching the `WindowProxyValue`
+      <dd>1. Let |remote value| be an [=object=] matching the `WindowProxyValue`
              production in the [=local end definition=], with the <code>objectId</code>
-             property set to the [=object id for an object=] |object|.
+             property set to the [=object id for an object=] |value|.
 
       <dt>Otherwise:
       <dd>
-      1. let |value| be null.
+      1. let |serialized| be null.
 
-      1. If |object| is not in the |set of known objects|, and |max depth|
+      1. If |value| is not in the |set of known objects|, and |max depth|
          is not null and greater than 0, run the following steps:
-         1. Append |object| to the |set of known objects|
+         1. Append |value| to the |set of known objects|
 
-         1. Let |value| be a new [=Object=].
+         1. Let |serialized| be a new [=Object=].
 
-         1. For each |key| of [=EnumerableOwnPropertyNames=](|object|, key)
+         1. For each |key| of [=EnumerableOwnPropertyNames=](|value|, key)
             run the following steps:
 
-            1. Let |child object| be [=Get=](|object|, |key|)
+            1. Let |child value| be [=Get=](|value|, |key|)
 
-            1. Let |child remote object| be the result of [=serialize as a
-               remote object=] with arguments |child object|, |max
+            1. Let |child remote value| be the result of [=serialize as a
+               remote value=] with arguments |child value|, |max
                depth| - 1, |node details| and |set of known objects|.
 
-            1. [=Set=](|value|, |key|, |child object|, false)
+            1. [=Set=](|serialized|, |key|, |child remote value|, false)
 
-      1. Let |remote object| be an [=object=] matching the `ObjectValue` production
+      1. Let |remote value| be an [=object=] matching the `ObjectValue` production
          in the [=local end definition=], with the <code>objectId</code> property set
-         to the [=object id for an object=] |object|, and the <code>value</code> field
-         set to |value|.
+         to the [=object id for an object=] |value|, and the <code>value</code> field
+         set to |serialized|.
     </dl>
 
-  1. Return |remote object|
+  1. Return |remote value|
 
 Issue: the way we check types is all wrong
 

--- a/index.bs
+++ b/index.bs
@@ -762,7 +762,7 @@ To get the <dfn>object id for an object</dfn> given an |object|:
 
      1. Let |object id| be a new, unique, string identifier for |object|. If
         |object| is an [=/element=] this must be the [=web element reference=]
-        for |object|; if it's [=WindowProxy=] object, this must be the
+        for |object|; if it's a [=WindowProxy=] object, this must be the
         [=window handle=] for |object|.
 
     1. Set the value of |object| in the [=object id map=] to |object id|.
@@ -867,7 +867,7 @@ ObjectValue = {
   value?: MappingValue,
 }
 
-FunctionObject = {
+FunctionValue = {
   type: "function",
   objectId: ObjectId,
 }
@@ -1041,7 +1041,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
           1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote | be an [=object=] matching the <code>RegExpValue</code>
+          1. Let |remote| be an [=object=] matching the <code>RegExpValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |serialized|
@@ -1143,7 +1143,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
             1. If |max depth| is null and or equal to 0 let |children| be null.
                Otherwise, let |children| be an empty list and, for each node
-               |child| in the [=children=] of |value|:
+               |child| in |value|'s [=children=]:
 
               1. Let |serialized| be the result of [=serialize as a remote value=]
                  with |child|, |max depth| - 1, |node details| and
@@ -1187,7 +1187,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
       <dt>Otherwise:
       <dd>
-      1. let |serialized| be null.
+      1. Let |serialized| be null.
 
       1. If |value| is not in the |set of known objects|, and |max depth|
          is not null and greater than 0, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,7 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
-      <dt>Regex
+      <dt>RegExp
       <dd>
           1. Let |pattern| be [=ToString=]([=Get=](|object|, "source")).
 
@@ -1056,7 +1056,7 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
           1. Let |value| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote object| be an [=object=] matching the `RegexValue`
+          1. Let |remote object| be an [=object=] matching the `RegExpValue`
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |value|

--- a/index.bs
+++ b/index.bs
@@ -718,14 +718,14 @@ Realm = text;
 Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm.
 
-## Remote Object ## {#data_types-remote_object}
+## Remote Value ## {#data-types-remote-value}
 
-Objects accessible from the ECMAScript runtime are represented by a mirror
-object, specified as <code>RemoteObject</code>. The object type is specified in
+Values accessible from the ECMAScript runtime are represented by a mirror
+object, specified as <code>RemoteValue</code>. The value's type is specified in
 the <code>type</code> property. In the case of JSON-representable primitive
-objects, this contains the object value in the <code>value</code> property; in
-the case of non-JSON-representable primitives, the <code>value</code> property
-contains a string representation of the object. For non-primitive objects, the
+values, this contains the value in the <code>value</code> property; in the case
+of non-JSON-representable primitives, the <code>value</code> property contains a
+string representation of the object. For non-primitive objects, the
 <code>objectId</code> property contains a string id that provides a unique
 handle to the object, valid for its lifetime inside the engine. In this case the
 <code>value</code> property can contain a complex object (either a list or a
@@ -775,82 +775,82 @@ To get the <dfn>object for an object id</dfn> given an |object id|:
 
 [=remote end definition=] and [=local end definition=]
 ```
-RemoteObject = {
-  UndefinedObject //
-  NullObject //
-  StringObject //
-  NumberObject //
-  BooleanObject //
-  BigIntObject //
-  SymbolObject //
-  ArrayObject //
-  FunctionObject //
-  ObjectObject //
-  FunctionObject //
-  RegexObject //
-  DateObject //
-  MapObject //
-  SetObject //
-  WeakMapObject //
-  WeakSetObject //
-  IteratorObject //
-  GeneratorObject //
-  ErrorObject //
-  ProxyObject //
-  PromiseObject //
-  TypedArrayObject //
-  ArrayBufferObject //
-  NodeObject //
-  WindowProxyObject //
+RemoteValue = {
+  UndefinedValue //
+  NullValue //
+  StringValue //
+  NumberValue //
+  BooleanValue //
+  BigIntValue //
+  Symbol //
+  ArrayValue //
+  FunctionValue //
+  ObjectValue //
+  FunctionValue //
+  RegexValue //
+  DateValue //
+  MapValue //
+  SetValue //
+  WeakMapValue //
+  WeakSetValue //
+  IteratorValue //
+  GeneratorValue //
+  ErrorValue //
+  ProxyValue //
+  PromiseValue //
+  TypedArrayValue //
+  ArrayBufferValue //
+  NodeValue //
+  WindowProxyValue //
 }
 
 ObjectId = text;
 
-UndefinedObject = {
+UndefinedValue = {
   type: "undefined",
 }
 
-NullObject = {
+NullValue = {
   type: "null",
 }
 
-StringObject = {
+StringValue = {
   type: "string",
   value: text,
 }
 
 SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
 
-NumberObject = {
+NumberValue = {
   type: "number",
   value: number / SpecialNumber,
 }
 
-BooleanObject = {
+BooleanValue = {
   type: "boolean",
   value: bool,
 }
 
-BigIntObject = {
+BigIntValue = {
   type: "bigint",
   value: text,
 }
 
-SymbolObject = {
+SymbolValue = {
   type: "symbol",
   objectId: ObjectId,
 }
 
-ArrayObject = {
+ArrayValue = {
   type: "array",
   objectId: ObjectId,
-  value?: [*RemoteObject]
+  value?: [*RemoteValue]
 }
 
-ObjectObject = {
+ObjectValue = {
   type: "object",
   objectId: ObjectId,
-  value?: {* text => RemoteObject}
+  value?: {* text => RemoteValue}
 }
 
 FunctionObject = {
@@ -858,90 +858,90 @@ FunctionObject = {
   objectId: ObjectId,
 }
 
-RegExpObject = {
+RegExpValue = {
   type: "regexp",
   objectId: ObjectId,
   value: text
 }
 
-DateObject = {
+DateValue = {
   type: "date",
   objectId: ObjectId,
   value: text
 }
 
-MapObject = {
+MapValue = {
   type: "map",
   objectId: ObjectId,
 }
 
-SetObject = {
+SetValue = {
   type: "set",
   objectId: ObjectId
 }
 
-WeakMapObject = {
+WeakMapValue = {
   type: "map",
   objectId: ObjectId,
 }
 
-WeakSetObject = {
+WeakSetValue = {
   type: "set",
   objectId: ObjectId,
 }
 
-IteratorObject = {
+IteratorValue = {
   type: "iterator",
   objectId: ObjectId,
 }
 
-GeneratorObject = {
+GeneratorValue = {
   type: "iterator",
   objectId: ObjectId,
 }
 
-ErrorObject = {
+ErrorValue = {
   type: "error",
   objectId: ObjectId,
 }
 
-ProxyObject = {
+ProxyValue = {
   type: "proxy",
   objectId: ObjectId,
 }
 
-PromiseObject = {
+PromiseValue = {
   type: "promise",
   objectId: ObjectId,
 }
 
-TypedArrayObject = {
+TypedArrayValue = {
   type: "typedarray",
   objectId: ObjectId,
 }
 
-ArrayBufferObject = {
+ArrayBufferValue = {
   type: "arraybuffer",
   objectId: ObjectId,
 }
 
-NodeObject = {
+NodeValue = {
   type: "node",
   objectId: ObjectId,
-  value?: NodeValue,
+  value?: NodeProperties,
 }
 
-NodeValue = {
+NodeProperties = {
   nodeType: uint,
   nodeName: text,
   localName: text,
   nodeValue: text,
   childNodeCount: uint,
-  children?: [*NodeObject],
+  children?: [*NodeValue],
   attributes?: {*text: text},
 }
 
-WindowProxyObject = {
+WindowProxyValue = {
   type: "window",
   objectId: ObjectId,
 }
@@ -962,15 +962,15 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
     <dl>
       <dt>Undefined
-      <dd>Let |remote object| be an [=object=] matching the `UndefinedObject`
+      <dd>Let |remote object| be an [=object=] matching the `UndefinedValue`
       production in the [=local end definition=].
 
       <dt>Null
-      <dd>Let |remote object| be an [=object=] matching the `NullObject`
+      <dd>Let |remote object| be an [=object=] matching the `NullValue`
       production in the [=local end definition=].
 
       <dt>String
-      <dd>Let |remote object| be an [=object=] matching the `StringObject`
+      <dd>Let |remote object| be an [=object=] matching the `StringValue`
       production in the [=local end definition=], with the <code>value</code>
       property set to |object|.
 
@@ -989,23 +989,23 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
           <dt>Otherwise:
           <dt>Let |value| be |object|
         </dl>
-        Let |remote object| be an [=object=] matching the `NumberObject`
+        Let |remote object| be an [=object=] matching the `NumberValue`
         production in the [=local end definition=], with the <code>value</code>
         property set to |value|.
 
       <dt>Boolean
-      <dd>Let |remote object| be an [=object=] matching the `BooleanObject`
+      <dd>Let |remote object| be an [=object=] matching the `BooleanValue`
           production in the [=local end definition=], with the <code>value</code>
           property set to |object|.
 
       <dt>BigInt
-      <dd>Let |remote object| be an [=object=] matching the `BigIntObject`
+      <dd>Let |remote object| be an [=object=] matching the `BigIntValue`
           production in the [=local end definition=], with the <code>value</code>
           property set to the result of running the [=ToString=] operation on
       |object|.
 
       <dt>Symbol
-      <dd>Let |remote object| be an [=object=] matching the `SymbolObject`
+      <dd>Let |remote object| be an [=object=] matching the `SymbolValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
@@ -1033,18 +1033,18 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
                      depth| - 1, |node details| and |set of known objects|.
 
                   Otherwise let |child remote object| be an [=object=] matching
-                  the `UndefinedObject` production in the [=remote end
+                  the `UndefinedValue` production in the [=remote end
                   definition=].
 
                 1. Append [=CreateArrayFromList=](|child remote object|) to |value|.
 
-      1. Let |remote object| be an [=object=] matching the `ArrayObject` production
+      1. Let |remote object| be an [=object=] matching the `ArrayValue` production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |object|, and the <code>value</code> field
          set to |value| if it's not null, or ommitted otherwise.
 
       <dt>Function
-      <dd>Let |remote object| be an [=object=] matching the `FunctionObject`
+      <dd>Let |remote object| be an [=object=] matching the `FunctionValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
@@ -1056,7 +1056,7 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
           1. Let |value| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote object| be an [=object=] matching the `RegexObject`
+          1. Let |remote object| be an [=object=] matching the `RegexValue`
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |value|
@@ -1065,63 +1065,63 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
       <dd>
         1. Let |value| be [=ToDateString=]([=thisTimeValue=](|object|)).
 
-        1. Let |remote object| be an [=object=] matching the `DateObject`
+        1. Let |remote object| be an [=object=] matching the `DateValue`
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
            set to |value|.
 
       <dt>Map
-      <dd>Let |remote object| be an [=object=] matching the `MapObject`
+      <dd>Let |remote object| be an [=object=] matching the `MapValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Set
-      <dd>Let |remote object| be an [=object=] matching the `SetObject`
+      <dd>Let |remote object| be an [=object=] matching the `SetValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>WeakMap
-      <dd>Let |remote object| be an [=object=] matching the `WeakMapObject`
+      <dd>Let |remote object| be an [=object=] matching the `WeakMapValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>WeakSet
-      <dd>Let |remote object| be an [=object=] matching the `WeakSetObject`
+      <dd>Let |remote object| be an [=object=] matching the `WeakSetValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Iterator
-      <dd>Let |remote object| be an [=object=] matching the `IteratorObject`
+      <dd>Let |remote object| be an [=object=] matching the `IteratorValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Generator
-      <dd>Let |remote object| be an [=object=] matching the `IteratorObject`
+      <dd>Let |remote object| be an [=object=] matching the `IteratorValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Error
-      <dd>Let |remote object| be an [=object=] matching the `ErrorObject`
+      <dd>Let |remote object| be an [=object=] matching the `ErrorValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Proxy
-      <dd>Let |remote object| be an [=object=] matching the `ProxyObject`
+      <dd>Let |remote object| be an [=object=] matching the `ProxyValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>Promise
-      <dd>Let |remote object| be an [=object=] matching the `PromiseObject`
+      <dd>Let |remote object| be an [=object=] matching the `PromiseValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>TypedArray
-      <dd>Let |remote object| be an [=object=] matching the `TypedArrayObject`
+      <dd>Let |remote object| be an [=object=] matching the `TypedArrayValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
       <dt>ArrayBuffer
-      <dd>Let |remote object| be an [=object=] matching the `ArrayBufferObject`
+      <dd>Let |remote object| be an [=object=] matching the `ArrayBufferValue`
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |object|.
 
@@ -1169,13 +1169,13 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
             1. [=Set=](|value|, "attributes", |attributes|, false)
 
-        1. Let |remote object| be an [=object=] matching the `NodeObject`
+        1. Let |remote object| be an [=object=] matching the `NodeValue`
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object|, and <code>value</code>
            set to |value|, if |value| is not null.
 
       <dt>WindowProxy
-      <dd>1. Let |remote object| be an [=object=] matching the `WindowProxyObject`
+      <dd>1. Let |remote object| be an [=object=] matching the `WindowProxyValue`
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object|.
 
@@ -1200,7 +1200,7 @@ To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
 
             1. [=Set=](|value|, |key|, |child object|, false)
 
-      1. Let |remote object| be an [=object=] matching the `ObjectObject` production
+      1. Let |remote object| be an [=object=] matching the `ObjectValue` production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |object|, and the <code>value</code> field
          set to |value|.

--- a/index.bs
+++ b/index.bs
@@ -59,7 +59,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
     text: web element reference; url: dfn-web-element-reference
     text: window handle; url: dfn-window-handle
-spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
+spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
     text: Array; url: sec-array-objects
     text: CreateArrayFromList; url: sec-createarrayfromlist
@@ -83,7 +83,7 @@ spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
     text: ToString; url: sec-tostring
     text: Type; url: sec-ecmascript-data-types-and-values
     text: realm; url: sec-code-realms
-spec: HTML urlPrefix: https://html.spec.whatwg.org/
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: dfn
     text: WindowProxy; url: windowproxy
 </pre>
@@ -735,15 +735,18 @@ object, specified as <code>RemoteValue</code>. The value's type is specified in
 the <code>type</code> property. In the case of JSON-representable primitive
 values, this contains the value in the <code>value</code> property; in the case
 of non-JSON-representable primitives, the <code>value</code> property contains a
-string representation of the object. For non-primitive objects, the
+string representation of the value. For non-primitive objects, the
 <code>objectId</code> property contains a string id that provides a unique
-handle to the object, valid for its lifetime inside the engine. In this case the
-<code>value</code> property can contain a complex object (either a list or a
-struct) itself containing further remote object values. This allows objects like
-arrays to have a single representation.
+handle to the object, valid for its lifetime inside the engine. For some
+non-primitive types, the <code>value</code> property contains a representation
+of the data in the ECMAScript object; for container types this can contain
+further <code>RemoteValue</code> instances. The <code>value</code> property can
+be null if there is a duplicate object i.e. the object has already been
+serialized in the current <code>RemoteValue</code>, perhaps as part of a
+cycle, or otherwise when the maximum serialization depth is reached.
 
-[=Nodes=] are also represented by <code>RemoteObject</code> instances. These
-have a partial serialization of the node in the value property.
+[=Nodes=] are also represented by <code>RemoteValue</code> instances. These have
+a partial serialization of the node in the value property.
 
 Note: mirror objects do not keep the original object alive in the runtime. If an
 object is discarded in the runtime subsequent attempts to access it via the
@@ -897,12 +900,12 @@ SetValue = {
 }
 
 WeakMapValue = {
-  type: "map",
+  type: "weakmap",
   objectId: ObjectId,
 }
 
 WeakSetValue = {
-  type: "set",
+  type: "weakset",
   objectId: ObjectId,
 }
 
@@ -934,12 +937,13 @@ NodeValue = {
 
 NodeProperties = {
   nodeType: uint,
-  nodeName: text,
-  localName: text,
   nodeValue: text,
+  localName?: text,
+  namespaceURI?: text,
   childNodeCount: uint,
   children?: [*NodeValue],
   attributes?: {*text => text},
+  shadowRoot?: NodeValue / null,
 }
 
 WindowProxyValue = {
@@ -949,8 +953,6 @@ WindowProxyValue = {
 ```
 
 Issue: Add WASM types?
-
-Issue: NodeValue needs more attributes
 
 Issue: Should WindowProxy get attributes in a similar style to Node?
 
@@ -1041,7 +1043,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
           1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote| be an [=object=] matching the <code>RegExpValue</code>
+          1. Let |remote value| be an [=object=] matching the <code>RegExpValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |serialized|
@@ -1063,7 +1065,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
            is not null and greater than 0, run the following steps:
              1. Append |value| to the |set of known objects|
 
-             1. Let |serialized| be the result of [=serialize as a list=] given
+             1. Let |serialized| be the result of [=serialize as a mapping=] given
                 [=CreateMapIterator=](|value|, key+value), |max depth|, |node details| and
                 |set of known objects|.
 
@@ -1131,19 +1133,23 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
             1. [=Set=](|serialized|, "nodeType", [=Get=](|value|, "nodeType"), false)
 
-            1. [=Set=](|serialized|, "nodeName", [=Get=](|value|, "nodeName"), false)
-
-            1. [=Set=](|serialized|, "localName", [=Get=](|value|, "localName"), false)
-
             1. [=Set=](|serialized|, "nodeValue", [=Get=](|value|, "nodeValue"), false)
+
+            1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
+
+
+              1. [=Set=](|serialized|, "localName", [=Get=](|value|, "localName"), false)
+
+              1. [=Set=](|serialized|, "namespaceURI", [=Get=](|value|, "namespaceURI"), false)
+
 
             1. Let |child node count| be the size of |serialized|'s [=children=].
 
             1. [=Set=](|serialized|, "childNodeCount", |child node count|, false)
 
-            1. If |max depth| is null and or equal to 0 let |children| be null.
+            1. If |max depth| is equal to 0 let |children| be null.
                Otherwise, let |children| be an empty list and, for each node
-               |child| in |value|'s [=children=]:
+               |child| in the [=children=] of |value|:
 
               1. Let |serialized| be the result of [=serialize as a remote value=]
                  with |child|, |max depth| - 1, |node details| and
@@ -1153,17 +1159,32 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
             1. [=Set=](|serialized|, "children", |serialized|, false)
 
-            1. Let |attributes| be a new [=Object=].
+            1. If |value| is an [=/Element=]:
 
-            1. For each |attribute| in |value|'s <a spec=dom>attributes</a>:
+               1. Let |attributes| be a new [=Object=].
 
-              1. Let |name| be |attribute|'s [=Attr/qualified name=]
+               1. For each |attribute| in |value|'s [=Element/attribute list=]:
 
-              1. Let |serialized| be |attribute|'s [=Attr/value=].
+                 1. Let |name| be |attribute|'s [=Attr/qualified name=]
 
-              1. [=Set=](|attributes|, |name|, |serialized|, false)
+                 1. Let |serialized| be |attribute|'s [=Attr/value=].
 
-            1. [=Set=](|serialized|, "attributes", |attributes|, false)
+                 1. [=Set=](|attributes|, |name|, |serialized|, false)
+
+               1. [=Set=](|serialized|, "attributes", |attributes|, false)
+
+               1. Let |shadow root| be |value|'s [=Element/shadow root=]
+
+               1. If |shadow root| is null, let |serialized shadow| be null.
+                  Otherwise let |serialized shadow| be the result of
+                  [=serialize as a remote value=] with |shadow root|, |max depth| - 1,
+                  false and |set of known objects|.
+
+                  Note: this means the <code>objectId</code> for the shadow root
+                  will be serialized irrespective of whether the shadow is open or closed,
+                  but no properties of the node will be returned.
+
+               1. [=Set=](|serialized|, "shadowRoot", |serialized shadow|, false)
 
         1. Let |remote value| be an [=object=] matching the <code>NodeValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
@@ -1187,10 +1208,12 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
       <dt>Otherwise:
       <dd>
-      1. Let |serialized| be null.
+      1. [=Assert=]: [=type=](|value|) is Object
+
+      1. let |serialized| be null.
 
       1. If |value| is not in the |set of known objects|, and |max depth|
-         is not null and greater than 0, run the following steps:
+         is greater than 0, run the following steps:
          1. Append |value| to the |set of known objects|
 
          1. Let |serialized| be the result of [=serialize as a mapping=] given
@@ -1213,8 +1236,6 @@ in general?
 </div>
 
 <div algorithm>
-Issue: this assumes for-in works on iterators
-
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 |node details| and |set of known objects|:
 
@@ -1230,6 +1251,8 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
   1. Return [=CreateArrayFromList=](|serialized|)
 </div>
+
+Issue: this assumes for-in works on iterators
 
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,

--- a/index.bs
+++ b/index.bs
@@ -45,6 +45,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: unknown command; url: dfn-unknown-command
+    text: no such element; url: dfn-no-such-element
     text: active sessions; url: dfn-active-session
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
@@ -56,13 +57,25 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
+    text: web element reference; url: dfn-web-element-reference
     text: window handle; url: dfn-window-handle
 spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
   type: dfn
+    text: Array; url: sec-array-objects
+    text: CreateArrayFromList; url: sec-createarrayfromlist
+    text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
+    text: Get; url: sec-get
+    text: HasProperty; url: sec-hasproperty
+    text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Object; url: sec-object-objects
     text: Set; url: sec-set
+    text: ThisTimeValue; url: thistimevalue
+    text: ToDateString; url: sec-todatestring
+    text: ToString; url: sec-tostring
     text: realm; url: sec-code-realms
-
+spec: HTML urlPrefix: https://html.spec.whatwg.org/
+  type: dfn
+    text: WindowProxy; url: windowproxy
 </pre>
 
 <pre class="link-defaults">
@@ -704,6 +717,507 @@ Realm = text;
 
 Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm.
+
+## Remote Object ## {#data_types-remote_object}
+
+Objects accessible from the ECMAScript runtime are represented by a mirror
+object, specified as <code>RemoteObject</code>. The object type is specified in
+the <code>type</code> property. In the case of JSON-representable primitive
+objects, this contains the object value in the <code>value</code> property; in
+the case of non-JSON-representable primitives, the <code>value</code> property
+contains a string representation of the object. For non-primitive objects, the
+<code>objectId</code> property contains a string id that provides a unique
+handle to the object, valid for its lifetime inside the engine. In this case the
+<code>value</code> property can contain a complex object (either a list or a
+struct) itself containing further remote object values. This allows objects like
+arrays to have a single representation.
+
+DOM Nodes are also represented by <code>RemoteObject</code> instances. These
+have a partial serialization of the node in the value property.
+
+Note: mirror objects do not keep the original object alive in the runtime. If an
+object is discarded in the runtime subsequent attempts to access it via the
+protocol will result in an error.
+
+A [=/session=] has an <dfn>object id map</dfn>. This is a weak map from objects to
+their corresponding id.
+
+Issue: Should this be explicitly per realm?
+
+<div algorithm>
+To get the <dfn export>object id for an object</dfn> given an |object|:
+
+  1. If [=object id map=] for the [=current session=] does not contain |object|
+     run the following steps:
+
+     1. Let |object id| be a new, unique, string identifier for |object|. If
+        |object| is an [=/element=] this must be the [=web element reference=]
+        for |object|; if it's [=WindowProxy=] object, this must be the
+        [=window handle=] for |object|.
+
+    1. Set the value of |object| in the [=object id map=] to |object id|.
+
+  1. Return the result of getting the value for |object| in [=object id map=].
+</div>
+
+<div algorithm>
+To get the <dfn export>object for an object id</dfn> given an |object id|:
+
+  1. For each |object| → |id value| of [=object id map=]:
+
+    1. If |id value| is equal to |object id|, return [=success=] with data
+       |object|
+
+  1. Return [=error=] with [=error code=] [=no such element=]
+
+  Issue: This error code isn't right.
+</div>
+
+[=remote end definition=] and [=local end definition=]
+```
+RemoteObject = {
+  UndefinedObject //
+  NullObject //
+  StringObject //
+  NumberObject //
+  BooleanObject //
+  BigIntObject //
+  SymbolObject //
+  ArrayObject //
+  FunctionObject //
+  ObjectObject //
+  FunctionObject //
+  RegexObject //
+  DateObject //
+  MapObject //
+  SetObject //
+  WeakMapObject //
+  WeakSetObject //
+  IteratorObject //
+  GeneratorObject //
+  ErrorObject //
+  ProxyObject //
+  PromiseObject //
+  TypedArrayObject //
+  ArrayBufferObject //
+  NodeObject //
+  WindowProxyObject //
+}
+
+ObjectId = text;
+
+UndefinedObject = {
+  type: "undefined",
+  value: null,
+}
+
+NullObject = {
+  type: "null",
+  value: null,
+}
+
+StringObject = {
+  type: "string",
+  value: text,
+}
+
+SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
+
+NumberObject = {
+  type: "number",
+  value: number / SpecialNumber,
+}
+
+BooleanObject = {
+  type: "boolean",
+  value: bool,
+}
+
+BigIntObject = {
+  type: "bigint",
+  value: text,
+}
+
+SymbolObject = {
+  type: "symbol",
+  objectId: ObjectId,
+}
+
+ArrayObject = {
+  type: "array",
+  objectId: ObjectId,
+  value?: [RemoteObject]
+}
+
+ObjectObject = {
+  type: "object",
+  objectId: ObjectId,
+  value?: {*text: RemoteObject}
+}
+
+FunctionObject = {
+  type: "function",
+  objectId: ObjectId,
+}
+
+RegexObject = {
+  type: "regex",
+  objectId: ObjectId,
+  value: text
+}
+
+DateObject = {
+  type: "date",
+  objectId: ObjectId,
+  value: text
+}
+
+MapObject = {
+  type: "map",
+  objectId: ObjectId,
+}
+
+SetObject = {
+  type: "set",
+  objectId: ObjectId
+}
+
+WeakMapObject = {
+  type: "map",
+  objectId: ObjectId,
+}
+
+WeakSetObject = {
+  type: "set",
+  objectId: ObjectId,
+}
+
+IteratorObject = {
+  type: "iterator",
+  objectId: ObjectId,
+}
+
+GeneratorObject = {
+  type: "iterator",
+  objectId: ObjectId,
+}
+
+ErrorObject = {
+  type: "error",
+  objectId: ObjectId,
+}
+
+ProxyObject = {
+  type: "proxy",
+  objectId: ObjectId,
+}
+
+PromiseObject = {
+  type: "promise",
+  objectId: ObjectId,
+}
+
+TypedArrayObject = {
+  type: "typedarray",
+  objectId: ObjectId,
+}
+
+ArrayBufferObject = {
+  type: "arraybuffer",
+  objectId: ObjectId,
+}
+
+NodeObject = {
+  type: "node",
+  objectId: ObjectId,
+  value?: NodeValue,
+}
+
+NodeValue = {
+  nodeType: uint,
+  nodeName: text,
+  localName: text,
+  nodeValue: text,
+  childNodeCount: uint,
+  children?: [*NodeObject],
+  attributes?: {*text: text},
+}
+
+WindowProxyObject = {
+  type: "window",
+  objectId: ObjectId,
+}
+
+
+```
+
+Issue: Add WASM types?
+
+Issue: NodeValue needs more attributes
+
+Issue: Should WindowProxy get attributes in a similar style to Node?
+
+<div algorithm>
+
+To <dfn>serialize as a remote object</dfn> given an |object|, a |max depth|,
+|node details|, and a |set of known objects|:
+
+  1. Switch on the type of |object|:
+
+    <dl>
+      <dt>Undefined
+      <dd>Let |remote object| be an [=object=] matching the `UndefinedObject`
+      production in the [=local end definition=].
+
+      <dt>Null
+      <dd>Let |remote object| be an [=object=] matching the `NullObject`
+      production in the [=local end definition=].
+
+      <dt>String
+      <dd>Let |remote object| be an [=object=] matching the `StringObject`
+      production in the [=local end definition=], with the <code>value</code>
+      property set to |object|.
+
+      <dt>Number
+      <dd>
+      1. Switch on the value of |object|:
+        <dl>
+          <dt>NaN
+          <dt>Let |value| be <code>"NaN"</code>
+          <dt>-0
+          <dt>Let |value| be <code>"-0"</code>
+          <dt>+Infinity
+          <dt>Let |value| be <code>"+Infinity"</code>
+          <dt>-Infinity
+          <dt>Let |value| be <code>"-Infinity"</code>
+          <dt>Otherwise:
+          <dt>Let |value| be |object|
+        </dl>
+        Let |remote object| be an [=object=] matching the `NumberObject`
+        production in the [=local end definition=], with the <code>value</code>
+        property set to |value|.
+
+      <dt>Boolean
+      <dd>Let |remote object| be an [=object=] matching the `BooleanObject`
+          production in the [=local end definition=], with the <code>value</code>
+          property set to |object|.
+
+      <dt>BigInt
+      <dd>Let |remote object| be an [=object=] matching the `BigIntObject`
+          production in the [=local end definition=], with the <code>value</code>
+          property set to the result of running the [=ToString=] operation on
+      |object|.
+
+      <dt>Symbol
+      <dd>Let |remote object| be an [=object=] matching the `SymbolObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Array
+      <dd>
+      1. Let |value| be null.
+
+      1. If |object| is not in the |set of known objects|, and |max depth|
+         is not null and greater than 0, run the following steps:
+             1. Append |object| to the |set of known objects|
+
+             1. Let |value| be a new List.
+
+             1. For each integer |index| in the range 0 to
+                [=LengthOfArrayLike=](|object|), run the following steps:
+
+                1. Let |index name| be [=ToString=](|index|)
+
+                1. If [=HasProperty=](|index name|) is true:
+
+                  1. Let |child object| be [=Get=](|object|, |index name|)
+
+                  1. Let |child remote object| be the result of [=serialize as a
+                     remote object=] with arguments |child object|, |max
+                     depth| - 1, |node details| and |set of known objects|.
+
+                  Otherwise let |child remote object| be an [=object=] matching
+                  the `UndefinedObject` production in the [=remote end
+                  definition=].
+
+                1. Append [=CreateArrayFromList=](|child remote object|) to |value|.
+
+      1. Let |remote object| be an [=object=] matching the `ArrayObject` production
+         in the [=local end definition=], with the <code>objectId</code> property set
+         to the [=object id for an object=] |object|, and the <code>value</code> field
+         set to |value| if it's not null, or ommitted otherwise.
+
+      <dt>Function
+      <dd>Let |remote object| be an [=object=] matching the `FunctionObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Regex
+      <dd>
+          1. Let |pattern| be [=ToString=]([=Get=](|object|, "source")).
+
+          1. Let |flags| be [=ToString=]([=Get=](|object|, "flags")).
+
+          1. Let |value| be the string-concatenation of "/", |pattern|, "/", and |flags|.
+
+          1. Let |remote object| be an [=object=] matching the `RegexObject`
+             production in the [=local end definition=], with the <code>objectId</code>
+             property set to the [=object id for an object=] |object| and the value
+             set to |value|
+
+      <dt>Date
+      <dd>
+        1. Let |value| be [=ToDateString=]([=thisTimeValue=](|object|)).
+
+        1. Let |remote object| be an [=object=] matching the `DateObject`
+           production in the [=local end definition=], with the <code>objectId</code>
+           property set to the [=object id for an object=] |object| and the value
+           set to |value|.
+
+      <dt>Map
+      <dd>Let |remote object| be an [=object=] matching the `MapObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Set
+      <dd>Let |remote object| be an [=object=] matching the `SetObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>WeakMap
+      <dd>Let |remote object| be an [=object=] matching the `WeakMapObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>WeakSet
+      <dd>Let |remote object| be an [=object=] matching the `WeakSetObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Iterator
+      <dd>Let |remote object| be an [=object=] matching the `IteratorObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Generator
+      <dd>Let |remote object| be an [=object=] matching the `IteratorObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Error
+      <dd>Let |remote object| be an [=object=] matching the `ErrorObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Proxy
+      <dd>Let |remote object| be an [=object=] matching the `ProxyObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Promise
+      <dd>Let |remote object| be an [=object=] matching the `PromiseObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>TypedArray
+      <dd>Let |remote object| be an [=object=] matching the `TypedArrayObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>ArrayBuffer
+      <dd>Let |remote object| be an [=object=] matching the `ArrayBufferObject`
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |object|.
+
+      <dt>Node
+      <dd>
+        1. Let |value| be null.
+
+        1. If |node details| is true, run the following steps:
+
+            1. Let |value| be a new [=Object=].
+
+            1. [=Set=](|value|, "nodeType", [=Get=](|object|, "nodeType"), false)
+
+            1. [=Set=](|value|, "nodeName", [=Get=](|object|, "nodeName"), false)
+
+            1. [=Set=](|value|, "localName", [=Get=](|object|, "localName"), false)
+
+            1. [=Set=](|value|, "nodeValue", [=Get=](|object|, "nodeValue"), false)
+
+            1. Let |child node count| be the size of |value|'s [=children=].
+
+            1. [=Set=](|value|, "childNodeCount", |child node count|, false)
+
+            1. If |max depth| is null and or equal to 0 let |children| be null.
+               Otherwise, let |children| be an empty list and, for each node
+               |child| in the [=children=] of |object|:
+
+              1. Let |serialized| be the result of [=serialize as a remote object=]
+                 with |child|, |max depth| - 1, |node details| and
+                 |set of known objects|.
+
+              1. Append |serialized| to |children|.
+
+            1. [=Set=](|value|, "children", |serialized|, false)
+
+            1. Let |attributes| be a new [=Object=].
+
+            1. For each |attribute| in |object|'s <a spec=dom>attributes</a>:
+
+              1. Let |name| be |attribute|'s [=Attr/qualified name=]
+
+              1. Let |value| be |attribute|'s [=Attr/value=].
+
+              1. [=Set=](|attributes|, |name|, |value|, false)
+
+            1. [=Set=](|value|, "attributes", |attributes|, false)
+
+        1. Let |remote object| be an [=object=] matching the `NodeObject`
+           production in the [=local end definition=], with the <code>objectId</code>
+           property set to the [=object id for an object=] |object|, and <code>value</code>
+           set to |value|, if |value| is not null.
+
+      <dt>WindowProxy
+      <dd>1. Let |remote object| be an [=object=] matching the `WindowProxyObject`
+             production in the [=local end definition=], with the <code>objectId</code>
+             property set to the [=object id for an object=] |object|.
+
+      <dt>Otherwise:
+      <dd>
+      1. let |value| be null.
+
+      1. If |object| is not in the |set of known objects|, and |max depth|
+         is not null and greater than 0, run the following steps:
+         1. Append |object| to the |set of known objects|
+
+         1. Let |value| be a new [=Object=].
+
+         1. For each |key| of [=EnumerableOwnPropertyNames=](|object|, key)
+            run the following steps:
+
+            1. Let |child object| be [=Get=](|object|, |key|)
+
+            1. Let |child remote object| be the result of [=serialize as a
+               remote object=] with arguments |child object|, |max
+               depth| - 1, |node details| and |set of known objects|.
+
+            1. [=Set=](|value|, |key|, |child object|, false)
+
+      1. Let |remote object| be an [=object=] matching the `ObjectObject` production
+         in the [=local end definition=], with the <code>objectId</code> property set
+         to the [=object id for an object=] |object|, and the <code>value</code> field
+         set to |value|.
+    </dl>
+
+  1. Return |remote object|
+
+Issue: the way we check types is all wrong
+
+Issue: Does it make sense to use the same depth parameter for nodes and objects
+in general?
+
+</div>
 
 Modules {#modules}
 ==================

--- a/index.bs
+++ b/index.bs
@@ -1175,6 +1175,11 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |value|.
 
+      <dt>|value| is a [=platform object=]
+      <dd>1. Let |remote value| be an [=object=] matching the <code>ObjectValue</code>
+             production in the [=local end definition=], with the <code>objectId</code>
+             property set to the [=object id for an object=] |value|.
+
       <dt>[=IsCallable=](|value|)
       <dd>Let |remote value| be an [=object=] matching the <code>FunctionValue</code>
           production in the [=local end definition=], with the <code>objectId</code>

--- a/index.bs
+++ b/index.bs
@@ -63,6 +63,10 @@ spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
   type: dfn
     text: Array; url: sec-array-objects
     text: CreateArrayFromList; url: sec-createarrayfromlist
+    text: CreateArrayIterator; url: sec-createarrayiterator
+    text: CreateListFromArrayLike; url: sec-createlistfromarraylike
+    text: CreateMapIterator; url: sec-createmapiterator
+    text: CreateSetIterator; url: sec-createsetiterator
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
     text: HasProperty; url: sec-hasproperty
@@ -812,6 +816,10 @@ RemoteValue = {
 
 ObjectId = text;
 
+ListValue = [*RemoteValue];
+
+MappingValue = [*[RemoteValue / text, RemoteValue]];
+
 UndefinedValue = {
   type: "undefined",
 }
@@ -850,13 +858,13 @@ SymbolValue = {
 ArrayValue = {
   type: "array",
   objectId: ObjectId,
-  value?: [*RemoteValue]
+  value?: ListValue,
 }
 
 ObjectValue = {
   type: "object",
   objectId: ObjectId,
-  value?: {* text => RemoteValue}
+  value?: MappingValue,
 }
 
 FunctionObject = {
@@ -879,11 +887,13 @@ DateValue = {
 MapValue = {
   type: "map",
   objectId: ObjectId,
+  value?: MappingValue,
 }
 
 SetValue = {
   type: "set",
-  objectId: ObjectId
+  objectId: ObjectId,
+  value?: ListValue
 }
 
 WeakMapValue = {
@@ -929,7 +939,7 @@ NodeProperties = {
   nodeValue: text,
   childNodeCount: uint,
   children?: [*NodeValue],
-  attributes?: {*text: text},
+  attributes?: {*text => text},
 }
 
 WindowProxyValue = {
@@ -1014,31 +1024,14 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
          is not null and greater than 0, run the following steps:
              1. Append |value| to the |set of known objects|
 
-             1. Let |serialized| be a new List.
-
-             1. For each integer |index| in the range 0 to
-                [=LengthOfArrayLike=](|object|), run the following steps:
-
-                1. Let |index name| be [=ToString=](|index|)
-
-                1. If [=HasProperty=](|index name|) is true:
-
-                  1. Let |child value| be [=Get=](|object|, |index name|)
-
-                  1. Let |serialized child| be the result of [=serialize as a
-                     remote value=] with arguments |child value|, |max
-                     depth| - 1, |node details| and |set of known objects|.
-
-                  Otherwise let |serialized child| be an [=object=] matching
-                  the <code>UndefinedValue</code> production in the [=remote end
-                  definition=].
-
-                1. Append [=CreateArrayFromList=](|serialized child|) to |serialized|.
+             1. Let |serialized| be the result of [=serialize as a list=] given
+                [=CreateArrayIterator=](|value|, value), |max depth|, |node details| and
+                |set of known objects|.
 
       1. Let |remote value| be an [=object=] matching the <code>ArrayValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
-         to the [=object id for an object=] |object|, and the <code>value</code> field
-         set to |serialized| if it's not null, or ommitted otherwise.
+         to the [=object id for an object=] |value|, and the <code>value</code>
+         field set to |serialized| if it's not null, or ommitted otherwise.
 
       <dt>[=IsRegExp=](|value|)
       <dd>
@@ -1063,14 +1056,40 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
            set to |serialized|.
 
       <dt>|value| has a \[[MapData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>MapValue</code>
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
+      <dd>
+        1. Let |serialized| be null.
+
+        1. If |value| is not in the |set of known objects|, and |max depth|
+           is not null and greater than 0, run the following steps:
+             1. Append |value| to the |set of known objects|
+
+             1. Let |serialized| be the result of [=serialize as a list=] given
+                [=CreateMapIterator=](|value|, key+value), |max depth|, |node details| and
+                |set of known objects|.
+
+      1. Let |remote value| be an [=object=] matching the <code>MapValue</code>
+         production in the [=local end definition=], with the
+         <code>objectId</code> property set to the [=object id for an object=]
+         |value|, and the <code>value</code> field set to |serialized| if it's
+         not null, or ommitted otherwise.
 
       <dt>|value| has a \[[SetData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>SetValue</code>
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
+      <dd>
+        1. Let |serialized| be null.
+
+        1. If |value| is not in the |set of known objects|, and |max depth|
+           is not null and greater than 0, run the following steps:
+             1. Append |value| to the |set of known objects|
+
+             1. Let |serialized| be the result of [=serialize as a list=] given
+                [=CreateSetIterator=](|value|, value), |max depth|, |node details| and
+                |set of known objects|.
+
+       1. Let |remote value| be an [=object=] matching the <code>SetValue</code>
+          production in the [=local end definition=], with the
+          <code>objectId</code> property set to the [=object id for an object=]
+          |value|, and the <code>value</code> field set to |serialized| if it's
+          not null, or ommitted otherwise.
 
       <dt>|value| has a \[[WeakMapData]] [=internal slot=]
       <dd>Let |remote value| be an [=object=] matching the <code>WeakMapValue</code>
@@ -1169,18 +1188,9 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
          is not null and greater than 0, run the following steps:
          1. Append |value| to the |set of known objects|
 
-         1. Let |serialized| be a new [=Object=].
-
-         1. For each |key| of [=EnumerableOwnPropertyNames=](|value|, key)
-            run the following steps:
-
-            1. Let |child value| be [=Get=](|value|, |key|)
-
-            1. Let |child remote value| be the result of [=serialize as a
-               remote value=] with arguments |child value|, |max
-               depth| - 1, |node details| and |set of known objects|.
-
-            1. [=Set=](|serialized|, |key|, |child remote value|, false)
+         1. Let |serialized| be the result of [=serialize as a mapping=] given
+            [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|, |node
+            details| and |set of known objects|
 
       1. Let |remote value| be an [=object=] matching the <code>ObjectValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
@@ -1196,6 +1206,59 @@ Issue: Does it make sense to use the same depth parameter for nodes and objects
 in general?
 
 </div>
+
+<div algorithm>
+Issue: this assumes for-in works on iterators
+
+To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
+|node details| and |set of known objects|:
+
+  1. Let |serialized| be a new list.
+
+  1. For each |child value| in |iterable|:
+
+    1. Let |serialized child| be the result of [=serialize as a
+       remote value=] with arguments |child value|, |max
+       depth| - 1, |node details| and |set of known objects|.
+
+    1. Append |serialized child| to |serialized|.
+
+  1. Return [=CreateArrayFromList=](|serialized|)
+</div>
+
+<div algorithm>
+To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
+|node details| and |set of known objects|:
+
+  1. Let |serialized| be a new list.
+
+  1. For |item| in |iterable|:
+    1. Assert: [=IsArray=](|item|)
+
+    1. Let |property| be [=CreateListFromArrayLike=](|item|)
+
+    1. Assert |property| is a list of size 2
+
+    1. Let |key| be |property|[0] and let |value| be |property|[1]
+
+    1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
+       otherwise let |serialized key| be the result of [=serialize as a remote
+       value=] with arguments |child key|, |max depth| - 1, |node details| and
+       |set of known objects|.
+
+    1. Let |serialized value| be the result of [=serialize as a
+       remote value=] with arguments |value|, |max
+       depth| - 1, |node details| and |set of known objects|.
+
+    1. Let |serialized child| be [=CreateArrayFromList=](«|serialized key|,
+       |serialized value|»).
+
+    1. Append |serialized child| to |serialized|.
+
+  1. Return [=CreateArrayFromList=](|serialized|)
+</div>
+
+
 
 Modules {#modules}
 ==================

--- a/index.bs
+++ b/index.bs
@@ -968,15 +968,15 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
     <dl>
       <dt>[=Type=](|value|) is Undefined
-      <dd>Let |remote value| be an [=object=] matching the <code>UndefinedValue</code>
+      <dd>Let |remote value| be a map matching the <code>UndefinedValue</code>
       production in the [=local end definition=].
 
       <dt>[=Type=](|value|) is Null
-      <dd>Let |remote value| be an [=object=] matching the <code>NullValue</code>
+      <dd>Let |remote value| be a map matching the <code>NullValue</code>
       production in the [=local end definition=].
 
       <dt>[=Type=](|value|) is String
-      <dd>Let |remote value| be an [=object=] matching the <code>StringValue</code>
+      <dd>Let |remote value| be a map matching the <code>StringValue</code>
       production in the [=local end definition=], with the <code>value</code>
       property set to |value|.
 
@@ -998,23 +998,23 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
           <dt>Let |serialized| be |value|
         </dl>
 
-      1. Let |remote value| be an [=object=] matching the <code>NumberValue</code>
+      1. Let |remote value| be a map matching the <code>NumberValue</code>
          production in the [=local end definition=], with the <code>value</code>
          property set to |serialized|.
 
       <dt>[=Type=](|value|) is Boolean
-      <dd>Let |remote value| be an [=object=] matching the <code>BooleanValue</code>
+      <dd>Let |remote value| be a map matching the <code>BooleanValue</code>
           production in the [=local end definition=], with the <code>value</code>
           property set to |value|.
 
       <dt>[=Type=](|value|) is BigInt
-      <dd>Let |remote value| be an [=object=] matching the <code>BigIntValue</code>
+      <dd>Let |remote value| be a map matching the <code>BigIntValue</code>
           production in the [=local end definition=], with the <code>value</code>
           property set to the result of running the [=ToString=] operation on
           |value|.
 
       <dt>[=Type=](|value|) is Symbol
-      <dd>Let |remote value| be an [=object=] matching the <code>SymbolValue</code>
+      <dd>Let |remote value| be a map matching the <code>SymbolValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
@@ -1030,7 +1030,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
                 [=CreateArrayIterator=](|value|, value), |max depth|, |node details| and
                 |set of known objects|.
 
-      1. Let |remote value| be an [=object=] matching the <code>ArrayValue</code> production
+      1. Let |remote value| be a map matching the <code>ArrayValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |value|, and the <code>value</code>
          field set to |serialized| if it's not null, or ommitted otherwise.
@@ -1043,7 +1043,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
           1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote value| be an [=object=] matching the <code>RegExpValue</code>
+          1. Let |remote value| be a map matching the <code>RegExpValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |serialized|
@@ -1052,7 +1052,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
       <dd>
         1. Let |serialized| be [=ToDateString=]([=thisTimeValue=](|value|)).
 
-        1. Let |remote value| be an [=object=] matching the <code>DateValue</code>
+        1. Let |remote value| be a map matching the <code>DateValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
            set to |serialized|.
@@ -1069,7 +1069,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
                 [=CreateMapIterator=](|value|, key+value), |max depth|, |node details| and
                 |set of known objects|.
 
-      1. Let |remote value| be an [=object=] matching the <code>MapValue</code>
+      1. Let |remote value| be a map matching the <code>MapValue</code>
          production in the [=local end definition=], with the
          <code>objectId</code> property set to the [=object id for an object=]
          |value|, and the <code>value</code> field set to |serialized| if it's
@@ -1087,39 +1087,39 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
                 [=CreateSetIterator=](|value|, value), |max depth|, |node details| and
                 |set of known objects|.
 
-       1. Let |remote value| be an [=object=] matching the <code>SetValue</code>
+       1. Let |remote value| be a map matching the <code>SetValue</code>
           production in the [=local end definition=], with the
           <code>objectId</code> property set to the [=object id for an object=]
           |value|, and the <code>value</code> field set to |serialized| if it's
           not null, or ommitted otherwise.
 
       <dt>|value| has a \[[WeakMapData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>WeakMapValue</code>
+      <dd>Let |remote value| be a map matching the <code>WeakMapValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
       <dt>|value| has a \[[WeakSetData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>WeakSetValue</code>
+      <dd>Let |remote value| be a map matching the <code>WeakSetValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
       <dt>|value| has an \[[ErrorData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>ErrorValue</code>
+      <dd>Let |remote value| be a map matching the <code>ErrorValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
       <dt>[=IsPromise=](|value|)
-      <dd>Let |remote value| be an [=object=] matching the <code>PromiseValue</code>
+      <dd>Let |remote value| be a map matching the <code>PromiseValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
       <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>TypedArrayValue</code>
+      <dd>Let |remote value| be a map matching the <code>TypedArrayValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
       <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
-      <dd>Let |remote value| be an [=object=] matching the <code>ArrayBufferValue</code>
+      <dd>Let |remote value| be a map matching the <code>ArrayBufferValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
@@ -1129,23 +1129,23 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
         1. If |node details| is true, run the following steps:
 
-            1. Let |serialized| be a new [=Object=].
+            1. Let |serialized| be a map.
 
-            1. [=Set=](|serialized|, "nodeType", [=Get=](|value|, "nodeType"), false)
+            1. "nodeType", [=Get=](|value|, "nodeType"), false)
 
-            1. [=Set=](|serialized|, "nodeValue", [=Get=](|value|, "nodeValue"), false)
+            1. Set |serialized|["<code>nodeValue</code>"] to [=Get=](|value|, "nodeValue")
 
             1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
 
 
-              1. [=Set=](|serialized|, "localName", [=Get=](|value|, "localName"), false)
+              1. Set |serialized|["<code>localName</code>" to [=Get=](|value|, "localName")
 
-              1. [=Set=](|serialized|, "namespaceURI", [=Get=](|value|, "namespaceURI"), false)
+              1. Set |serialized|["<code>namespaceURI</code>"] to [=Get=](|value|, "namespaceURI")
 
 
             1. Let |child node count| be the size of |serialized|'s [=children=].
 
-            1. [=Set=](|serialized|, "childNodeCount", |child node count|, false)
+            1. Set |serialized|["<code>childNodeCount</code>" to |child node count|
 
             1. If |max depth| is equal to 0 let |children| be null.
                Otherwise, let |children| be an empty list and, for each node
@@ -1157,23 +1157,23 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
               1. Append |serialized| to |children|.
 
-            1. [=Set=](|serialized|, "children", |serialized|, false)
+            1. Set |serialized|["<code>children</code>"] to |children|.
 
             1. If |value| is an [=/Element=]:
 
-               1. Let |attributes| be a new [=Object=].
+               1. Let |attributes| be a new map.
 
                1. For each |attribute| in |value|'s [=Element/attribute list=]:
 
                  1. Let |name| be |attribute|'s [=Attr/qualified name=]
 
-                 1. Let |serialized| be |attribute|'s [=Attr/value=].
+                 1. Let |value| be |attribute|'s [=Attr/value=].
 
-                 1. [=Set=](|attributes|, |name|, |serialized|, false)
+                 1. Set |attributes|[|name|] to |value|
 
-               1. [=Set=](|serialized|, "attributes", |attributes|, false)
+               1. Set |serialized|["<code>attributes</code>"] to |attributes|.
 
-               1. Let |shadow root| be |value|'s [=Element/shadow root=]
+               1. Let |shadow root| be |value|'s [=Element/shadow root=].
 
                1. If |shadow root| is null, let |serialized shadow| be null.
                   Otherwise let |serialized shadow| be the result of
@@ -1184,25 +1184,25 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
                   will be serialized irrespective of whether the shadow is open or closed,
                   but no properties of the node will be returned.
 
-               1. [=Set=](|serialized|, "shadowRoot", |serialized shadow|, false)
+               1. Set= |serialized|["<code>shadowRoot</code>"] to |serialized shadow|.
 
-        1. Let |remote value| be an [=object=] matching the <code>NodeValue</code>
+        1. Let |remote value| be a map matching the <code>NodeValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |value|, and <code>value</code>
            set to |serialized|, if |serialized| is not null.
 
       <dt>|value| is a [=platform object=] that implements [=WindowProxy=]
-      <dd>1. Let |remote value| be an [=object=] matching the <code>WindowProxyValue</code>
+      <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |value|.
 
       <dt>|value| is a [=platform object=]
-      <dd>1. Let |remote value| be an [=object=] matching the <code>ObjectValue</code>
+      <dd>1. Let |remote value| be a map matching the <code>ObjectValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |value|.
 
       <dt>[=IsCallable=](|value|)
-      <dd>Let |remote value| be an [=object=] matching the <code>FunctionValue</code>
+      <dd>Let |remote value| be a map matching the <code>FunctionValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
@@ -1220,15 +1220,13 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
             [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|, |node
             details| and |set of known objects|
 
-      1. Let |remote value| be an [=object=] matching the <code>ObjectValue</code> production
+      1. Let |remote value| be a map matching the <code>ObjectValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |value|, and the <code>value</code> field
          set to |serialized|.
     </dl>
 
   1. Return |remote value|
-
-Issue: the way we check types is all wrong
 
 Issue: Does it make sense to use the same depth parameter for nodes and objects
 in general?
@@ -1249,7 +1247,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
     1. Append |serialized child| to |serialized|.
 
-  1. Return [=CreateArrayFromList=](|serialized|)
+  1. Return |serialized|
 </div>
 
 Issue: this assumes for-in works on iterators
@@ -1278,12 +1276,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
        remote value=] with arguments |value|, |max
        depth| - 1, |node details| and |set of known objects|.
 
-    1. Let |serialized child| be [=CreateArrayFromList=](«|serialized key|,
-       |serialized value|»).
+    1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
     1. Append |serialized child| to |serialized|.
 
-  1. Return [=CreateArrayFromList=](|serialized|)
+  1. Return |serialized|
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -66,12 +66,18 @@ spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
     text: HasProperty; url: sec-hasproperty
+    text: internal slot; url: sec-object-internal-methods-and-internal-slots
+    text: IsArray; url: sec-isarray
+    text: IsCallable; url: sec-iscallable
+    text: IsPromise; url: sec-ispromise
+    text: IsRegExp; url: sec-isregexp
     text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Object; url: sec-object-objects
     text: Set; url: sec-set
     text: ThisTimeValue; url: thistimevalue
     text: ToDateString; url: sec-todatestring
     text: ToString; url: sec-tostring
+    text: Type; url: sec-ecmascript-data-types-and-values
     text: realm; url: sec-code-realms
 spec: HTML urlPrefix: https://html.spec.whatwg.org/
   type: dfn
@@ -890,23 +896,8 @@ WeakSetValue = {
   objectId: ObjectId,
 }
 
-IteratorValue = {
-  type: "iterator",
-  objectId: ObjectId,
-}
-
-GeneratorValue = {
-  type: "iterator",
-  objectId: ObjectId,
-}
-
 ErrorValue = {
   type: "error",
-  objectId: ObjectId,
-}
-
-ProxyValue = {
-  type: "proxy",
   objectId: ObjectId,
 }
 
@@ -953,28 +944,33 @@ Issue: NodeValue needs more attributes
 
 Issue: Should WindowProxy get attributes in a similar style to Node?
 
+Issue: handle String / Number / etc. wrapper objects specially?
+
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 |node details|, and a |set of known objects|:
 
-  1. Switch on the type of |value|:
+  1. In the following list of conditions and associated steps, run the first set
+     of steps for which the associated condition is true:
 
     <dl>
-      <dt>Undefined
-      <dd>Let |remote value| be an [=object=] matching the `UndefinedValue`
+      <dt>[=Type=](|value|) is Undefined
+      <dd>Let |remote value| be an [=object=] matching the <code>UndefinedValue</code>
       production in the [=local end definition=].
 
-      <dt>Null
-      <dd>Let |remote value| be an [=object=] matching the `NullValue`
+      <dt>[=Type=](|value|) is Null
+      <dd>Let |remote value| be an [=object=] matching the <code>NullValue</code>
       production in the [=local end definition=].
 
-      <dt>String
-      <dd>Let |remote value| be an [=object=] matching the `StringValue`
+      <dt>[=Type=](|value|) is String
+      <dd>Let |remote value| be an [=object=] matching the <code>StringValue</code>
       production in the [=local end definition=], with the <code>value</code>
       property set to |value|.
 
-      <dt>Number
+      Issue: This doesn't handle lone surrogates
+
+      <dt>[=Type=](|value|) is Number
       <dd>
       1. Switch on the value of |value|:
         <dl>
@@ -989,27 +985,28 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
           <dt>Otherwise:
           <dt>Let |serialized| be |value|
         </dl>
-        Let |remote value| be an [=object=] matching the `NumberValue`
-        production in the [=local end definition=], with the <code>value</code>
-        property set to |serialized|.
 
-      <dt>Boolean
-      <dd>Let |remote value| be an [=object=] matching the `BooleanValue`
+      1. Let |remote value| be an [=object=] matching the <code>NumberValue</code>
+         production in the [=local end definition=], with the <code>value</code>
+         property set to |serialized|.
+
+      <dt>[=Type=](|value|) is Boolean
+      <dd>Let |remote value| be an [=object=] matching the <code>BooleanValue</code>
           production in the [=local end definition=], with the <code>value</code>
           property set to |value|.
 
-      <dt>BigInt
-      <dd>Let |remote value| be an [=object=] matching the `BigIntValue`
+      <dt>[=Type=](|value|) is BigInt
+      <dd>Let |remote value| be an [=object=] matching the <code>BigIntValue</code>
           production in the [=local end definition=], with the <code>value</code>
           property set to the result of running the [=ToString=] operation on
           |value|.
 
-      <dt>Symbol
-      <dd>Let |remote value| be an [=object=] matching the `SymbolValue`
+      <dt>[=Type=](|value|) is Symbol
+      <dd>Let |remote value| be an [=object=] matching the <code>SymbolValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Array
+      <dt>[=IsArray=](|value|)
       <dd>
       1. Let |serialized| be null.
 
@@ -1033,22 +1030,17 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
                      depth| - 1, |node details| and |set of known objects|.
 
                   Otherwise let |serialized child| be an [=object=] matching
-                  the `UndefinedValue` production in the [=remote end
+                  the <code>UndefinedValue</code> production in the [=remote end
                   definition=].
 
                 1. Append [=CreateArrayFromList=](|serialized child|) to |serialized|.
 
-      1. Let |remote value| be an [=object=] matching the `ArrayValue` production
+      1. Let |remote value| be an [=object=] matching the <code>ArrayValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |object|, and the <code>value</code> field
          set to |serialized| if it's not null, or ommitted otherwise.
 
-      <dt>Function
-      <dd>Let |remote value| be an [=object=] matching the `FunctionValue`
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
-
-      <dt>RegExp
+      <dt>[=IsRegExp=](|value|)
       <dd>
           1. Let |pattern| be [=ToString=]([=Get=](|value|, "source")).
 
@@ -1056,76 +1048,61 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
           1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-          1. Let |remote | be an [=object=] matching the `RegExpValue`
+          1. Let |remote | be an [=object=] matching the <code>RegExpValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |object| and the value
              set to |serialized|
 
-      <dt>Date
+      <dt>|value| has a \[[DateValue]] [=internal slot=].
       <dd>
         1. Let |serialized| be [=ToDateString=]([=thisTimeValue=](|value|)).
 
-        1. Let |remote value| be an [=object=] matching the `DateValue`
+        1. Let |remote value| be an [=object=] matching the <code>DateValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
            set to |serialized|.
 
-      <dt>Map
-      <dd>Let |remote value| be an [=object=] matching the `MapValue`
+      <dt>|value| has a \[[MapData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>MapValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Set
-      <dd>Let |remote value| be an [=object=] matching the `SetValue`
+      <dt>|value| has a \[[SetData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>SetValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>WeakMap
-      <dd>Let |remote value| be an [=object=] matching the `WeakMapValue`
+      <dt>|value| has a \[[WeakMapData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>WeakMapValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>WeakSet
-      <dd>Let |remote value| be an [=object=] matching the `WeakSetValue`
+      <dt>|value| has a \[[WeakSetData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>WeakSetValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Iterator
-      <dd>Let |remote value| be an [=object=] matching the `IteratorValue`
+      <dt>|value| has an \[[ErrorData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>ErrorValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Generator
-      <dd>Let |remote value| be an [=object=] matching the `IteratorValue`
+      <dt>[=IsPromise=](|value|)
+      <dd>Let |remote value| be an [=object=] matching the <code>PromiseValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Error
-      <dd>Let |remote value| be an [=object=] matching the `ErrorValue`
+      <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>TypedArrayValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Proxy
-      <dd>Let |remote value| be an [=object=] matching the `ProxyValue`
+      <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
+      <dd>Let |remote value| be an [=object=] matching the <code>ArrayBufferValue</code>
           production in the [=local end definition=], with the <code>objectId</code>
           property set to the [=object id for an object=] |value|.
 
-      <dt>Promise
-      <dd>Let |remote value| be an [=object=] matching the `PromiseValue`
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
-
-      <dt>TypedArray
-      <dd>Let |remote value| be an [=object=] matching the `TypedArrayValue`
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
-
-      <dt>ArrayBuffer
-      <dd>Let |remote value| be an [=object=] matching the `ArrayBufferValue`
-          production in the [=local end definition=], with the <code>objectId</code>
-          property set to the [=object id for an object=] |value|.
-
-      <dt>Node
+      <dt>|value| is a [=platform object=] that implements [=Node=]
       <dd>
         1. Let |serialized| be null.
 
@@ -1169,15 +1146,20 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
             1. [=Set=](|serialized|, "attributes", |attributes|, false)
 
-        1. Let |remote value| be an [=object=] matching the `NodeValue`
+        1. Let |remote value| be an [=object=] matching the <code>NodeValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |value|, and <code>value</code>
            set to |serialized|, if |serialized| is not null.
 
-      <dt>WindowProxy
-      <dd>1. Let |remote value| be an [=object=] matching the `WindowProxyValue`
+      <dt>|value| is a [=platform object=] that implements [=WindowProxy=]
+      <dd>1. Let |remote value| be an [=object=] matching the <code>WindowProxyValue</code>
              production in the [=local end definition=], with the <code>objectId</code>
              property set to the [=object id for an object=] |value|.
+
+      <dt>[=IsCallable=](|value|)
+      <dd>Let |remote value| be an [=object=] matching the <code>FunctionValue</code>
+          production in the [=local end definition=], with the <code>objectId</code>
+          property set to the [=object id for an object=] |value|.
 
       <dt>Otherwise:
       <dd>
@@ -1200,7 +1182,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
             1. [=Set=](|serialized|, |key|, |child remote value|, false)
 
-      1. Let |remote value| be an [=object=] matching the `ObjectValue` production
+      1. Let |remote value| be an [=object=] matching the <code>ObjectValue</code> production
          in the [=local end definition=], with the <code>objectId</code> property set
          to the [=object id for an object=] |value|, and the <code>value</code> field
          set to |serialized|.

--- a/index.bs
+++ b/index.bs
@@ -818,7 +818,7 @@ ObjectId = text;
 
 ListValue = [*RemoteValue];
 
-MappingValue = [*[RemoteValue / text, RemoteValue]];
+MappingValue = [*[(RemoteValue / text), RemoteValue]];
 
 UndefinedValue = {
   type: "undefined",

--- a/index.bs
+++ b/index.bs
@@ -728,7 +728,7 @@ Realm = text;
 Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm.
 
-## Remote Value ## {#data-types-remote-object}
+## Remote Value ## {#data-types-remote-value}
 
 Values accessible from the ECMAScript runtime are represented by a mirror
 object, specified as <code>RemoteValue</code>. The value's type is specified in
@@ -760,7 +760,7 @@ Issue: Should this be explicitly per realm?
 <div algorithm>
 To get the <dfn>object id for an object</dfn> given an |object|:
 
-  1. If [=object id map=] for the [=current session=] does not contain |object|
+  1. If the [=object id map=] for the [=current session=] does not contain |object|
      run the following steps:
 
      1. Let |object id| be a new, unique, string identifier for |object|. If
@@ -987,15 +987,15 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
       1. Switch on the value of |value|:
         <dl>
           <dt>NaN
-          <dt>Let |serialized| be <code>"NaN"</code>
+          <dd>Let |serialized| be <code>"NaN"</code>
           <dt>-0
-          <dt>Let |serialized| be <code>"-0"</code>
+          <dd>Let |serialized| be <code>"-0"</code>
           <dt>+Infinity
-          <dt>Let |serialized| be <code>"+Infinity"</code>
+          <dd>Let |serialized| be <code>"+Infinity"</code>
           <dt>-Infinity
-          <dt>Let |serialized| be <code>"-Infinity"</code>
+          <dd>Let |serialized| be <code>"-Infinity"</code>
           <dt>Otherwise:
-          <dt>Let |serialized| be |value|
+          <dd>Let |serialized| be |value|
         </dl>
 
       1. Let |remote value| be a map matching the <code>NumberValue</code>
@@ -1263,7 +1263,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 
     1. Let |property| be [=CreateListFromArrayLike=](|item|)
 
-    1. Assert |property| is a list of size 2
+    1. Assert: |property| is a list of size 2
 
     1. Let |key| be |property|[0] and let |value| be |property|[1]
 

--- a/index.bs
+++ b/index.bs
@@ -792,12 +792,12 @@ RemoteValue = {
   NumberValue //
   BooleanValue //
   BigIntValue //
-  Symbol //
+  SymbolValue //
   ArrayValue //
   FunctionValue //
   ObjectValue //
   FunctionValue //
-  RegexValue //
+  RegExpValue //
   DateValue //
   MapValue //
   SetValue //


### PR DESCRIPTION
This starts building out the serialization infrastructure for sending
runtime-accessible objects over the wire. The format is based on
what's possible in CDP, with the notable change that the `value` field
is directly able to handle array and object types recursively rather
than using a seperate `preview` field. Also `type` and `subtype` are
merged into a single field and `value` and `unserializableValue` are
merged.

At this point there's no support for directly producing JSON values in
the serialization, we could add that later if required (but it's
arguably less important if the client is able to reconstruct the JSON
output when required).

There are also several other fields from CDP missing; we can add those
later if required.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/57.html" title="Last updated on Oct 26, 2020, 2:17 PM UTC (ab5bb13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/57/819fd0c...ab5bb13.html" title="Last updated on Oct 26, 2020, 2:17 PM UTC (ab5bb13)">Diff</a>