### PR TITLE
Use “WebDriver Bidirectional protocol”, not “BiDi”

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class=metadata>
-Title: WebDriver BiDi
+Title: WebDriver Bidirectional Protocol
 Shortname: webdriver-bidi
 Level: 1
 Status: ED
@@ -7,7 +7,7 @@ Group: browser-testing-tools
 URL: https://w3c.github.io/webdriver-bidi/
 Repository: w3c/webdriver-bidi
 No Editor: true
-Abstract: This document defines the BiDirectional WebDriver Protocol, a mechanism for remote control of user agents.
+Abstract: This document defines the WebDriver Bidirectional Protocol, a mechanism for remote control of user agents.
 Boilerplate: conformance no
 Complain About: accidental-2119 yes, missing-example-ids yes
 Default Ref Status: current
@@ -132,7 +132,7 @@ Network protocol messages are defined using CDDL. [[!RFC8610]]
 
 # Protocol # {#protocol}
 
-This section defines the basic concepts of the WebDriver BiDi
+This section defines the basic concepts of the WebDriver Bidirectional
 protocol. These terms are distinct from their representation at the
 <a href=#transport>transport</a> layer.
 
@@ -213,11 +213,11 @@ EventData = (
 
 ## Session ## {#session}
 
-WebDriver BiDi uses the same [=/session=] concept as WebDriver.
+The WebDriver Bidirectional protocol uses the same [=/session=] concept as WebDriver.
 
 ## Modules ## {#protocol-modules}
 
-The WebDriver BiDi protocol is organized into modules.
+The WebDriver Bidirectional protocol is organized into modules.
 
 Each <dfn export>module</dfn> represents a collection of related
 [=commands=] and [=events=] pertaining to a certain aspect of the user


### PR DESCRIPTION
In W3C fora, the term *bidi* is used often in discussions about Internationalization, where it is widely understood to refer to bidirectional text — with associated specifications such as the Unicode Bidirectional Algorithm spec https://unicode.org/reports/tr9/

So a number of people who reviewed the Browser Testing and Tools WG charter were thrown off by the use of the term *BiDi* in the title of the WebDriver Bidirectional protocol spec. Based on the title, they expected the spec to have something to do with bidirectional text — which it doesn’t of course.

Thus to preempt ongoing confusion from future readers (especially those involved in the W3C and in Unicode work), it seems prudent *throughout the specification itself* to just consistently write out the full name of the protocol, WebDriver Bidirectional protocol, and avoid the “BiDi” shorthand.

But making that change doesn’t preclude continuing to use the “WebDriver BiDi” shorthand term in documents other than the spec itself, and in mailing-list discussions, etc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/92.html" title="Last updated on Mar 4, 2021, 7:21 AM UTC (c8f7b63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/92/9f81644...c8f7b63.html" title="Last updated on Mar 4, 2021, 7:21 AM UTC (c8f7b63)">Diff</a>