### PR TITLE
Define commands and events related to navigation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -131,37 +131,38 @@ This specification depends on the Infra Standard. [[!INFRA]]
 
 Network protocol messages are defined using CDDL. [[!RFC8610]]
 
-This specification defines a <dfn>wait queue</dfn> which is a list.
+This specification defines a <dfn>wait queue</dfn> which is a map.
 
 Issue: Surely there's a better mechanism for doing this "wait for an event" thing.
 
 <div algorithm>
 
 When an algorithm |algorithm| running [=in parallel=] <dfn>awaits</dfn> a set of
-events |events|, each consisting of a tuple (<code>name</code>, <code>resume
-id</code>):
+events |events|, and |resume id|:
 
 1. Pause the execution of |algorithm|.
 
-1. Append (|events|, |algorithm|) to [=wait queue=].
+1. Assert: [=wait queue=] does not contain |resume id|.
+
+1. Set [=wait queue=][|resume id|] to (|events|, |algorithm|).
 
 </div>
 
 <div algorithm>
 To <dfn>resume</dfn> given |name|, |id| and |parameters|:
 
-1. For each |paused| in |wait queue|:
+1. If [=wait queue=] does not contain |id|, return.
 
-  1. Let |events| and |algorithm| be the two items in |paused|
+1. Let |events|, |algorithm| be [=wait queue=][|id|]
 
-  1. For each |event| in |events|:
+1. For each |event| in |events|:
 
-    1. If the two items in |event| are equal to |name| and |id|:
+  1. If |event| equals |name|:
 
-      1. Remove |paused| from |wait queue|.
+    1. Remove |id| from [=wait queue=].
 
-      1. Resume running the steps in |algorithm| from the point at which they were
-         paused, passing |name| and |parameters| as the result of the [=await=].
+    1. Resume running the steps in |algorithm| from the point at which they were
+       paused, passing |name| and |parameters| as the result of the [=await=].
 
 </div>
 
@@ -1861,9 +1862,9 @@ The [=remote end steps=] with |command parameters| are:
   1. If |wait condition| is interactive, let |event name| be
      "<code>DOMContentLoaded</code>", otherwise let |event name| be "<code>load</code>".
 
-  1. Let (|event received|, |status|) be [=await=] [(|event name|, |navigation
-     id|), ("<code>download started</code>", |navigation id|),
-     ("<code>navigation failed</code>", |navigation id|)].
+  1. Let (|event received|, |status|) be [=await=] given «|event name|,
+      "<code>download started</code>", "<code>navigation failed</code>"» and
+     |navigation id|.
 
   1. If |event received| is "<code>navigate failed</code>"
      return [=error=] with [=error code=] [=unknown error=].

--- a/index.bs
+++ b/index.bs
@@ -1548,6 +1548,9 @@ The [=remote end steps=] with |command parameters| are:
 The <dfn export for=modules>browsingContext</dfn> module contains commands and
 events relating to browsing contexts.
 
+A [=/session=] has an <dfn>set of contexts with an ongoing navigate</dfn>. This
+is a set that is initially empty.
+
 ### Definition ### {#module-browsingContext-definition}
 
 [=remote end definition=]
@@ -1850,8 +1853,12 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let |request| be a new [=/request=] whose URL is |url record|.
 
+  1. Append |context id| to the [=set of contexts with an ongoing navigate=].
+
   1. Let |navigate status| be the result of [=navigate|navigating=] |context| with resource
      |request|, and using |context| as the [=source browsing context=].
+
+  1. Remove |context id| from the [=set of contexts with an ongoing navigate=].
 
   1. Let |navigation id| be |navigate status|'s id
 
@@ -1863,9 +1870,15 @@ The [=remote end steps=] with |command parameters| are:
        <code>navigation</code> field set to null, and the <code>url</code> field
        set to the result of the [=URL serializer=] given |navigate status|'s url.
 
-    1. Return [=success=] with data |body|
+    1. Return [=success=] with data |body|, and then run the following steps [=in
+       parallel=]:
 
-     Note: this is the case if the navigation only caused the fragment to change.
+       1. Run the [=WebDriver-BiDi fragment navigated=] steps given |context|
+          and |navigate status|
+
+     Note: this is the case if the navigation only caused the fragment to
+     change. The parallel steps here ensure that we return the command result
+     before emitting the event, so the navigation id is known.
 
   1. If |navigate status|'s status is "<code>cancelled</code>" return [=error=]
      with [=error code=] [=unknown error=].
@@ -2052,6 +2065,9 @@ Define the following [=fragment navigated steps=] with |context| and |navigation
  1. If the [=current session=] is null, return.
 
  1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. If |context id| is in the [=set of contexts with an ongoing navigate=],
+    then return.
 
  1. Let |url| be |navigation status|'s url.
 

--- a/index.bs
+++ b/index.bs
@@ -1584,6 +1584,7 @@ BrowsingContextEvent = (
     BrowsingContextDomContentLoadedEvent //
     BrowsingContextLoadEvent //
     BrowsingContextDownloadWillBegin //
+    BrowsingContextNavigationAbortedEvent //
     BrowsingContextNavigationFailedEvent
 )
 
@@ -1920,7 +1921,8 @@ The [=remote end steps=] with |command parameters| are:
      "<code>load</code>".
 
   1. Let (|event received|, |status|) be [=await=] given «|event name|,
-      "<code>download started</code>", "<code>navigation failed</code>"» and
+      "<code>download started</code>", "<code>navigation aborted</code>",
+      "<code>navigation failed</code>"» and
      |navigation id|.
 
   1. If |event received| is "<code>navigation failed</code>"
@@ -2205,6 +2207,44 @@ started</dfn> steps given |context| and |navigation status|:
  1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
 
 </div>
+
+#### The browsingContext.navigationAborted Event #### {#event-browsingContext-navigationAborted}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextNavigationAborted = {
+         method: "browsingContext.navigationAborted",
+         params: NavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+aborted</dfn> steps given |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextNavigationAborted</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. [=Resume=] with "<code>navigation aborted</code>", |navigation id|, and |navigation status|.
+
+</div>
+
 
 #### The browsingContext.navigationFailed Event #### {#event-browsingContext-navigationFailed}
 

--- a/index.bs
+++ b/index.bs
@@ -1859,7 +1859,7 @@ The [=remote end steps=] with |command parameters| are:
      null:
 
     1. Let |body| be a [=map=] matching the
-       <code>BrowsingContextNavigatenResult</code> production, with the
+       <code>BrowsingContextNavigateResult</code> production, with the
        <code>navigation</code> field set to null, and the <code>url</code> field
        set to the result of the [=URL serializer=] given |navigate status|'s url.
 
@@ -2088,7 +2088,7 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for browsingContext.domContentLoaded">
 
-Define the following [=dom load complete steps=] with |context| and |navigation status|:
+Define the following [=dom content loaded steps=] with |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 

--- a/index.bs
+++ b/index.bs
@@ -2016,11 +2016,10 @@ become inaccessible but not yet get discarded because bfcache.
       </pre>
    </dd>
 </dl>
-The [=remote end event trigger=] is:
 
-<div algorithm="remote end event trigger for browsingContext.navigationStarted">
-
-Define the following [=navigation started steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
@@ -2056,11 +2055,9 @@ Define the following [=navigation started steps=] with |context| and |navigation
    </dd>
 </dl>
 
-The [=remote end event trigger=] is:
-
-<div algorithm="remote end event trigger for browsingContext.fragmentNavigated">
-
-Define the following [=fragment navigated steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi fragment
+navigated</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
@@ -2100,11 +2097,9 @@ Define the following [=fragment navigated steps=] with |context| and |navigation
    </dd>
 </dl>
 
-The [=remote end event trigger=] is:
-
-<div algorithm="remote end event trigger for browsingContext.domContentLoaded">
-
-Define the following [=dom content loaded steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi DOM content
+loaded</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
@@ -2137,12 +2132,10 @@ Define the following [=dom content loaded steps=] with |context| and |navigation
       </pre>
    </dd>
 </dl>
-The [=remote end event trigger=] is:
 
-
-<div algorithm="remote end event trigger for browsingContext.load">
-
-Define the following [=load complete steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi load
+complete</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
@@ -2176,12 +2169,10 @@ Define the following [=load complete steps=] with |context| and |navigation stat
       </pre>
    </dd>
 </dl>
-The [=remote end event trigger=] is:
 
-
-<div algorithm="remote end event trigger for browsingContext.downloadWillBegin">
-
-Define the following [=download started steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi download
+started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
@@ -2215,12 +2206,10 @@ Define the following [=download started steps=] with |context| and |navigation s
       </pre>
    </dd>
 </dl>
-The [=remote end event trigger=] is:
 
-
-<div algorithm="remote end event trigger for browsingContext.navigationFailed">
-
-Define the following [=navigation failed steps=] with |context| and |navigation status|:
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+failed</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 

--- a/index.bs
+++ b/index.bs
@@ -101,6 +101,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
     text: create a new browsing context; url: creating-a-new-browsing-context
     text: environment settings object's Realm; url: environment-settings-object's-realm
     text: handled; url: concept-error-handled
+    text: navigation id; url: concept-navigation-id
     text: report an error; url: report-the-error
     text: remove a browsing context; url: bcg-remove
     text: session history; url: session-history
@@ -161,7 +162,7 @@ To <dfn>resume</dfn> given |name|, |id| and |parameters|:
 
     1. Remove |id| from [=wait queue=].
 
-    1. [=Queue a WebDriver task=] to resume running the steps in |algorithm| from the
+    1. Resume running the steps in |algorithm| from the
        point at which they were paused, passing |name| and |parameters| as the
        result of the [=await=].
 
@@ -1552,8 +1553,24 @@ The [=remote end steps=] with |command parameters| are:
 The <dfn export for=modules>browsingContext</dfn> module contains commands and
 events relating to browsing contexts.
 
-A [=/session=] has an <dfn>set of contexts with an ongoing navigate</dfn>. This
-is a set that is initially empty.
+The progress of navigation is communicated using an immutable <dfn export>WebDriver
+navigation status</dfn> struct, which has the following items:
+
+<dl>
+  <dt><dfn export id="navigation-status-id">id</dfn></dt>
+  <dd>The [=navigation id=] for the navigation, or null when the navigation is
+  canceled before making progress.</dd>
+
+  <dt><dfn export id="navigation-status-status">status</dfn></dt>
+    <dd>A status code that is either
+      "<dfn export id="navigation-status-canceled"><code>canceled</code></dfn>",
+      "<dfn export id="navigation-status-pending"><code>pending</code></dfn>", or
+      "<dfn export id="navigation-status-complete"><code>complete</code></dfn>".
+    </dd>
+
+  <dt><dfn export id="navigation-status-url">url</dfn></dt>
+  <dd>The URL which is being loaded in the navigation</dd>
+</dl>
 
 ### Definition ### {#module-browsingContext-definition}
 
@@ -1858,14 +1875,17 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let |request| be a new [=/request=] whose URL is |url record|.
 
-  1. Append |context id| to the [=set of contexts with an ongoing navigate=].
+  1. Let |navigation id| be the string representation of a
+     [[!RFC4122|UUID]] based on truly random, or pseudo-random numbers.
 
-  1. Let |navigate status| be the result of [=navigate|navigating=] |context| with resource
-     |request|, and using |context| as the [=source browsing context=].
+  1. [=Navigate=] |context| with resource |request|, and using |context| as the
+     [=source browsing context=], and with navigation id |navigation id|.
 
-  1. Remove |context id| from the [=set of contexts with an ongoing navigate=].
+  1.  Let (|event received|, |navigate status|) be [=await=] given
+      «"<code>navigation started</code>", "<code>navigation failed</code>",
+      and "<code>fragment navigated</code>"» and |navigation id|.
 
-  1. Let |navigation id| be |navigate status|'s id
+  1. Assert: |navigate status|'s id is |navigation id|.
 
   1. If |navigate status|'s status is "<code>complete</code>":
 
@@ -1922,8 +1942,7 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let (|event received|, |status|) be [=await=] given «|event name|,
       "<code>download started</code>", "<code>navigation aborted</code>",
-      "<code>navigation failed</code>"» and
-     |navigation id|.
+      "<code>navigation failed</code>"» and |navigation id|.
 
   1. If |event received| is "<code>navigation failed</code>"
      return [=error=] with [=error code=] [=unknown error=].
@@ -2042,11 +2061,6 @@ started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. If |context id| is in the [=set of contexts with an ongoing navigate=],
-    then return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2054,7 +2068,12 @@ started</dfn> steps given |context| and |navigation status|:
     <code>BrowsingContextNavigationStarted</code> production, with the
     <code>params</code> field set to |params|.
 
+ 1. Let |navigation id| be |navigation status|'s id.
+
  1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Resume=] with "<code>navigation started</code>", |navigation id|, and
+    |navigation status|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
 
@@ -2080,11 +2099,6 @@ navigated</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. If |context id| is in the [=set of contexts with an ongoing navigate=],
-    then return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2092,7 +2106,12 @@ navigated</dfn> steps given |context| and |navigation status|:
      <code>BrowsingContextFragmentNavigatedEvent</code> production, with the
      <code>params</code> field set to |params|.
 
+ 1. Let |navigation id| be |navigation status|'s id.
+
  1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Resume=] with "<code>fragment navigated</code>", |navigation id|, and
+    |navigation status|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
 
@@ -2127,12 +2146,14 @@ loaded</dfn> steps given |context| and |navigation status|:
 
  1. Let |related browsing contexts| be a set containing |context|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
-
  1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>domContentLoaded</code>", |navigation id|, and
-    |navigation status|.  </div>
+    |navigation status|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+</div>
 
 #### The browsingContext.load Event #### {#event-browsingContext-load}
 
@@ -2162,12 +2183,12 @@ complete</dfn> steps given |context| and |navigation status|:
 
  1. Let |related browsing contexts| be a set containing |context|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
-
  1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>load</code>", |navigation id| and
     |navigation status|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
 
 </div>
 
@@ -2198,13 +2219,13 @@ started</dfn> steps given |context| and |navigation status|:
      <code>BrowsingContextDownloadWillBegin</code> production, with the
      <code>params</code> field set to |params|.
 
- 1. Let |related browsing contexts| be a set containing |context|.
-
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
-
  1. Let |navigation id| be |navigation status|'s id.
 
+ 1. Let |related browsing contexts| be a set containing |context|.
+
  1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
 
 </div>
 
@@ -2235,13 +2256,13 @@ aborted</dfn> steps given |context| and |navigation status|:
      <code>BrowsingContextNavigationAborted</code> production, with the
      <code>params</code> field set to |params|.
 
- 1. Let |related browsing contexts| be a set containing |context|.
-
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
-
  1. Let |navigation id| be |navigation status|'s id.
 
+ 1. Let |related browsing contexts| be a set containing |context|.
+
  1. [=Resume=] with "<code>navigation aborted</code>", |navigation id|, and |navigation status|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
 
 </div>
 
@@ -2273,13 +2294,13 @@ failed</dfn> steps given |context| and |navigation status|:
      <code>BrowsingContextNavigationFailed</code> production, with the
      <code>params</code> field set to |params|.
 
- 1. Let |related browsing contexts| be a set containing |context|.
-
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
-
  1. Let |navigation id| be |navigation status|'s id.
 
+ 1. Let |related browsing contexts| be a set containing |context|.
+
  1. [=Resume=] with "<code>navigation failed</code>", |navigation id|, and |navigation status|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1632,7 +1632,8 @@ BrowsingContextInfo = {
 The <code>BrowsingContextInfo</code> type represents the properties of a
 browsing context.
 
-<div algorithm> To <dfn>get the browsing context info</dfn> given |context|,
+<div algorithm>
+To <dfn>get the browsing context info</dfn> given |context|,
 |depth| and |max depth|:
 
  1. Let |context id| be the [=browsing context id=] for |context|.
@@ -1714,6 +1715,23 @@ NavigationInfo = {
 </pre>
 
 The <code>NavigationInfo</code> type provides details of an ongoing navigation.
+
+<div algorithm>
+To <dfn>get the navigation info</dfn>, given |context| and |navigation status|:
+
+1. Let |context id| be the [=browsing context id=] for |context|.
+
+1. Let |navigation id| be |navigation status|'s id.
+
+1. Let |url| be |navigation status|'s url.
+
+1. Return a [=map=] matching the
+   <code>NavigationInfo</code> production, with the
+   <code>context</code> field set to |context id|, the <code>navigation</code>
+   field set to |navigation id|, and the <code>url</code> field set to the
+   result of the [=URL serializer=] given |url|.
+
+</div>
 
 ### Commands ### {#module-browsingContext-commands}
 
@@ -1993,21 +2011,12 @@ Define the following [=navigation started steps=] with |context| and |navigation
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. Let |navigation id| be |navigation status|'s navigation id.
-
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>NavigationInfo</code> production, with the
-    <code>context</code> field set to |context id|, the <code>navigation</code>
-    field set to |navigation id| and the <code>url</code> field set to the
-    result of the [=URL serializer=] given |url|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
  1. Let |body| be a [=map=] matching the
-     <code>BrowsingContextNavigationStarted</code> production, with the
-     <code>params</code> field set to |params|.
+    <code>BrowsingContextNavigationStarted</code> production, with the
+    <code>params</code> field set to |params|.
 
  1. Let |related browsing contexts| be a set containing |context|.
 
@@ -2083,25 +2092,18 @@ Define the following [=dom load complete steps=] with |context| and |navigation 
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. Let |navigation id| be |navigation status|'s id.
-
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>NavigationInfo</code> production, with the
-    <code>context</code> field set to |context id|, the <code>navigation</code>
-    field set to |navigation id|, and the <code>url</code> field set to the
-    result of the [=URL serializer=] given |url|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
  1. Let |body| be a [=map=] matching the
-     <code>BrowsingContextDomContentLoadedEvent</code> production, with the
-     <code>params</code> field set to |params|.
+    <code>BrowsingContextDomContentLoadedEvent</code> production, with the
+    <code>params</code> field set to |params|.
 
  1. Let |related browsing contexts| be a set containing |context|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>domContentLoaded</code>", |navigation id|, and
     |navigation status|.  </div>
@@ -2128,24 +2130,17 @@ Define the following [=load complete steps=] with |context| and |navigation stat
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
- 1. Let |navigation id| be |navigation status|'s id.
-
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>NavigationInfo</code> production, with the
-    <code>context</code> field set to |context id|, the <code>navigation</code>
-    field set to |navigation id|, and the <code>url</code> field set to the
-    result of the [=URL serializer=] given |url|.
-
-1. Let |body| be a [=map=] matching the <code>BrowsingContextLoadEvent</code>
-     production, with the <code>params</code> field set to |params|.
+ 1. Let |body| be a [=map=] matching the <code>BrowsingContextLoadEvent</code>
+    production, with the <code>params</code> field set to |params|.
 
  1. Let |related browsing contexts| be a set containing |context|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>load</code>", |navigation id| and
     |navigation status|.
@@ -2174,17 +2169,8 @@ Define the following [=download started steps=] with |context| and |navigation s
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. Let |navigation id| be |navigation status|'s id.
-
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>NavigationInfo</code> production, with the
-    <code>context</code> field set to |context id|, the <code>navigation</code>
-    field set to |navigation id|, and the <code>url</code> field set to the
-    result of the [=URL serializer=] given |url|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
  1. Let |body| be a [=map=] matching the
      <code>BrowsingContextDownloadWillBegin</code> production, with the
@@ -2193,6 +2179,8 @@ Define the following [=download started steps=] with |context| and |navigation s
  1. Let |related browsing contexts| be a set containing |context|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
 
@@ -2220,17 +2208,8 @@ Define the following [=navigation failed steps=] with |context| and |navigation 
 
  1. If the [=current session=] is null, return.
 
- 1. Let |context id| be the [=browsing context id=] for |context|.
-
- 1. Let |navigation id| be |navigation status|'s id.
-
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>NavigationInfo</code> production, with the
-    <code>context</code> field set to |context id|, the <code>navigation</code>
-    field set to |navigation id|, and the <code>url</code> field set to the
-    result of the [=URL serializer=] given |url|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
  1. Let |body| be a [=map=] matching the
      <code>BrowsingContextNavigationFailed</code> production, with the
@@ -2239,6 +2218,8 @@ Define the following [=navigation failed steps=] with |context| and |navigation 
  1. Let |related browsing contexts| be a set containing |context|.
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
 
  1. [=Resume=] with "<code>navigation failed</code>", |navigation id|, and |navigation status|.
 

--- a/index.bs
+++ b/index.bs
@@ -1818,9 +1818,17 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |url| be the value of the <code>url</code> field of |command
      parameters|.
 
-  1. TODO: validate |url|. Should we allow relative URLs or only absolute URLs?
+  1. Let |document| be |context|'s [=active document=].
 
-  1. Let |request| be a new [=/request=] whose URL is |url|.
+  1. Let |base| be |document|'s [=base URL=].
+
+  1. Let |url record| be the result of applying the [=URL parser=] to |url|,
+     with [=base URL=] |base|.
+
+  1. If |url record| is failure, return [=error=] with [=error code=] [=invalid
+     argument=].
+
+  1. Let |request| be a new [=/request=] whose URL is |url record|.
 
   1. Let |navigate status| be the result of [=navigate|navigating=] |context| with resource
      |request|, and using |context| as the [=source browsing context=].

--- a/index.bs
+++ b/index.bs
@@ -45,6 +45,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: unknown command; url: dfn-unknown-command
+    text: unknown error; url: dfn-unknown-error
     text: no such element; url: dfn-no-such-element
     text: no such frame; url: dfn-no-such-frame
     text: active sessions; url: dfn-active-session
@@ -1552,18 +1553,29 @@ events relating to browsing contexts.
 
 <pre class="cddl remote-cddl">
 
-BrowsingContextCommand = (BrowsingContextGetTreeCommand)
+BrowsingContextCommand = (
+    BrowsingContextGetTreeCommand //
+    BrowsingContextNavigateCommand
+)
 </pre>
 
 [=local end definition=]
 
 <pre class="cddl local-cddl">
 
-BrowsingContextResult = (BrowsingContextGetTreeResult)
+BrowsingContextResult = (
+    BrowsingContextGetTreeResult //
+    BrowsingContextNavigateResult
+)
 
 BrowsingContextEvent = (
     BrowsingContextCreatedEvent //
-    BrowsingContextDestroyedEvent
+    BrowsingContextDestroyedEvent //
+    BrowsingContextNavigationStartedEvent //
+    BrowsingContextFragmentNavigatedEvent //
+    BrowsingContextDomContentLoadedEvent //
+    BrowsingContextLoadEvent //
+    BrowsingContextNavigationFailedEvent
 )
 
 </pre>
@@ -1673,9 +1685,36 @@ browsing context.
 
 </div>
 
+#### The browsingContext.Navigation Type #### {#type-browsingContext-Navigation}
+
+[=remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+Navigation = text;
+</pre>
+
+The <code>Navigation</code> type is a unique string identifying an ongoing
+navigation.
+
+TODO: Link to the definition in the HTML spec.
+
 ### Commands ### {#module-browsingContext-commands}
 
-#### The browsingContext.getTree Command ####  {#command-browsingContext-list}
+#### The browsingContext.NavigationInfo Type #### {#type-browsingContext-NavigationInfo}
+
+[=local end definition=]:
+
+<pre class="cddl local-cddl">
+BrowsingContextNavigationInfo = {
+  context: BrowsingContext,
+  navigation: Navigation / null,
+  url: text,
+}
+</pre>
+
+The <code>NavigationInfo</code> type provides details of an ongoing navigation.
+
+#### The browsingContext.getTree Command ####  {#command-browsingContext-getTree}
 
 The <dfn export for=commands>browsingContext.getTree</dfn> command returns a
 tree of all browsing contexts that are descendents of the given context, or all
@@ -1722,6 +1761,114 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let |body| be a [=map=] matching the <code>BrowsingContextGetTreeResult</code>
      production, with the <code>contexts</code> field set to |contexts|.
+
+  1. Return [=success=] with data |body|.
+
+</div>
+
+#### The browsingContext.navigate Command ####  {#command-browsingContext-navigate}
+
+The <dfn export for=commands>browsingContext.navigates</dfn> command navigates a
+browsing context to the given URL.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      BrowsingContextGetTreeCommand = {
+        method: "browsingContext.navigate",
+        params: BrowsingContextNavigateParameters
+      }
+
+      BrowsingContextNavigateParameters = {
+        context: BrowsingContext,
+        url: text,
+        ?wait: ReadinessState,
+      }
+
+       ReadinessState = "none" / "interactive" / "complete"
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+        BrowsingContextNavigateResult = {
+            navigation: Navigation / null,
+            url: text,
+        }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.navigate">
+The [=remote end steps=] with |command parameters| are:
+
+  1. Let |context id| be the value of the <code>context</code> field of
+     |command parameters|.
+
+  1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+     with |context id|.
+
+  1. Assert: |context| is not null.
+
+  1. Let |wait condition| be the value of the <code>wait</code> field of |command
+     parameters| if present, or "<code>none</code>" otherwise.
+
+  1. Let |url| be the value of the <code>url</code> field of |command
+     parameters|.
+
+  1. TODO: validate |url|. Should we allow relative URLs or only absolute URLs?
+
+  1. Let |request| be a new [=/request=] whose URL is |url|.
+
+  1. Let |navigate status| be the result of [=navigate=] |context| with resource
+     |request|, and using |context| as the [=source browsing context=].
+
+  1. If |navigate status|'s status is complete and |navigate status|'s
+     navigation id is null:
+
+    1. Let |body| be a [=map=] matching the
+       <code>BrowsingContextNavigationResult</code> production, with the
+       <code>navigation</code> field set to null, and the <code>url</code> field
+       set to the result of the [=URL serializer=] given |navigate status|'s url.
+
+    1. Return [=success=] with data |body|
+
+     Note: this is the case if the navigation only caused the fragment to change.
+
+  1. If |navigate status|'s status is cancelled return [=error=] with [=error code=]
+     [=unknown error=].
+
+     TODO: is this the right way to handle errors here?
+
+  1. Assert: |navigate status|'s status is pending and |navigate status|'s id is
+     not null.
+
+  1. Let |navigation id| be |navigate status|'s id
+
+  1. If |wait condition| is "<code>none</code>", return [=success=] with data
+     |body|.
+
+  1. If |wait condition| is interactive, let |event name| be
+     "<code>DOMContentLoaded</code>", otherwise let |event name| be "<code>load</code>".
+
+  1. Let (|event received|, |status|) be [=await=] [(|event name|, |navigation
+     id|), ("<code>download started</code>", |navigation id|),
+     ("<code>navigation failed</code>", |navigation id|)].
+
+  1. If |event received| is "<code>navigate failed</code>"
+     return [=error=] with [=error code=] [=unknown error=].
+
+     Issue: Are we surfacting enough information about what failed and why with
+     an error here? What error code do we want? Is there going to be a problem
+     where local ends parse the implementation-defined strings to figure out
+     what actually went wrong?
+
+  1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextNavigationResult</code> production, with the
+     <code>navigation</code> field set to |status|'s id, and the
+     <code>url</code> field set to the result of the [=URL serializer=] given
+     |status|'s url.
 
   1. Return [=success=] with data |body|.
 
@@ -1781,7 +1928,7 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for browsingContext.contexDestroyed">
 
-Run the following [=browsing context tree discarded=] steps:
+Define the following [=browsing context tree discarded=] steps:
 
  1. If the [=current session=] is null, return.
 
@@ -1805,6 +1952,278 @@ Issue: It's unclear if we ought to only fire this event for browsing
 contexts that have active documents; navigation can also cause contexts to
 become inaccessible but not yet get discarded because bfcache.
 </div>
+
+#### The browsingContext.navigationStarted Event #### {#event-browsingContext-navigationStarted}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextNavigationStartedEvent = {
+         method: "browsingContext.navigationStarted",
+         params: BrowsingContextNavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+<div algorithm="remote end event trigger for browsingContext.navigationStarted">
+
+Define the following [=navigation started steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |navigation id| be |navigation status|'s navigation id.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>context</code> field set to |context id|, the <code>navigation</code>
+    field set to |navigation id| and the <code>url</code> field set to the
+    result of the [=URL serializer=] given |url|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextNavigationStarted</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+</div>
+
+#### The browsingContext.fragmentNavigated Event #### {#event-browsingContext-fragmentNavigated}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextFragmentNavigatedEvent = {
+         method: "browsingContext.fragmentNavigated",
+         params: BrowsingContextFragmentNavigatedParameters
+       }
+
+       BrowsingContextFragmentNavigatedParameters = {
+        context: BrowsingContext,
+        url: text,
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+<div algorithm="remote end event trigger for browsingContext.fragmentNavigated">
+
+Define the following [=fragment navigated steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextFragmentNavigatedParameters</code> production, with the
+    <code>context</code> field set to |context id| and the <code>url</code>
+    field set to the result of the [=URL serializer=] given |url|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextFragmentNavigatedEvent</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+</div>
+
+#### The browsingContext.domContentLoaded Event #### {#event-browsingContext-domContentLoaded}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextDomContentLoadedEvent = {
+         method: "browsingContext.domContentLoaded",
+         params: BrowsingContextNavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+
+<div algorithm="remote end event trigger for browsingContext.domContentLoaded">
+
+Define the following [=dom load complete steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>context</code> field set to |context id|, the <code>navigation</code>
+    field set to |navigation id|, and the <code>url</code> field set to the
+    result of the [=URL serializer=] given |url|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextDomContentLoadedEvent</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. [=Resume=] with "<code>DOMContentLoaded</code>", |navigation id|, and
+    |navigation status|.  </div>
+
+#### The browsingContext.load Event #### {#event-browsingContext-load}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextLoadEvent = {
+         method: "browsingContext.load",
+         params: BrowsingContextNavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+
+<div algorithm="remote end event trigger for browsingContext.load">
+
+Define the following [=load complete steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>context</code> field set to |context id|, the <code>navigation</code>
+    field set to |navigation id|, and the <code>url</code> field set to the
+    result of the [=URL serializer=] given |url|.
+
+1. Let |body| be a [=map=] matching the <code>BrowsingContextLoadEvent</code>
+     production, with the <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. [=Resume=] with "<code>load</code>", |navigation id| and
+    |navigation status|.
+
+</div>
+
+#### The browsingContext.downloadWillBegin Event #### {#event-browsingContext-downoadWillBegin}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextDownloadWillBegin = {
+         method: "browsingContext.downloadWillBegin",
+         params: BrowsingContextNavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+
+<div algorithm="remote end event trigger for browsingContext.downloadWillBegin">
+
+Define the following [=download started steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>context</code> field set to |context id|, the <code>navigation</code>
+    field set to |navigation id|, and the <code>url</code> field set to the
+    result of the [=URL serializer=] given |url|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextDownloadWillBegin</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+
+</div>
+
+#### The browsingContext.navigationFailed Event #### {#event-browsingContext-navigationFailed}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        BrowsingContextNavigationFailed = {
+         method: "browsingContext.navigationFailed",
+         params: BrowsingContextNavigationInfo
+       }
+      </pre>
+   </dd>
+</dl>
+The [=remote end event trigger=] is:
+
+
+<div algorithm="remote end event trigger for browsingContext.navigationFailed">
+
+Define the following [=navigation failed steps=] with |context| and |navigation status|:
+
+ 1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. Let |url| be |navigation status|'s url.
+
+ 1. Let |params| be a [=map=] matching the
+    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>context</code> field set to |context id|, the <code>navigation</code>
+    field set to |navigation id|, and the <code>url</code> field set to the
+    result of the [=URL serializer=] given |url|.
+
+ 1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextNavigationFailed</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |related browsing contexts| be a set containing |context|.
+
+ 1. [=Emit an event=] with |body| and |related browsing contexts|.
+
+ 1. [=Resume=] with "<code>navigation failed</code>", |navigation id|, and |navigation status|.
+
+</div>
+
 
 ## The script Module ## {#module-script}
 
@@ -2397,7 +2816,7 @@ The [=a browsing context is discarded=] algorithm is modified to read as follows
 To discard a browsing context |browsingContext|, run these steps:
 
  1. If this is not a recursive invocation of this algorithm, call any <dfn export>browsing context
-    tree discarded</dfn> steps defined in external specifications with |browsingContext|.
+    tree discarded</dfn> steps defined in other applicable specifications with |browsingContext|.
 
  1. Discard all {{Document}} objects for all the entries in |browsingContext|'s [=session
     history=].

--- a/index.bs
+++ b/index.bs
@@ -161,8 +161,12 @@ To <dfn>resume</dfn> given |name|, |id| and |parameters|:
 
     1. Remove |id| from [=wait queue=].
 
-    1. Resume running the steps in |algorithm| from the point at which they were
-       paused, passing |name| and |parameters| as the result of the [=await=].
+    1. [=Queue a WebDriver task=] to resume running the steps in |algorithm| from the
+       point at which they were paused, passing |name| and |parameters| as the
+       result of the [=await=].
+
+       Issue: Should we have something like microtasks to ensure this runs
+       before any other tasks on the event loop?
 
 </div>
 
@@ -1890,13 +1894,26 @@ The [=remote end steps=] with |command parameters| are:
 
   1. If |wait condition| is "<code>none</code>":
 
-   1. Let |body| be a [=map=] matching the
-     <code>BrowsingContextNavigateResult</code> production, with the
-     <code>navigation</code> field set to |navigation id|, and the
-     <code>url</code> field set to the result of the [=URL serializer=] given
-     |navigate status|'s url.
+    1. Let |body| be a [=map=] matching the
+       <code>BrowsingContextNavigateResult</code> production, with the
+       <code>navigation</code> field set to |navigation id|, and the
+       <code>url</code> field set to the result of the [=URL serializer=] given
+       |navigate status|'s url.
 
-   1. Return [=success=] with data |body|.
+    1. Return [=success=] with data |body|, and then run the following steps [=in
+       parallel=]:
+
+       1. Run the [=WebDriver-BiDi navigation started=] steps given |context|
+          and |navigate status|
+
+  1. Run the [=WebDriver-BiDi navigation started=] steps given |context|
+     and |navigate status|
+
+     Note: this event was previously suppressed to ensure that it would come
+     after the command response in the case that |wait condition| is
+     "<code>none</code>".
+
+     Issue: Replace this suppression mechanism with an event queue.
 
   1. If |wait condition| is "<code>interactive</code>", let |event name| be
      "<code>domContentLoaded</code>", otherwise let |event name| be
@@ -2022,6 +2039,11 @@ The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
 started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
+
+ 1. Let |context id| be the [=browsing context id=] for |context|.
+
+ 1. If |context id| is in the [=set of contexts with an ongoing navigate=],
+    then return.
 
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.

--- a/index.bs
+++ b/index.bs
@@ -1884,7 +1884,7 @@ The [=remote end steps=] with |command parameters| are:
      change. The parallel steps here ensure that we return the command result
      before emitting the event, so the navigation id is known.
 
-  1. If |navigate status|'s status is "<code>cancelled</code>" return [=error=]
+  1. If |navigate status|'s status is "<code>canceled</code>" return [=error=]
      with [=error code=] [=unknown error=].
 
      TODO: is this the right way to handle errors here?

--- a/index.bs
+++ b/index.bs
@@ -130,6 +130,40 @@ This specification depends on the Infra Standard. [[!INFRA]]
 
 Network protocol messages are defined using CDDL. [[!RFC8610]]
 
+This specification defines a <dfn>wait queue</dfn> which is a list.
+
+Issue: Surely there's a better mechanism for doing this "wait for an event" thing.
+
+<div algorithm>
+
+When an algorithm |algorithm| running [=in parallel=] <dfn>awaits</dfn> a set of
+events |events|, each consisting of a tuple (<code>name</code>, <code>resume
+id</code>):
+
+1. Pause the execution of |algorithm|.
+
+1. Append (|events|, |algorithm|) to [=wait queue=].
+
+</div>
+
+<div algorithm>
+To <dfn>resume</dfn> given |name|, |id| and |parameters|:
+
+1. For each |paused| in |wait queue|:
+
+  1. Let |events| and |algorithm| be the two items in |paused|
+
+  1. For each |event| in |events|:
+
+    1. If the two items in |event| are equal to |name| and |id|:
+
+      1. Remove |paused| from |wait queue|.
+
+      1. Resume running the steps in |algorithm| from the point at which they were
+         paused, passing |name| and |parameters| as the result of the [=await=].
+
+</div>
+
 # Protocol # {#protocol}
 
 This section defines the basic concepts of the WebDriver BiDi

--- a/index.bs
+++ b/index.bs
@@ -1862,13 +1862,13 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let |navigation id| be |navigate status|'s id
 
-  1. If |navigate status|'s status is "<code>complete</code>" |navigation id| is
-     null:
+  1. If |navigate status|'s status is "<code>complete</code>":
 
     1. Let |body| be a [=map=] matching the
        <code>BrowsingContextNavigateResult</code> production, with the
-       <code>navigation</code> field set to null, and the <code>url</code> field
-       set to the result of the [=URL serializer=] given |navigate status|'s url.
+       <code>navigation</code> field set to |navigation id|, and the
+       <code>url</code> field set to the result of the [=URL serializer=] given
+       |navigate status|'s url.
 
     1. Return [=success=] with data |body|, and then run the following steps [=in
        parallel=]:
@@ -2044,12 +2044,7 @@ started</dfn> steps given |context| and |navigation status|:
       <pre class="cddl local-cddl">
         BrowsingContextFragmentNavigatedEvent = {
          method: "browsingContext.fragmentNavigated",
-         params: BrowsingContextFragmentNavigatedParameters
-       }
-
-       BrowsingContextFragmentNavigatedParameters = {
-        context: BrowsingContext,
-        url: text,
+         params: NavigationInfo
        }
       </pre>
    </dd>
@@ -2066,12 +2061,8 @@ navigated</dfn> steps given |context| and |navigation status|:
  1. If |context id| is in the [=set of contexts with an ongoing navigate=],
     then return.
 
- 1. Let |url| be |navigation status|'s url.
-
- 1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextFragmentNavigatedParameters</code> production, with the
-    <code>context</code> field set to |context id| and the <code>url</code>
-    field set to the result of the [=URL serializer=] given |url|.
+ 1. Let |params| be the result of [=get the navigation info=] given |context|
+    and |navigation status|.
 
  1. Let |body| be a [=map=] matching the
      <code>BrowsingContextFragmentNavigatedEvent</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -1698,7 +1698,6 @@ navigation.
 
 TODO: Link to the definition in the HTML spec.
 
-### Commands ### {#module-browsingContext-commands}
 
 #### The browsingContext.NavigationInfo Type #### {#type-browsingContext-NavigationInfo}
 
@@ -1713,6 +1712,8 @@ BrowsingContextNavigationInfo = {
 </pre>
 
 The <code>NavigationInfo</code> type provides details of an ongoing navigation.
+
+### Commands ### {#module-browsingContext-commands}
 
 #### The browsingContext.getTree Command ####  {#command-browsingContext-getTree}
 

--- a/index.bs
+++ b/index.bs
@@ -1768,14 +1768,14 @@ The [=remote end steps=] with |command parameters| are:
 
 #### The browsingContext.navigate Command ####  {#command-browsingContext-navigate}
 
-The <dfn export for=commands>browsingContext.navigates</dfn> command navigates a
+The <dfn export for=commands>browsingContext.navigate</dfn> command navigates a
 browsing context to the given URL.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      BrowsingContextGetTreeCommand = {
+      BrowsingContextNavigateCommand = {
         method: "browsingContext.navigate",
         params: BrowsingContextNavigateParameters
       }
@@ -1821,7 +1821,7 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Let |request| be a new [=/request=] whose URL is |url|.
 
-  1. Let |navigate status| be the result of [=navigate=] |context| with resource
+  1. Let |navigate status| be the result of [=navigate|navigating=] |context| with resource
      |request|, and using |context| as the [=source browsing context=].
 
   1. If |navigate status|'s status is complete and |navigate status|'s

--- a/index.bs
+++ b/index.bs
@@ -153,7 +153,7 @@ To <dfn>resume</dfn> given |name|, |id| and |parameters|:
 
 1. If [=wait queue=] does not contain |id|, return.
 
-1. Let |events|, |algorithm| be [=wait queue=][|id|]
+1. Let (|events|, |algorithm|) be [=wait queue=][|id|]
 
 1. For each |event| in |events|:
 
@@ -1576,6 +1576,7 @@ BrowsingContextEvent = (
     BrowsingContextFragmentNavigatedEvent //
     BrowsingContextDomContentLoadedEvent //
     BrowsingContextLoadEvent //
+    BrowsingContextDownloadWillBegin //
     BrowsingContextNavigationFailedEvent
 )
 
@@ -1705,7 +1706,7 @@ TODO: Link to the definition in the HTML spec.
 [=local end definition=]:
 
 <pre class="cddl local-cddl">
-BrowsingContextNavigationInfo = {
+NavigationInfo = {
   context: BrowsingContext,
   navigation: Navigation / null,
   url: text,
@@ -1834,11 +1835,13 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |navigate status| be the result of [=navigate|navigating=] |context| with resource
      |request|, and using |context| as the [=source browsing context=].
 
-  1. If |navigate status|'s status is complete and |navigate status|'s
-     navigation id is null:
+  1. Let |navigation id| be |navigate status|'s id
+
+  1. If |navigate status|'s status is "<code>complete</code>" |navigation id| is
+     null:
 
     1. Let |body| be a [=map=] matching the
-       <code>BrowsingContextNavigationResult</code> production, with the
+       <code>BrowsingContextNavigatenResult</code> production, with the
        <code>navigation</code> field set to null, and the <code>url</code> field
        set to the result of the [=URL serializer=] given |navigate status|'s url.
 
@@ -1846,36 +1849,42 @@ The [=remote end steps=] with |command parameters| are:
 
      Note: this is the case if the navigation only caused the fragment to change.
 
-  1. If |navigate status|'s status is cancelled return [=error=] with [=error code=]
-     [=unknown error=].
+  1. If |navigate status|'s status is "<code>cancelled</code>" return [=error=]
+     with [=error code=] [=unknown error=].
 
      TODO: is this the right way to handle errors here?
 
-  1. Assert: |navigate status|'s status is pending and |navigate status|'s id is
-     not null.
+  1. Assert: |navigate status|'s status is "<code>pending</code>" and
+     |navigation id| is not null.
 
-  1. Let |navigation id| be |navigate status|'s id
+  1. If |wait condition| is "<code>none</code>":
 
-  1. If |wait condition| is "<code>none</code>", return [=success=] with data
-     |body|.
+   1. Let |body| be a [=map=] matching the
+     <code>BrowsingContextNavigateResult</code> production, with the
+     <code>navigation</code> field set to |navigation id|, and the
+     <code>url</code> field set to the result of the [=URL serializer=] given
+     |navigate status|'s url.
 
-  1. If |wait condition| is interactive, let |event name| be
-     "<code>DOMContentLoaded</code>", otherwise let |event name| be "<code>load</code>".
+   1. Return [=success=] with data |body|.
+
+  1. If |wait condition| is "<code>interactive</code>", let |event name| be
+     "<code>domContentLoaded</code>", otherwise let |event name| be
+     "<code>load</code>".
 
   1. Let (|event received|, |status|) be [=await=] given «|event name|,
       "<code>download started</code>", "<code>navigation failed</code>"» and
      |navigation id|.
 
-  1. If |event received| is "<code>navigate failed</code>"
+  1. If |event received| is "<code>navigation failed</code>"
      return [=error=] with [=error code=] [=unknown error=].
 
-     Issue: Are we surfacting enough information about what failed and why with
+     Issue: Are we surfacing enough information about what failed and why with
      an error here? What error code do we want? Is there going to be a problem
      where local ends parse the implementation-defined strings to figure out
      what actually went wrong?
 
   1. Let |body| be a [=map=] matching the
-     <code>BrowsingContextNavigationResult</code> production, with the
+     <code>BrowsingContextNavigateResult</code> production, with the
      <code>navigation</code> field set to |status|'s id, and the
      <code>url</code> field set to the result of the [=URL serializer=] given
      |status|'s url.
@@ -1971,7 +1980,7 @@ become inaccessible but not yet get discarded because bfcache.
       <pre class="cddl local-cddl">
         BrowsingContextNavigationStartedEvent = {
          method: "browsingContext.navigationStarted",
-         params: BrowsingContextNavigationInfo
+         params: NavigationInfo
        }
       </pre>
    </dd>
@@ -1991,7 +2000,7 @@ Define the following [=navigation started steps=] with |context| and |navigation
  1. Let |url| be |navigation status|'s url.
 
  1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>NavigationInfo</code> production, with the
     <code>context</code> field set to |context id|, the <code>navigation</code>
     field set to |navigation id| and the <code>url</code> field set to the
     result of the [=URL serializer=] given |url|.
@@ -2024,6 +2033,7 @@ Define the following [=navigation started steps=] with |context| and |navigation
       </pre>
    </dd>
 </dl>
+
 The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for browsingContext.fragmentNavigated">
@@ -2059,13 +2069,13 @@ Define the following [=fragment navigated steps=] with |context| and |navigation
       <pre class="cddl local-cddl">
         BrowsingContextDomContentLoadedEvent = {
          method: "browsingContext.domContentLoaded",
-         params: BrowsingContextNavigationInfo
+         params: NavigationInfo
        }
       </pre>
    </dd>
 </dl>
-The [=remote end event trigger=] is:
 
+The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for browsingContext.domContentLoaded">
 
@@ -2080,7 +2090,7 @@ Define the following [=dom load complete steps=] with |context| and |navigation 
  1. Let |url| be |navigation status|'s url.
 
  1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>NavigationInfo</code> production, with the
     <code>context</code> field set to |context id|, the <code>navigation</code>
     field set to |navigation id|, and the <code>url</code> field set to the
     result of the [=URL serializer=] given |url|.
@@ -2093,7 +2103,7 @@ Define the following [=dom load complete steps=] with |context| and |navigation 
 
  1. [=Emit an event=] with |body| and |related browsing contexts|.
 
- 1. [=Resume=] with "<code>DOMContentLoaded</code>", |navigation id|, and
+ 1. [=Resume=] with "<code>domContentLoaded</code>", |navigation id|, and
     |navigation status|.  </div>
 
 #### The browsingContext.load Event #### {#event-browsingContext-load}
@@ -2104,7 +2114,7 @@ Define the following [=dom load complete steps=] with |context| and |navigation 
       <pre class="cddl local-cddl">
         BrowsingContextLoadEvent = {
          method: "browsingContext.load",
-         params: BrowsingContextNavigationInfo
+         params: NavigationInfo
        }
       </pre>
    </dd>
@@ -2125,7 +2135,7 @@ Define the following [=load complete steps=] with |context| and |navigation stat
  1. Let |url| be |navigation status|'s url.
 
  1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>NavigationInfo</code> production, with the
     <code>context</code> field set to |context id|, the <code>navigation</code>
     field set to |navigation id|, and the <code>url</code> field set to the
     result of the [=URL serializer=] given |url|.
@@ -2150,7 +2160,7 @@ Define the following [=load complete steps=] with |context| and |navigation stat
       <pre class="cddl local-cddl">
         BrowsingContextDownloadWillBegin = {
          method: "browsingContext.downloadWillBegin",
-         params: BrowsingContextNavigationInfo
+         params: NavigationInfo
        }
       </pre>
    </dd>
@@ -2171,7 +2181,7 @@ Define the following [=download started steps=] with |context| and |navigation s
  1. Let |url| be |navigation status|'s url.
 
  1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>NavigationInfo</code> production, with the
     <code>context</code> field set to |context id|, the <code>navigation</code>
     field set to |navigation id|, and the <code>url</code> field set to the
     result of the [=URL serializer=] given |url|.
@@ -2196,7 +2206,7 @@ Define the following [=download started steps=] with |context| and |navigation s
       <pre class="cddl local-cddl">
         BrowsingContextNavigationFailed = {
          method: "browsingContext.navigationFailed",
-         params: BrowsingContextNavigationInfo
+         params: NavigationInfo
        }
       </pre>
    </dd>
@@ -2217,7 +2227,7 @@ Define the following [=navigation failed steps=] with |context| and |navigation 
  1. Let |url| be |navigation status|'s url.
 
  1. Let |params| be a [=map=] matching the
-    <code>BrowsingContextNavigationInfo</code> production, with the
+    <code>NavigationInfo</code> production, with the
     <code>context</code> field set to |context id|, the <code>navigation</code>
     field set to |navigation id|, and the <code>url</code> field set to the
     result of the [=URL serializer=] given |url|.


### PR DESCRIPTION
Add command and events related to browsing context navigation.

This adds a navigate command to the browsingContext module that
initiates a navigation of the given context to the given URL. The
command also accepts a wait parameter which affects whether it returns
immediately after the navigation is started or waits until the
document that's loaded is eventually parsed. In the case of early
return the navigation id allows later events to be connected to this
specific navigation.
    
In addition we also add a set of events relating to the navigation
lifecycle, corresponding to the navigation starting, failing, reaching
DOMContentLoaded, and reaching load. There is also an event for
synchronous same-page navigations.
    
There are quite a few open questions here about how we want to expose
error conditions. Currently we emit errors from the command, but these
don't have a lot of structured information and might end up with local
ends trying to parse additional information out of the message part.

The PR depends on changes in HTML to define the necessary integration points. I'll update with a link to that PR once it's ready.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/93.html" title="Last updated on Jul 6, 2021, 6:40 PM UTC (3601523)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/93/9f81644...3601523.html" title="Last updated on Jul 6, 2021, 6:40 PM UTC (3601523)">Diff</a>