### PR TITLE
Remote end behavior for duplicate command id

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -254,6 +254,12 @@ Note: This is because the command id is entirely controlled by the [=local end=]
 and isn't necessarily unique over the course of a session. For example a [=local
 end=] which ignores all responses could use the same command id for each command.
 
+Issue: Do we want to say the behavior is undefined if remote end receives different
+commands with the same command id? In that case, the local end cannot distinguish
+which response is for which command since they can be out of order. Also, do we want
+to say remote end should be idempotent (i.e. no effect if same command with same id
+is received again)?
+
 The <dfn export for=command>set of all command names</dfn> is a set containing
 all the defined [=command names=], including any belonging to [=extension
 modules=].


### PR DESCRIPTION
This adds an issue to handling of commands with duplicate id
for same or different commands.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k7z45/webdriver-bidi/pull/80.html" title="Last updated on Dec 16, 2020, 6:55 PM UTC (d175a3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/80/16f1bec...k7z45:d175a3f.html" title="Last updated on Dec 16, 2020, 6:55 PM UTC (d175a3f)">Diff</a>