### PR TITLE
Fix the heading ID markup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 spec:infra; type:dfn; for:/; text:set
 </pre>
 
-# Introduction {#intro}
+# Introduction # {#intro}
 
 <em>This section is non-normative.</em>
 
@@ -112,7 +112,7 @@ command/response format of WebDriver, this permits events to stream
 from the user agent to the controlling software, better matching the
 evented nature of the browser DOM.
 
-# Infrastructure {#infrastructure}
+# Infrastructure # {#infrastructure}
 
 This specification depends on the Infra Standard. [[!INFRA]]
 


### PR DESCRIPTION
The lack of a # caused {#intro} and {#infrastructure} in the built
spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/83.html" title="Last updated on Jan 20, 2021, 11:27 AM UTC (92db9ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/83/ba481c9...92db9ea.html" title="Last updated on Jan 20, 2021, 11:27 AM UTC (92db9ea)">Diff</a>