### PR TITLE
Editorial: fix a small typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -301,7 +301,7 @@ occurred on the [=remote end=].
    triggered and steps to construct the [=event type=] data.
 
 A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set
-containing containing the event names for events that are enabled for all
+containing the event names for events that are enabled for all
 browsing contexts. This initially contains the [=event name=] for events that
 are <dfn export for=event>in the default event set</dfn>.
 


### PR DESCRIPTION
Removed extra containing in 3.5 Events