### PR TITLE
Fix nesting of final "handle an incoming message" steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -545,15 +545,15 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
       1. [=Send a WebSocket message=] comprised of |serialized| over
          |connection| and return.
 
-  1. Otherwise there is no match.
+ 1. Otherwise there is no match.
 
-     Let |error code| be [=invalid argument=].
+    Let |error code| be [=invalid argument=].
 
-  1. If |data| is a map and |data|["<code>method</code>"] exists and is a
-     string, but |data|["<code>method</code>"] is not in the [=set of all
-     command names=], let |error code| be [=unknown command=].
+ 1. If |data| is a map and |data|["<code>method</code>"] exists and is a
+    string, but |data|["<code>method</code>"] is not in the [=set of all
+    command names=], let |error code| be [=unknown command=].
 
-  1. [=Respond with an error=] given |connection|, |data|, and |error code|.
+ 1. [=Respond with an error=] given |connection|, |data|, and |error code|.
 
 </div>
 


### PR DESCRIPTION
These were indented one space too much and ended up under the "If this
results in a match" branch, which made no sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/76.html" title="Last updated on Dec 4, 2020, 9:14 AM UTC (75220ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/76/e533bf1...75220ba.html" title="Last updated on Dec 4, 2020, 9:14 AM UTC (75220ba)">Diff</a>