### PR TITLE
Align `browsingContext.contextDestroyed` with event definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1693,7 +1693,7 @@ When the [=create a new browsing context=] algorithm is invoked, after the
       <pre class="cddl local-cddl">
         BrowsingContextDestroyedEvent = {
          method: "browsingContext.contextDestroyed",
-         result: BrowsingContextInfo
+         params: BrowsingContextInfo
        }
       </pre>
    </dd>


### PR DESCRIPTION
Events should have [`params` field](https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/73.html#events), while [`BrowsingContextDestroyedEvent`](https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/73.html#event-browsingContext-contextDestroyed) has `result` instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver-bidi/pull/84.html" title="Last updated on Jan 25, 2021, 1:00 PM UTC (c699571)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/84/c4501a3...sadym-chromium:c699571.html" title="Last updated on Jan 25, 2021, 1:00 PM UTC (c699571)">Diff</a>