### PR TITLE
Add GitHub workflow to test CDDL syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,15 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - run: npm install cddl parse5
-      - run: ./scripts/cddl/generate.js
-      - run: |
-          cat remote.cddl
-          cat local.cddl
-      - run: |
+      - name: Install Dependencies
+        run: npm install cddl parse5
+      - name: Extract CDDL content from spec into files
+        run: ./scripts/cddl/generate.js
+      - name: Print remote.cddl
+        run: cat remote.cddl
+      - name: Print local.cddl
+        run: cat local.cddl
+      - name: Validate CDDL files
+        run: |
           npx cddl validate local.cddl
           npx cddl validate remote.cddl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  cddl:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: npm install -g cddl
+      - run: ./scripts/cddl/generate.js
+      - run: cat index.cddl
+      - run: cddl validate index.cddl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - run: npm install -g cddl
+      - run: npm install cddl parse5
       - run: ./scripts/cddl/generate.js
-      - run: cat index.cddl
-      - run: cddl validate index.cddl
+      - run: |
+          cat remote.cddl
+          cat local.cddl
+      - run: |
+          npx cddl validate local.cddl
+          npx cddl validate remote.cddl

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /index.html
+*.cddl
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules
 /index.html
 *.cddl
 *.json

--- a/index.bs
+++ b/index.bs
@@ -1365,8 +1365,8 @@ to the implementation.
    <dd>
       <pre class="cddl local-cddl">
       StatusResult = {
-         ready: bool,
-         message: text,
+        ready: bool,
+        message: text,
       }
       </pre>
    </dd>
@@ -1440,10 +1440,10 @@ Issue: This needs to be generalised to work with realms too
    <dt>Command Type</dt>
    <dd>
      <pre class="cddl remote-cddl">
-       UnsubscribeCommand = {
-         method: "session.unsubscribe",
-         params: SubscribeParameters
-       }
+     UnsubscribeCommand = {
+       method: "session.unsubscribe",
+       params: SubscribeParameters
+     }
      </pre>
    </dd>
    <dt>Return Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -166,13 +166,9 @@ CommandResponse = {
 
 ErrorResponse = {
   id: uint / null,
-  error: (
-    "unknown error" /
-    "unknown method" /
-    "invalid argument"
-  ),
+  error: "unknown error" / "unknown method" / "invalid argument",
   message: text,
-  stacktrace?: text,
+  ?stacktrace: text,
 }
 
 ResultData = (
@@ -1409,7 +1405,7 @@ Issue: This needs to be generalized to work with realms too
 
       SubscribeParameters = {
         events: [*text],
-        contexts?: [*BrowsingContext],
+        ?contexts: [*BrowsingContext],
       }
       </pre>
    </dd>

--- a/scripts/cddl/generate.js
+++ b/scripts/cddl/generate.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const spec = path.resolve(__dirname, '..', '..', 'index.bs')
+const specContent = fs.readFileSync(spec, 'utf-8')
+
+const preFormattedTexts = [...specContent.match(/<pre .*>([^<]*)<\/pre>/g)]
+    /**
+     * filter for CDDL code
+     */
+    .filter((pre) => pre.split('\n')[0].includes('cddl'))
+    /**
+     * drop HTML tags
+     */
+    .map((pre) => pre.split('\n').slice(1, -1))
+    /**
+     * remove obsolete whitespace
+     */
+    .map((pre) => {
+        const preceedingSpace = pre.reduce((prev, line) => {
+            if (line.length === 0) {
+                return prev
+            }
+    
+            const spaces = line.match(/^\s+/)
+            if (spaces) {
+                return Math.min(prev, spaces[0].length)
+            }
+    
+            return 0
+        }, Infinity)
+        return pre.map((line) => line.slice(preceedingSpace))
+    })
+    /**
+     * drop all cddl snippets without declarations, e.g.
+     * ```
+     * EmptyResult
+     * ```
+     */
+    .filter((pre) => pre.length > 1)
+    /**
+     * join code lines
+     */
+    .map((pre) => pre.join('\n'))
+    .join('\n')
+
+fs.writeFileSync(path.join(process.cwd(), 'index.cddl'), preFormattedTexts)

--- a/scripts/cddl/utils.js
+++ b/scripts/cddl/utils.js
@@ -1,0 +1,36 @@
+/**
+ * Helper function to iterate through the parsed spec document and
+ * filter out all `<pre>` nodes with class `cddl`, e.g.
+ * ```
+ * <pre class="cddl remote-cddl">...</pre>
+ * <pre class="cddl local-cddl">...</pre>
+ * ```
+ * 
+ * @param {[Document] | DefaultTreeNode[]} nodes tree nodes
+ * @return {
+ *   {
+ *     nodeClass: string,
+ *     content: string[]
+ *   }[]
+ * } a list of pre texts
+ */
+function getCDDLNodes (nodes) {
+    return nodes.map((node) => {
+        if (node.nodeName === 'pre') {
+            const nodeClass = node.attrs.find((attr) => attr.name === 'class')
+            const content = node.childNodes.map((child) => child.value).join('')
+
+            if (nodeClass && nodeClass.value.includes('cddl')) {
+                return { nodeClass: nodeClass.value.split(' ').pop(), content }
+            }
+        }
+
+        if (!node.childNodes) {
+            return
+        }
+
+        return getCDDLNodes(node.childNodes)
+    }).flat().filter(Boolean)
+}
+
+module.exports = { getCDDLNodes }


### PR DESCRIPTION
Over the last weeks/month I was working on a [CDDL parser](https://www.npmjs.com/package/cddl) as some sort of hobby project. It is now at a stage where it can be used to validate the cddl syntax of all cddl pre formatted texts we have in the spec. My next task is to actually validate the content of the cddl file (e.g. to make sure that all groups that are referenced are also defined etc.).

With the help of this I was able to expose and fix 3 cddl syntax errors we had in the spec already.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christian-bromann/webdriver-bidi/pull/69.html" title="Last updated on Nov 13, 2020, 2:17 PM UTC (fa45d61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/69/502ddf9...christian-bromann:fa45d61.html" title="Last updated on Nov 13, 2020, 2:17 PM UTC (fa45d61)">Diff</a>