### PR TITLE
Remove the table of commands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -251,30 +251,6 @@ The <dfn export for=command>set of all command names</dfn> is a set containing
 all the defined [=command names=], including any belonging to [=extension
 modules=].
 
-### Table of Commands ### {#table-of-commands}
-
-<div class=non-normative>
-
-<em>This section is non-normative.</em>
-
-The following table of commands lists the available [=command|commands=] by
-module and name.
-
-<table class="simple">
-   <tr>
-      <th>Module Name</th>
-      <th>Command Name</th>
-      <th>Command</th>
-   </tr>
-   <tr>
-      <td>session</td>
-      <td>status</td>
-      <td>[=commands/status|session.status=]</td>
-   </tr>
-</table>
-
-</div>
-
 ## Events ## {#events}
 
 An <dfn export>event</dfn> is a notification, sent by the [=remote


### PR DESCRIPTION
This doesn't add enough value to be worth the maintainance cost. If we really want
to keep it we ought to figure out how to autogenerate it as part of the build
process


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/75.html" title="Last updated on Dec 3, 2020, 10:58 AM UTC (46c8a73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/75/b1bfe6a...46c8a73.html" title="Last updated on Dec 3, 2020, 10:58 AM UTC (46c8a73)">Diff</a>