### PR TITLE
Respond with an error for binary messages

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -495,10 +495,9 @@ typically be "<code>localhost</code>".
 To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 |connection|, type |type| and data |data|:
 
- 1. If |type| is not [=%x1 denotes a text frame|text=], return.
-
-    Issue: Should we instead close |connection| with [=status
-    codes|status code=] 1003, or [=respond with an error=]?
+ 1. If |type| is not [=%x1 denotes a text frame|text=], [=respond with an
+    error=] given |connection|, null, and [=invalid argument=], and finally
+    return.
 
  1. [=Assert=]: |data| is a [=scalar value string=], because the
      WebSocket [=handling errors in UTF-8-encoded data=] would already
@@ -508,26 +507,32 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     Issue: Nothing seems to define what [=status codes|status code=]
     is used for UTF-8 errors.
 
- 1. Match |data| against the [=remote end definition=]. If this results in a
+1. Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
+   into Infra values=] given |data|. If this throws an exception, then [=respond
+   with an error=] given |connection|, null, and [=invalid argument=], and
+   finally return.
+
+ 1. Match |parsed| against the [=remote end definition=]. If this results in a
     match:
 
-    1. Let |parsed| be the map representing the matched data.
+    1. Let |matched| be the map representing the matched data.
 
-    1. Assert: |parsed| contains "<code>id</code>", "method", and
-       "<code>params</code>"
+    1. Assert: |matched| contains "<code>id</code>", "<code>method</code>", and
+       "<code>params</code>" and no other keys.
 
-    1. Let |command id| be |parsed|["<code>id</code>"].
+    1. Let |command id| be |matched|["<code>id</code>"].
 
-    1. Let |method| be |parsed|["<code>method</code>"]
+    1. Let |method| be |matched|["<code>method</code>"]
 
     1. Run the following steps in parallel:
 
       1. Let |result| be the result of running the [=remote end steps=] for the
          command with [=command name=] |method| given [=command parameters=]
-         |parsed|["<code>params</code>"]
+         |matched|["<code>params</code>"]
 
       1. If |result| is an [=error=], then [=respond with an error=] given
-         |connection|, |data|, and |result|'s [=error code=], and finally return.
+         |connection|, |command id|, and |result|'s [=error code=], and finally
+         return.
 
       1. Let |value| be |result|'s data.
 
@@ -545,43 +550,42 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
       1. [=Send a WebSocket message=] comprised of |serialized| over
          |connection| and return.
 
- 1. Otherwise there is no match.
+ 1. Otherwise:
 
-    Let |error code| be [=invalid argument=].
+    1. Let |command id| be null.
 
- 1. If |data| is a map and |data|["<code>method</code>"] exists and is a
-    string, but |data|["<code>method</code>"] is not in the [=set of all
-    command names=], let |error code| be [=unknown command=].
+    1. If |parsed| is a map and |parsed|["<code>id</code>"] exists and is an
+       integer greater than or equal to zero, set |command id| to that integer.
 
- 1. [=Respond with an error=] given |connection|, |data|, and |error code|.
+    1. Let |error code| be [=invalid argument=].
+
+    1. If |parsed| is a map and |parsed|["<code>method</code>"] exists and is a
+       string, but |parsed|["<code>method</code>"] is not in the [=set of all
+       command names=], set |error code| to [=unknown command=].
+
+    1. [=Respond with an error=] given |connection|, |command id|, and
+       |error code|.
 
 </div>
 
 <div algorithm>
 To <dfn>respond with an error</dfn> given a [=WebSocket connection=]
-|connection|, |data| and |error code|:
-
- 1. Let |command id| be null.
-
- 1.  Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
-     into Infra values=] given |data|. If this does not throw an exception, and
-     results in a map that contains "<code>id</code>", then let |command id| be
-     |parsed|["<code>id</code>"].
-
- 1. If |command id| is not an integer greater than or equal to zero, let
-    |command id| be null.
+|connection|, |command id|, and |error code|:
 
  1. Let |error data| be a new map matching the <code>ErrorResponse</code>
     production in the [=local end definition=], with the <code>id</code> field
     set to |command id|, the <code>error</code> field set to |error code|, the
     <code>message</code> field set to an implementation-defined string
-    containing a human-readable definition of the error that occured and the
+    containing a human-readable definition of the error that occurred and the
     <code>stacktrace</code> field optionally set to an implementation-defined
     string containing a stack trace report of the active stack frames at the
     time when the error occurred.
 
  1. Let |response| be the result of [=serialize an infra value to JSON bytes=]
     given |error data|.
+
+    Note: |command id| can be null, in which case the <code>id</code> field will
+    also be set to null, not omitted from |response|.
 
  1. [=Send a WebSocket message=] comprised of |response| over |connection|.
 

--- a/index.bs
+++ b/index.bs
@@ -518,7 +518,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     1. Let |matched| be the map representing the matched data.
 
     1. Assert: |matched| contains "<code>id</code>", "<code>method</code>", and
-       "<code>params</code>" and no other keys.
+       "<code>params</code>".
 
     1. Let |command id| be |matched|["<code>id</code>"].
 


### PR DESCRIPTION
Silently doing nothing is not very easy to debug, and more importantly
if in the future do support some binary messages, we should respond with
an error for any we do not recognize, just as we do for text messages.

Doing this required refactoring since "respond with an error" previous
assumed a text |data| argument, but we should not attempt to parse a
binary message as JSON.

Lift out the JSON parsing to before try to match against the CDDL, to
avoid parsing twice. Previously parsing was implicit in the "match"
verb, but we can just as well "match" against a parsed representation,
it is no more or less defined what that means.

One typo was fixed: occured

The only intended observable change is for non-text messages.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/77.html" title="Last updated on Dec 10, 2020, 11:57 PM UTC (1f316b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/77/fe54519...1f316b2.html" title="Last updated on Dec 10, 2020, 11:57 PM UTC (1f316b2)">Diff</a>