### PR TITLE
Comment out unused "object for an object id" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -751,6 +751,7 @@ To get the <dfn>object id for an object</dfn> given an |object|:
   1. Return the result of getting the value for |object| in [=object id map=].
 </div>
 
+<!--
 <div algorithm>
 To get the <dfn>object for an object id</dfn> given an |object id|:
 
@@ -763,6 +764,7 @@ To get the <dfn>object for an object id</dfn> given an |object id|:
 
   Issue: This error code isn't right.
 </div>
+-->
 
 [=remote end definition=] and [=local end definition=]
 ```


### PR DESCRIPTION
We'll need it later, but now it is unused and causing a Bikeshed
link warning.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/74.html" title="Last updated on Dec 3, 2020, 10:37 AM UTC (be6a82f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/74/b1bfe6a...be6a82f.html" title="Last updated on Dec 3, 2020, 10:37 AM UTC (be6a82f)">Diff</a>