### PR TITLE
Add the ability to start a session directly with the bidi connection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1605,7 +1605,6 @@ Capabilities = {
     ?browserName: text,
     ?browserVersion: text,
     ?platformName: text,
-    ?pageLoadStrategy: "none" / "eager" / "normal",
     ?proxy: {
         ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
         ?proxyAutoconfigUrl: text,
@@ -1615,15 +1614,7 @@ Capabilities = {
         ?sslProxy: text,
         ?socksProxy: text,
         ?socksVersion: int,
-    }
-    ?strictFileInteractability: bool,
-    ?timeouts: {
-        ?script: int / null,
-        ?pageLoad: int,
-        ?implicit: int
     },
-    ?unhandledPromptBehaviour: "dismiss" / "accept" / "dismiss and notify" / "accept and notify" / "ignore",
-    ?webSocketUrl: bool,
     *text => any
 };
 </pre>
@@ -1716,7 +1707,6 @@ This is a [=static command=].
           browserName: text,
           browserVersion: text,
           platformName: text,
-          pageLoadStrategy: "none" / "eager" / "normal",
           proxy: {
             ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
             ?proxyAutoconfigUrl: text,
@@ -1728,14 +1718,6 @@ This is a [=static command=].
             ?socksVersion: int,
           },
           setWindowRect: bool,
-          strictFileInteractability: bool,
-          timeouts: {
-            script: int / null,
-            pageLoad: int,
-            implicit: int
-          },
-          ?unhandledPromptBehaviour: "dismiss" / "accept" / "dismiss and notify" / "accept and notify" / "ignore",
-          ?webSocketUrl: text,
           *text => any
         }
       }

--- a/index.bs
+++ b/index.bs
@@ -2258,7 +2258,7 @@ browsing context to the given URL.
 </dl>
 
 <div algorithm="remote end steps for browsingContext.navigate">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 
   1. Let |context id| be the value of the <code>context</code> field of
      |command parameters|.
@@ -2479,8 +2479,6 @@ become inaccessible but not yet get discarded because bfcache.
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 started</dfn> steps given |context| and |navigation status|:
 
- 1. If the [=current session=] is null, return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2519,8 +2517,6 @@ started</dfn> steps given |context| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi fragment
 navigated</dfn> steps given |context| and |navigation status|:
-
- 1. If the [=current session=] is null, return.
 
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
@@ -2561,8 +2557,6 @@ navigated</dfn> steps given |context| and |navigation status|:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi DOM content
 loaded</dfn> steps given |context| and |navigation status|:
 
- 1. If the [=current session=] is null, return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2602,8 +2596,6 @@ loaded</dfn> steps given |context| and |navigation status|:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi load
 complete</dfn> steps given |context| and |navigation status|:
 
- 1. If the [=current session=] is null, return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2641,8 +2633,6 @@ complete</dfn> steps given |context| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download
 started</dfn> steps given |context| and |navigation status|:
-
- 1. If the [=current session=] is null, return.
 
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
@@ -2682,8 +2672,6 @@ started</dfn> steps given |context| and |navigation status|:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 aborted</dfn> steps given |context| and |navigation status|:
 
- 1. If the [=current session=] is null, return.
-
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.
 
@@ -2722,8 +2710,6 @@ aborted</dfn> steps given |context| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 failed</dfn> steps given |context| and |navigation status|:
-
- 1. If the [=current session=] is null, return.
 
  1. Let |params| be the result of [=get the navigation info=] given |context|
     and |navigation status|.

--- a/index.bs
+++ b/index.bs
@@ -46,13 +46,17 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: getting a property; url: dfn-get-a-property
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
+    text: invalid session id; url: dfn-invalid-session-id
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
+    text: maximum active sessions; url: dfn-maximum-active-sessions
     text: no such element; url: dfn-no-such-element
     text: no such frame; url: dfn-no-such-frame
+    text: process capabilities; url: dfn-processing-capabilities
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
     text: session ID; url: dfn-session-id
+    text: session not created; url: dfn-session-not-created
     text: session; url: dfn-sessions
     text: set a property; url: dfn-set-a-property
     text: success; url: dfn-success
@@ -60,6 +64,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: unknown command; url: dfn-unknown-command
     text: unknown error; url: dfn-unknown-error
     text: web element reference; url: dfn-web-element-reference
+    text: webdriver-active flag; url: dfn-webdriver-active-flag
     text: window handle; url: dfn-window-handle
 spec: CONSOLE; urlPrefix: https://console.spec.whatwg.org
   type: dfn
@@ -315,8 +320,12 @@ Each [=command=] is defined by:
 - A <dfn export for=command>result type</dfn>, which is defined by a [=local
   end definition=] fragment.
 - A set of [=remote end steps=] which define the actions to take for a command
-  given [=command parameters=] and return an instance of the command [=return
-  type=].
+  given a [= BiDi session=] and [=command parameters=] and return an
+  instance of the command [=return type=].
+
+A command that can run without an active session is a <dfn>static
+command</dfn>. Commands are not static commands unless stated in their
+definition.
 
 When commands are send from the [=local end=] they have a command id. This is an
 identifier used by the [=local end=] to identify the response from a particular
@@ -463,6 +472,9 @@ established from |listener| must be TLS encrypted.
 A [=remote end=] has a [=set=] of [=WebSocket listeners=] <dfn>active
 listeners</dfn>, which is initially empty.
 
+A [=remote end=] has a [=set=] of <dfn>WebSocket connections not associated with a
+session</dfn>, which is initially empty.
+
 A WebDriver [=/session=] has a <dfn>WebSocket connection</dfn> which is
 a network connection that follows the requirements of the
 [[!RFC6455|WebSocket protocol]]. This is initially null.
@@ -481,21 +493,33 @@ accept the incoming connection:
    running these steps and act as if the requested service is not
    available.
 
-2. [=Get a session ID for a WebSocket resource=] with |resource name|
+1. If |resource name| is the byte string "<code>/session</code>",
+   and the implementation [=supports BiDi-only sessions=]:
+
+    1. Run any other implementation-defined steps to decide if the
+       connection should be accepted, and if it is not stop running these
+       steps and act as if the requested service is not available.
+
+    1. Add the connection to the set of [=WebSocket connections not associated
+       with a session=].
+
+    1. Return.
+
+1. [=Get a session ID for a WebSocket resource=] with |resource name|
    and let |session id| be that value. If |session id| is null then
    stop running these steps and act as if the requested service is not
    available.
 
-3. If there is a [=/session=] in the list of [=active sessions=] with
+1. If there is a [=/session=] in the list of [=active sessions=] with
    |session id| as its [=session ID=] then let |session| be that
    session. Otherwise stop running these steps and act as if the
    requested service is not available.
 
-4. Run any other implementation-defined steps to decide if the
+1. Run any other implementation-defined steps to decide if the
    connection should be accepted, and if it is not stop running these
    steps and act as if the requested service is not available.
 
-5. Otherwise set |session|'s [=WebSocket connection=] to
+1. Otherwise set |session|'s [=WebSocket connection=] to
    |connection|, and proceed with the WebSocket [=server-side
    requirements=] when a server chooses to accept an incoming connection.
 
@@ -521,6 +545,8 @@ WebSocket connection to be closed without a closing handshake.
 To <dfn lt="construct a WebSocket resource name|constructing a
 WebSocket resource name">construct a WebSocket resource name</dfn>
 given a [=/session=] |session|:
+
+1. If |session| is null, return "<code>/session</code>"
 
 1. Return the result of concatenating the string "<code>/session/</code>"
    with |session|'s [=session ID=].
@@ -610,6 +636,11 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     Issue: Nothing seems to define what [=status codes|status code=]
     is used for UTF-8 errors.
 
+1. If there is a WebDriver [=/session=] with |connection| as its [=connection=],
+   let |session| be that session. Otherwise if |connection| is in the set of
+   [=WebSocket connections not associated with a session=], let |session| be
+   null. Otherwise, return.
+
 1. Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
    into Infra values=] given |data|. If this throws an exception, then [=respond
    with an error=] given |connection|, null, and [=invalid argument=], and
@@ -627,10 +658,16 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 
     1. Let |method| be |matched|["<code>method</code>"]
 
+    1. Let |command| be the command with [=command name=] |method|.
+
+    1. If |session| is null and |command| is not a [=static command=], then
+       [=respond with an error=] given |connection|, |command id|, and [=invalid
+       session id=], and return.
+
     1. Run the following steps in parallel:
 
-      1. Let |result| be the result of running the [=remote end steps=] for the
-         command with [=command name=] |method| given [=command parameters=]
+      1. Let |result| be the result of running the [=remote end steps=] for
+         |command| given |session| and [=command parameters=]
          |matched|["<code>params</code>"]
 
       1. If |result| is an [=error=], then [=respond with an error=] given
@@ -641,6 +678,10 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 
       1. Assert: |value| matches the definition for the [=result type=]
          corresponding to the command with [=command name=] |method|.
+
+      1. If |method| is "<code>session.new</code>, let the [=current session=]'s
+         [=WebSocket connection=] be |connection| and remove |connection| from
+         the set of [=WebSocket connections not associated with a session=].
 
       1. Let |response| be a new map matching the <code>CommandResponse</code>
          production in the [=local end definition=] with the <code>id</code>
@@ -748,6 +789,9 @@ To <dfn>handle a connection closing</dfn> given a [=WebSocket connection=]
  1. If there is a WebDriver [=/session=] with |connection| as its [=connection=],
     set the [=connection=] on that [=/session=] to null.
 
+ 1. If the set of [=WebSocket connections not associated with a session=]
+    contains |connection|, remove |connection| from that set.
+
 Issue: This should also reset any internal state
 
 </div>
@@ -806,6 +850,18 @@ with parameters |session| and |capabilities| is:
 
  6. [=Set a property=] on |capabilities| named
     "<code>webSocketUrl</code>" to |webSocketUrl|.
+
+</div>
+
+<div algorithm="no HTTP new session">
+
+Implementations should also allow clients to establish a connection without
+going via a HTTP WebDriver session. In this case the URL to the WebSocket server
+is communicated out-of-band. Implementations that allow this <dfn>supports
+BiDi-only sessions</dfn>. At the time such an implementation is ready to accept
+requests to start a WebDriver session, it must:
+
+1. [=Start listening for a WebSocket connection=] given null.
 
 </div>
 
@@ -1512,6 +1568,45 @@ filter only those that ought to be returned to the local end.
 
 </div>
 
+### Types ### {#module-session-types}
+
+#### The session.CapabilitiesRequest Type #### {#type-session-capabilitiesRequest}
+
+[=remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+Capabilities = {
+    ?acceptInsecureCertificates: bool,
+    ?browserName: text,
+    ?browserVersion: text,
+    ?platformName: text,
+    ?pageLoadStrategy: "none" / "eager" / "normal",
+    ?proxy: {
+        ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
+        ?proxyAutoconfigUrl: text,
+        ?ftpProxy: text,
+        ?httpProxy: text,
+        ?noProxy: [*text],
+        ?sslProxy: text,
+        ?socksProxy: text,
+        ?socksVersion: int,
+    }
+    ?strictFileInteractability: bool,
+    ?timeouts: {
+        ?script: int / null,
+        ?pageLoad: int,
+        ?implicit: int
+    },
+    ?unhandledPromptBehaviour: "dismiss" / "accept" / "dismiss and notify" / "accept and notify" / "ignore",
+    ?webSocketUrl: bool,
+    *text => any
+};
+</pre>
+
+The <code>CapabilitiesRequest</code> type represents the capabilities requested
+for a session.
+
+
 ### Commands ### {#module-session-commands}
 
 #### The session.status Command #### {#command-session-status}
@@ -1520,6 +1615,8 @@ The <dfn export for=commands>session.status</dfn> command returns information ab
 whether a remote end is in a state in which it can create new sessions,
 but may additionally include arbitrary meta information that is specific
 to the implementation.
+
+This is a [=static command=].
 
 <dl>
    <dt>Command Type</dt>
@@ -1542,7 +1639,10 @@ to the implementation.
    </dd>
 </dl>
 
-The [=remote end steps=] are:
+<div algorithm="remote end steps for session.status">
+
+The [=remote end steps=] given <var ignore>session</var>, and <var
+ignore>command parameters</var> are:
 
 1. Let |body| be a new [=map=] with the following properties:
 
@@ -1556,6 +1656,110 @@ The [=remote end steps=] are:
    </dl>
 
 2. Return [=success=] with data |body|
+
+#### The session.new Command #### {#command-session-new}
+
+The <dfn export for=commands>session.new</dfn> command allows creating a new
+WebDriver [=/session=].
+
+This is a [=static command=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      SessionNewCommand = {
+        method: "session.new",
+        params: {capabilities: CapabilitiesRequestParameters},
+      }
+
+      CapabilitiesRequestParameters = {
+        ?alwaysMatch: CapabilitiesRequest,
+        ?firstMatch: [*CapabilitiesRequest]
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+      SessionNewResult = {
+        sessionId: text,
+        capabilities: {
+          acceptInsecureCertificates: bool,
+          browserName: text,
+          browserVersion: text,
+          platformName: text,
+          pageLoadStrategy: "none" / "eager" / "normal",
+          proxy: {
+            ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
+            ?proxyAutoconfigUrl: text,
+            ?ftpProxy: text,
+            ?httpProxy: text,
+            ?noProxy: [*text],
+            ?sslProxy: text,
+            ?socksProxy: text,
+            ?socksVersion: int,
+          },
+          setWindowRect: bool,
+          strictFileInteractability: bool,
+          timeouts: {
+            script: int / null,
+            pageLoad: int,
+            implicit: int
+          },
+          ?unhandledPromptBehaviour: "dismiss" / "accept" / "dismiss and notify" / "accept and notify" / "ignore",
+          ?webSocketUrl: text,
+          *text => any
+        }
+      }
+      </pre>
+   </dd>
+</dl>
+
+Issue: This currently assumes we accept all the classic WebDriver capabilites
+But it's unclear if that's what we want to do. Some of them control legacy
+behaviour like `strictFileInteractability`. Others repersent global state that we
+might hope to do without in the case of BiDi e.g. global timeouts, global
+pageLoadStrategy. Probably we need at least `acceptInsecureCerts`, the various
+browser selection bits, and `proxy`. We just ignore additional properties, so if
+there are some that don't make sense we could just omit them and clients could
+still send them if that's easier than having seperate codepaths.
+
+<div algorithm="remote end steps for session.new">
+
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. If |session| is not null, or the [=maximum active sessions=] is equal to the
+   length of the list of [=active sessions=], return [=error=] with [=error
+   code=] [=session not created=].
+
+1. Let |capabilities| be the result of [=trying=] to [=process capabilities=]
+   with |command parameters|.
+
+1. If |capabilities| is null, return an [=error=] with [=error code=] [=session
+   not created=].
+
+1. If |capabilities| contains "<code>webSocketUrl</code>", remove
+   capabilities["<code>webSocketUrl</code>"].
+
+   Note: this ensures we don't try to restart the server; presumably the local
+   end already knows that BiDi is enabled since it's using it already.
+
+1. Run any [=WebDriver new session algorithm=] defined in external
+   specifications, with arguments |session| and |capabilities|.
+
+1. Let |session id| be a new [[!RFC4122|UUID]].
+
+1. Let |session| be a new [=/session=] with [=session ID=] |session id|.
+
+   Note: the connection for this session will be set to the current connection
+   by the caller.
+
+1. Let |body| be a new map matching the <code>SessionNewResult</code> production,
+   with the <code>sessionId</code> field set to |session|'s [=session ID=], and
+   the <code>capabilities</code> field set to |capabilities|.
+
+1. Return [=success=] with data |body|.
 
 #### The session.subscribe Command #### {#command-session-subscribe}
 
@@ -1587,8 +1791,8 @@ Issue: This needs to be generalized to work with realms too
    </dd>
 </dl>
 
-The [=remote end steps=] with |command parameters| are:
 <div algorithm="remote end steps for session.subscribe">
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let the |list of event names| be the value of the <code>events</code> field of
    |command parameters|
@@ -1597,7 +1801,7 @@ The [=remote end steps=] with |command parameters| are:
    field of |command parameters| if it is present or null if it isn't.
 
 1. Let |enabled events| be the result of [=trying=] to [=update the event map=]
-   with [=current session=], |list of event names| , |list of contexts| and
+   with |session|, |list of event names| , |list of contexts| and
    enabled true.
 
 1. Let |subscribe step events| be a new map.
@@ -1655,8 +1859,8 @@ Issue: This needs to be generalised to work with realms too
    </dd>
 </dl>
 
-The [=remote end steps=] with |command parameters| are:
 <div algorithm="remote end steps for session.unsubscribe">
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let the |list of event names| be the value of the <code>events</code> field of
    |command parameters|.
@@ -1664,7 +1868,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let the |list of contexts| be the value of the <code>contexts</code>
    field of |command parameters| if it is present or null if it isn't.
 
-1. [=Try=] to [=update the event map=] with [=current session=],
+1. [=Try=] to [=update the event map=] with |session|,
    |list of event names|, |list of contexts| and enabled false.
 
 1. Return [=success=] with data null.
@@ -1999,7 +2203,7 @@ top-level contexts when no parent is provided.
 </dl>
 
 <div algorithm="remote end steps for browsingContext.getTree">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 
   1. Let the |parent id| be the value of the <code>parent</code> field of
      |command parameters| if present, or null otherwise.
@@ -2695,7 +2899,7 @@ realm associated with the [=document=] currently loaded in a specified
 </dl>
 
 <div algorithm="remote end steps for script.getRealms">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 
   1. Let |environment settings| be a list of all the [=environment settings objects=]
      that have their [=execution ready flag=] set.

--- a/index.bs
+++ b/index.bs
@@ -929,17 +929,17 @@ from objects to their corresponding id.
 Issue: Should this be explicitly per realm?
 
 <div algorithm>
-To get the <dfn>object id for an object</dfn> given an |object|:
+To get the <dfn>object id for an object</dfn> given a |session| and |object|:
 
-  1. If the [=object id map=] for the [=current session=] does not contain |object|,
-     run the following steps:
+  1. If |session|'s [=object id map=] does not contain |object|, run the
+     following steps:
 
      1. Let |object id| be a new, unique, string identifier for |object|. If
         |object| is an [=/element=] this must be the [=web element reference=]
         for |object|; if it's a {{WindowProxy}} object, this must be the
         [=window handle=] for |object|.
 
-    1. Set the value of |object| in the [=object id map=] to |object id|.
+    1. Set the value of |object| in |session|'s [=object id map=] to |object id|.
 
   1. Return the result of getting the value for |object| in [=object id map=].
 </div>

--- a/index.bs
+++ b/index.bs
@@ -39,10 +39,12 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: additional WebDriver capability; url: dfn-additional-webdriver-capability
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
+    text: create a session; url: dfn-create-a-session
     text: endpoint node; url: dfn-endpoint-node
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
     text: getting a property; url: dfn-get-a-property
+    text: http session; url: dfn-http-session
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: invalid session id; url: dfn-invalid-session-id

--- a/index.bs
+++ b/index.bs
@@ -34,8 +34,10 @@ spec: RFC8610; urlPrefix: https://tools.ietf.org/html/rfc8610
     text: match a CDDL specification; url: appendix-C
 spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
   type: dfn
-    text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
+    text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
+    text: active sessions; url: dfn-active-session
     text: additional WebDriver capability; url: dfn-additional-webdriver-capability
+    text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
     text: current session; url: dfn-current-session
     text: endpoint node; url: dfn-endpoint-node
@@ -44,21 +46,19 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: getting a property; url: dfn-get-a-property
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
-    text: unknown command; url: dfn-unknown-command
-    text: unknown error; url: dfn-unknown-error
-    text: no such element; url: dfn-no-such-element
-    text: no such frame; url: dfn-no-such-frame
-    text: active sessions; url: dfn-active-session
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
-    text: remote end; url: dfn-remote-ends
+    text: no such element; url: dfn-no-such-element
+    text: no such frame; url: dfn-no-such-frame
     text: remote end steps; url: dfn-remote-end-steps
-    text: session; url: dfn-sessions
+    text: remote end; url: dfn-remote-ends
     text: session ID; url: dfn-session-id
+    text: session; url: dfn-sessions
     text: set a property; url: dfn-set-a-property
     text: success; url: dfn-success
     text: try; url: dfn-try
-    text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
+    text: unknown command; url: dfn-unknown-command
+    text: unknown error; url: dfn-unknown-error
     text: web element reference; url: dfn-web-element-reference
     text: window handle; url: dfn-window-handle
 spec: CONSOLE; urlPrefix: https://console.spec.whatwg.org

--- a/index.bs
+++ b/index.bs
@@ -511,9 +511,18 @@ listeners</dfn>, which is initially empty.
 A [=remote end=] has a [=set=] of <dfn>WebSocket connections not associated with a
 session</dfn>, which is initially empty.
 
-A [=WebDriver BiDi session=] has a <dfn>WebSocket connection</dfn> which is a
-network connection that follows the requirements of the [[!RFC6455|WebSocket
-protocol]]. This is initially null.
+A <dfn>WebSocket connection</dfn> is a network connection that follows the
+requirements of the [[!RFC6455|WebSocket protocol]]
+
+A [=BiDi session=] has a set of <dfn>session WebSocket
+connections</dfn> whose elements are [=WebSocket connections=]. This is
+initially empty.
+
+A [=BiDi session=] |session| is <dfn>associated with connection</dfn>
+|connection| if |session|'s [=session WebSocket connections=] contains |connection|.
+
+Note: Each [=WebSocket connection=] is associated with at most one [=BiDi
+session=].
 
 <div>
 
@@ -555,9 +564,9 @@ accept the incoming connection:
    connection should be accepted, and if it is not stop running these
    steps and act as if the requested service is not available.
 
-1. Otherwise set |session|'s [=WebSocket connection=] to
-   |connection|, and proceed with the WebSocket [=server-side
-   requirements=] when a server chooses to accept an incoming connection.
+1. Otherwise append |connection| to |session|'s [=session WebSocket
+   connections=], and proceed with the WebSocket [=server-side requirements=]
+   when a server chooses to accept an incoming connection.
 
 Issue: Do we support > 1 connection for a single session?
 
@@ -672,7 +681,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     Issue: Nothing seems to define what [=status codes|status code=]
     is used for UTF-8 errors.
 
-1. If there is a WebDriver [=/session=] with |connection| as its [=connection=],
+1. If there is a [=BiDi Session=] [=associated with connection=] |connection|,
    let |session| be that session. Otherwise if |connection| is in the set of
    [=WebSocket connections not associated with a session=], let |session| be
    null. Otherwise, return.
@@ -815,13 +824,16 @@ To <dfn>respond with an error</dfn> given a [=WebSocket connection=]
 To <dfn>handle a connection closing</dfn> given a [=WebSocket connection=]
 |connection|:
 
- 1. If there is a WebDriver [=/session=] with |connection| as its [=connection=],
-    set the [=connection=] on that [=/session=] to null.
+ 1. If there is a [=BiDi session=] [=associated with connection=] |connection|:
 
- 1. If the set of [=WebSocket connections not associated with a session=]
+   1. Let |session| be the [=BiDi session=] [=associated with connection=]
+      |connection|.
+
+   1. Remove |connection| from |session|'s [=session WebSocket
+      connections=].
+
+ 1. Otherwise, if the set of [=WebSocket connections not associated with a session=]
     contains |connection|, remove |connection| from that set.
-
-Issue: This should also reset any internal state
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -409,7 +409,23 @@ To obtain a list of <dfn>event enabled browsing contexts</dfn> given
 
 <div algorithm>
 
-To determine if an <dfn export>event is enabled</dfn> given |session|,
+The <dfn>set of sessions for which an event is enabled</dfn> given |event name| and
+|browsing contexts| is:
+
+1. Let |sessions| be a new set.
+
+1. For each |session| in [=active BiDI sessions=]:
+
+  1. If [=event is enabled=] with |session|, |event name| and |browsing
+     contexts|, append |session| to |sessions|.
+
+1. Return |sessions|
+
+</div>
+
+<div algorithm>
+
+To determine if an <dfn>event is enabled</dfn> given |session|,
 |event name| and |browsing contexts|:
 
 Note: |browsing contexts| is a set because a [=shared worker=] can be associated
@@ -751,28 +767,19 @@ To <dfn>get related browsing contexts</dfn> given an [=script/settings object=]
 
 </div>
 
-<div algorithm> To <dfn export>emit an event</dfn> given |body| and |related
-browsing contexts|:
+<div algorithm> To <dfn export>emit an event</dfn> given |session|, and |body|:
 
  1. [=Assert=]: |body| has [=map/size=] 2 and [=contains=] "<code>method</code>"
     and "<code>params</code>".
 
- 1. If the [=current session=] is null, or the [=current session=]'s [=WebSocket
-    Connection=] is null then return false.
+ 1. Let |connection| be |session|'s [=WebSocket connection=].
 
- 1. If [=event is enabled=] given [=current session=],
-    |body|["<code>method</code>"] and |related browsing contexts|:
+ 1. If |connection| is null, return.
 
-   1. Let |connection| be the [=current session=]'s [=WebSocket connection=].
+ 1. Let |serialized| be the result of [=serialize an infra value to JSON
+    bytes=] given |body|.
 
-   1. Let |serialized| be the result of [=serialize an infra value to JSON
-        bytes=] given |body|.
-
-   1. [=Send a WebSocket message=] comprised of |serialized| over |connection|.
-
-   1. Return true
-
- 1. Return false
+ 1. [=Send a WebSocket message=] comprised of |serialized| over |connection|.
 
 </div>
 
@@ -1820,7 +1827,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. For each |event name| → |contexts| in |subscribe step events|:
 
   1. Run the [=remote end subscribe steps=] for the [=event=] with [=event name=]
-     |event name| given |contexts| and |include global|.
+     |event name| given |session|, |contexts| and |include global|.
 
 1. Return [=success=] with data null.
 
@@ -2354,21 +2361,19 @@ The [=remote end steps=] with |command parameters| are:
 
 <div algorithm>
 
-To <dfn>Recursively emit context created events</dfn> given |context|:
+To <dfn>Recursively emit context created events</dfn> given |session| and |context|:
 
-1. [=Emit a context created event=] with |context|.
+1. [=Emit a context created event=] with |session| and |context|.
 
 1. For each child browsing context, |child|, of |context|:
 
-  1. [=Recursively emit context created events=] given |child|.
+  1. [=Recursively emit context created events=] given |session| and |child|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>Emit a context created event</dfn> given |context|:
-
-1. Let |related contexts| be a set containing |context|.
+To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=] given
    |context|, 0, and 1.
@@ -2377,7 +2382,7 @@ To <dfn>Emit a context created event</dfn> given |context|:
    <code>BrowsingContextCreatedEvent</code> production, with the
    <code>params</code> field set to |params|.
 
-1. [=Emit an event=] with |body| and |related contexts|.
+1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2390,18 +2395,24 @@ When the [=create a new browsing context=] algorithm is invoked, after the
 
 1. Let |context| be the newly created browsing context.
 
-1. [=Emit a context created event=] given |context|.
+1. Let |related browsing contexts| be a set containing |context|.
+
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>browsingContext.contextCreated</code>" and |related browsing
+   contexts|:
+
+  1. [=Emit a context created event=] given |session| and |context|.
 
 </div>
 
 <div algorithm="remote end subscribe steps for browsingContext.contextCreated">
 
 The [=remote end subscribe steps=], with [=subscribe priority=] 1, given
-|contexts| and <var ignore>include global</var> are:
+|session|, |contexts| and <var ignore>include global</var> are:
 
 1. For each |context| in |contexts|:
 
-  1. [=Recursively emit context created events=] given |context|.
+  1. [=Recursively emit context created events=] given |session| and |context|.
 
 </div>
 
@@ -2424,8 +2435,6 @@ The [=remote end event trigger=] is:
 
 Define the following [=browsing context tree discarded=] steps:
 
- 1. If the [=current session=] is null, return.
-
  1. Let |context| be the browsing context being discarded.
 
  1. Let |params| be the result of [=get the browsing context info=], given
@@ -2438,7 +2447,11 @@ Define the following [=browsing context tree discarded=] steps:
  1. Let |related browsing contexts| be a set containing the [=parent browsing
     context=] of |context|, if that is not null, or an empty set otherwise.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>browsingContext.contextDestroyed</code>" and |related browsing
+   contexts|:
+
+  1. [=Emit an event=] with |session| and |body|.
 
 Issue: the way this hooks into HTML feels very fragile. See https://github.com/whatwg/html/issues/6194
 
@@ -2481,7 +2494,10 @@ started</dfn> steps given |context| and |navigation status|:
  1. [=Resume=] with "<code>navigation started</code>", |navigation id|, and
     |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.navigationStarted</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2519,7 +2535,10 @@ navigated</dfn> steps given |context| and |navigation status|:
  1. [=Resume=] with "<code>fragment navigated</code>", |navigation id|, and
     |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.fragmentNavigated</code>" and |related browsing contexts|:
+
+  1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2557,7 +2576,10 @@ loaded</dfn> steps given |context| and |navigation status|:
  1. [=Resume=] with "<code>domContentLoaded</code>", |navigation id|, and
     |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.domContentLoaded</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2594,7 +2616,10 @@ complete</dfn> steps given |context| and |navigation status|:
  1. [=Resume=] with "<code>load</code>", |navigation id| and
     |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.load</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2631,7 +2656,10 @@ started</dfn> steps given |context| and |navigation status|:
 
  1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.downloadWillBegin</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2668,7 +2696,10 @@ aborted</dfn> steps given |context| and |navigation status|:
 
  1. [=Resume=] with "<code>navigation aborted</code>", |navigation id|, and |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.navigationAborted</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2706,7 +2737,10 @@ failed</dfn> steps given |context| and |navigation status|:
 
  1. [=Resume=] with "<code>navigation failed</code>", |navigation id|, and |navigation status|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.navigationFailed</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
@@ -2981,19 +3015,24 @@ object:
  1. Let |body| be a map matching the <code>RealmCreatedEvent</code>
     production, with the <code>params</code> field set to |realm info|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>script.realmCreated</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 </div>
 
 <div algorithm="remote end subscribe steps for script.realmCreated">
 
 The [=remote end subscribe steps=] with [=subscribe priority=] 2, given
-|contexts| and |include global| are:
+|session|, |contexts| and |include global| are:
 
 1. Let |environment settings| be a list of all the [=environment settings objects=]
    that have their [=execution ready flag=] set.
 
 1. For each |settings| of |environment settings|:
+
+  1. Let |related browsing contexts| be a new set.
 
   1. If the [=responsible document=] of |settings| is a [=Document=]:
 
@@ -3002,7 +3041,7 @@ The [=remote end subscribe steps=] with [=subscribe priority=] 2, given
 
      1. If |context| is not in |contexts|, continue.
 
-     1. Append |context| to |related contexts|.
+     1. Append |context| to |related browsing contexts|.
 
     Otherwise, if |include global| is false, continue.
 
@@ -3011,7 +3050,10 @@ The [=remote end subscribe steps=] with [=subscribe priority=] 2, given
   1. Let |body| be a map matching the <code>RealmCreatedEvent</code>
      production, with the <code>params</code> field set to |realm info|.
 
-  1. [=Emit an event=] with |body| and |related contexts|.
+  1. If [=event is enabled=] givenn |session|,
+     "<code>script.realmCreated</code>" and |related browsing contexts|:
+
+    1. [=Emit an event=] with |session| and |body|.
 
 Issue: Should the order here be better defined?
 
@@ -3056,7 +3098,10 @@ Define the following [=unloading document cleanup steps=] with |document|:
    1. Let |body| be a map matching the <code>RealmDestroyedEvent</code>
       production, with the <code>params</code> field set to |params|.
 
-   1. [=Emit an event=] with |body| and |related browsing contexts|.
+   1. For each |session| in the [=set of sessions for which an event is enabled=]
+      given "<code>script.realmDestroyed</code>" and |related browsing contexts|:
+
+     1. [=Emit an event=] with |session| and |body|.
 
  1. Let |environment settings| be the [=environment settings object=] whose
     [=responsible document=] is |document|.
@@ -3071,7 +3116,10 @@ Define the following [=unloading document cleanup steps=] with |document|:
  1. Let |body| be a map matching the <code>RealmDestroyedEvent</code>
     production, with the <code>params</code> field set to |params|.
 
- 1. [=Emit an event=] with |body| and |related browsing contexts|.
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>script.realmDestroyed</code>" and |related browsing contexts|:
+
+   1. [=Emit an event=] with |session| and |body|.
 
 Whenever a [=worker event loop=] |event loop| is destroyed, either because the
 worker comes to the end of its lifecycle, or prematurely via the [=terminate a
@@ -3109,9 +3157,9 @@ before the entry for A.
 
 <div algorithm>
 
-To <dfn>buffer a log event</dfn> given |contexts| and |event|:
+To <dfn>buffer a log event</dfn> given |session|, |contexts| and |event|:
 
-1. Let |buffer| be the [=current session=]'s [=log event buffer=].
+1. Let |buffer| be |session|'s [=log event buffer=].
 
 1. Let |context ids| be a new list.
 
@@ -3324,11 +3372,13 @@ ignore>options</var>:
 1. Let |related browsing contexts| be the result of [=get related browsing
    contexts=] given |settings|.
 
-1. Let |emitted| be the result of [=emit an event=] with |body| and |related
-   browsing contexts|.
+1. For each |session| in [=active BiDi sessions=]:
 
-1. If |emitted| is false, append (|related browsing contexts|, |body|) to the
-   [=current session=]'s [=log event buffer=].
+  1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
+     |related browsing contexts|, [=emit an event=] with |session| and |body|.
+
+     Otherwise, [=buffer a log event=] with |session|, |related browsing
+     contexts|, and |body|.
 
 Define the following [=error reporting steps=] with arguments |script|, <var
 ignore>line number</var>, <var ignore>column number</var>, |message| and
@@ -3347,11 +3397,13 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
 1. Let |related browsing contexts| be the result of [=get related browsing
    contexts=] given |settings|.
 
-1. Let |emitted| be the result of [=emit an event=] with |body| and |related
-   browsing contexts|.
+1. For each |session| in [=active BiDi sessions=]:
 
-1. If |emitted| is false, [=buffer a log event=] given |related browsing contexts|
-   and |body|.
+  1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
+     |related browsing contexts|, [=emit an event=] with |session| and |body|.
+
+     Otherwise, [=buffer a log event=] with |session|, |related browsing
+     contexts|, and |body|.
 
 Issue: Lots more things require logging. CDP has LogEntryAdded types xml,
 javascript, network, storage, appcache, rendering, security, deprecation,
@@ -3365,9 +3417,9 @@ Issue: Allow implementation-defined log types
 <div algorithm="remote end subscribe steps for log.entryAdded">
 
 The [=remote end subscribe steps=], with [=subscribe priority=] 10, given
-|contexts| and |include global| are:
+|session|, |contexts| and |include global| are:
 
-1. For each |context id| → |events| in [=log event buffer=]:
+1. For each |context id| → |events| in |session|'s [=log event buffer=]:
 
   1. Let |maybe context| be the result of [=getting a browsing context=] given
      |context id|.
@@ -3379,14 +3431,12 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 10, given
 
   1. Let |top level context| be |context|'s [=top-level browsing context=].
 
-  1. Let |related contexts| be a new set containing |context|.
-
   1. If |include global| is true and |top level context| is not in |contexts|,
      or if |include global| is false and |top level context| is in |contexts|:
 
     1. For each (|event|, |other contexts|) in |events|:
 
-      1. [=Emit an event=] with |event| and |related contexts|.
+      1. [=Emit an event=] with |session| and |event|.
 
       1. For each |other context id| in |other contexts|:
 

--- a/index.bs
+++ b/index.bs
@@ -267,7 +267,26 @@ EventData = (
 
 ## Session ## {#session}
 
-WebDriver BiDi uses the same [=/session=] concept as WebDriver.
+WebDriver BiDi extends the [=/session=] concept from [[WEBDRIVER|WebDriver]].
+
+A [=/session=] has a <dfn>BiDi flag</dfn>, which is false unless otherwise
+stated.
+
+A <dfn>BiDi session</dfn> is a [=/session=] which has the [=BiDi flag=]
+set to true.
+
+<div algorithm>
+The set of <dfn>active BiDi sessions</dfn> is given by:
+
+1. Let |BiDi sessions| be a new set.
+
+1. For each |session| in [=active sessions=]:
+
+  1. If |session| is a [=BiDi session=] append |session| to |BiDi sessions|.
+
+1. Return |BiDi sessions|
+
+</div>
 
 ## Modules ## {#protocol-modules}
 
@@ -363,15 +382,15 @@ occurred on the [=remote end=].
    controlling the order in which the steps are run when multiple events are
    enabled at once, with lower integers indicating steps that run earlier.
 
-A [=/session=] has a <dfn export for=event>global event set</dfn> which is a set
-containing the event names for events that are enabled for all
+A [=BiDi session=] has a <dfn export for=event>global event set</dfn>
+which is a set containing the event names for events that are enabled for all
 browsing contexts. This initially contains the [=event name=] for events that
 are <dfn export for=event>in the default event set</dfn>.
 
-A [=/session=] has a <dfn export for=event>browsing context event map</dfn>,
-which is a map with [=/top-level browsing context=] keys and values that are a
-set of [=event name=]s for events that are enabled in the given browsing
-context.
+A [=BiDi session=] has a <dfn export for=event>browsing context event
+map</dfn>, which is a map with [=/top-level browsing context=] keys and values
+that are a set of [=event name=]s for events that are enabled in the given
+browsing context.
 
 <div algorithm>
 
@@ -833,23 +852,29 @@ with parameter |value| is:
 
 <div algorithm="webSocketUrl new session algorithm">
 The [=WebDriver new session algorithm=] defined by this specification,
-with parameters |session| and |capabilities| is:
+with parameters |session|, |capabilities|, and |flags| is:
 
- 1. Let |webSocketUrl| be the result of [=getting a property=] named
-    "<code>webSocketUrl</code>" from |capabilities|.
+1. If |flags| contains "<code>bidi</code>", return.
 
- 2. If |webSocketUrl| is undefined, return.
+1. Let |webSocketUrl| be the result of [=getting a property=] named
+   "<code>webSocketUrl</code>" from |capabilities|.
 
- 3. [=Assert=]: |webSocketUrl| is true.
+1. If |webSocketUrl| is undefined or false, return.
 
- 4. Let |listener| be the result of [=start listening for a WebSocket
-    connection=] given |session|.
+1. [=Assert=]: |webSocketUrl| is true.
 
- 5. Set |webSocketUrl| to the result of [=constructing a WebSocket
-    URL=] given |listener| and |session|.
+1. Let |listener| be the result of [=start listening for a WebSocket
+   connection=] given |session|.
 
- 6. [=Set a property=] on |capabilities| named
-    "<code>webSocketUrl</code>" to |webSocketUrl|.
+1. Set |webSocketUrl| to the result of [=constructing a WebSocket
+   URL=] given |listener| and |session|.
+
+1. [=Set a property=] on |capabilities| named
+   "<code>webSocketUrl</code>" to |webSocketUrl|.
+
+1. Set |session|'s [=BiDi flag=] to true.
+
+1. Append "<code>bidi</code>" to flags.
 
 </div>
 
@@ -891,8 +916,8 @@ Note: mirror objects do not keep the original object alive in the runtime. If an
 object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
-A [=/session=] has an <dfn>object id map</dfn>. This is a weak map from objects to
-their corresponding id.
+A [=BiDi session=] has an <dfn>object id map</dfn>. This is a weak map
+from objects to their corresponding id.
 
 Issue: Should this be explicitly per realm?
 
@@ -1660,7 +1685,9 @@ ignore>command parameters</var> are:
 #### The session.new Command #### {#command-session-new}
 
 The <dfn export for=commands>session.new</dfn> command allows creating a new
-WebDriver [=/session=].
+[=BiDi session=].
+
+Note: A session created this way will not be accessible via HTTP.
 
 This is a [=static command=].
 
@@ -1716,41 +1743,24 @@ This is a [=static command=].
    </dd>
 </dl>
 
-Issue: This currently assumes we accept all the classic WebDriver capabilites
-But it's unclear if that's what we want to do. Some of them control legacy
-behaviour like `strictFileInteractability`. Others repersent global state that we
-might hope to do without in the case of BiDi e.g. global timeouts, global
-pageLoadStrategy. Probably we need at least `acceptInsecureCerts`, the various
-browser selection bits, and `proxy`. We just ignore additional properties, so if
-there are some that don't make sense we could just omit them and clients could
-still send them if that's easier than having seperate codepaths.
-
 <div algorithm="remote end steps for session.new">
 
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. If |session| is not null, or the [=maximum active sessions=] is equal to the
-   length of the list of [=active sessions=], return [=error=] with [=error
-   code=] [=session not created=].
+1. If |session| is not null, return an [=error=] with error code [=session not created=].
+
+1. If the implementation is unable to start a new session for any reason, return
+   an [=error=] with error code [=session not created=].
+
+1. Let |flags| be a set containing "<code>bidi</code>".
 
 1. Let |capabilities| be the result of [=trying=] to [=process capabilities=]
-   with |command parameters|.
+   with |command parameters| and |flags|.
 
-1. If |capabilities| is null, return an [=error=] with [=error code=] [=session
-   not created=].
+1. Let |session| be the result of [=trying=] to [=create a session=] with
+   |capabilities| and |flags|.
 
-1. If |capabilities| contains "<code>webSocketUrl</code>", remove
-   capabilities["<code>webSocketUrl</code>"].
-
-   Note: this ensures we don't try to restart the server; presumably the local
-   end already knows that BiDi is enabled since it's using it already.
-
-1. Run any [=WebDriver new session algorithm=] defined in external
-   specifications, with arguments |session| and |capabilities|.
-
-1. Let |session id| be a new [[!RFC4122|UUID]].
-
-1. Let |session| be a new [=/session=] with [=session ID=] |session id|.
+1. Set |session|'s [=BiDi flag=] to true.
 
    Note: the connection for this session will be set to the current connection
    by the caller.
@@ -3108,7 +3118,7 @@ worker=] algorithm:
 The <dfn export for=modules>log</dfn> module contains functionality and events
 related to logging.
 
-A [=/session=] has a <dfn>log event buffer</dfn> which is a [=map=] from
+A [=BiDi Session=] has a <dfn>log event buffer</dfn> which is a [=map=] from
 [=browsing context id=] to a list of log events for that context that have not
 been emitted. User agents may impose a maximum size on this buffer, subject to
 the condition that if events A and B happen in the same context with A occuring

--- a/index.bs
+++ b/index.bs
@@ -39,7 +39,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: additional WebDriver capability; url: dfn-additional-webdriver-capability
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
-    text: current session; url: dfn-current-session
     text: endpoint node; url: dfn-endpoint-node
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
@@ -510,9 +509,9 @@ listeners</dfn>, which is initially empty.
 A [=remote end=] has a [=set=] of <dfn>WebSocket connections not associated with a
 session</dfn>, which is initially empty.
 
-A WebDriver [=/session=] has a <dfn>WebSocket connection</dfn> which is
-a network connection that follows the requirements of the
-[[!RFC6455|WebSocket protocol]]. This is initially null.
+A [=WebDriver BiDi session=] has a <dfn>WebSocket connection</dfn> which is a
+network connection that follows the requirements of the [[!RFC6455|WebSocket
+protocol]]. This is initially null.
 
 <div>
 
@@ -714,8 +713,10 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
       1. Assert: |value| matches the definition for the [=result type=]
          corresponding to the command with [=command name=] |method|.
 
-      1. If |method| is "<code>session.new</code>, let the [=current session=]'s
-         [=WebSocket connection=] be |connection| and remove |connection| from
+      1. If |method| is "<code>session.new</code>", let |session| be the entry in
+         the list of [=active sessions=] whose [=session ID=] is equal to the
+         "<code>sessionId</code>" property of |value|, let |session|'s
+         [=WebSocket connection=] be |connection|, and remove |connection| from
          the set of [=WebSocket connections not associated with a session=].
 
       1. Let |response| be a new map matching the <code>CommandResponse</code>
@@ -887,9 +888,9 @@ with parameters |session|, |capabilities|, and |flags| is:
 
 <div algorithm="no HTTP new session">
 
-Implementations should also allow clients to establish a connection without
-going via a HTTP WebDriver session. In this case the URL to the WebSocket server
-is communicated out-of-band. Implementations that allow this <dfn>supports
+Implementations should also allow clients to establish a [=BiDi Session=] which
+is not a [=HTTP Session=]. In this case the URL to the WebSocket server is
+communicated out-of-band. An implementation that allows this <dfn>supports
 BiDi-only sessions</dfn>. At the time such an implementation is ready to accept
 requests to start a WebDriver session, it must:
 


### PR DESCRIPTION
The case for this is:

* Some clients might be uninterested in using the classic WebDriver
HTTP connection, and want to avoid depending on a HTTP client just for
session creation.

* Some implementations might ship the HTTP server as a seperate
component, but have the bidi connection built-in to the browser
itself. This will allow clients to use bidi without a seperate driver
binary (similar to devtools) without requiring the browser to ship a
full HTTP implementation just for new session.

* It is needed to "explain" the behaviour of classic WebDriver in
terms of the BiDI protocol; in particular the new session and session
status command.

Implementation-wise the model is that a remote end is allowed to start
a WebSockets server that accepts connections to the `/session`
resource. This connection can then be used for "static" commands
i.e. those which don't require a session. Currently this is just
`session.status` and `session.new`. Once `session.new` is called, the
same WS connection is reused for subsequent commands that are part of
the session.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/99.html" title="Last updated on Sep 22, 2021, 2:27 PM UTC (495cce0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/99/fbafbf3...495cce0.html" title="Last updated on Sep 22, 2021, 2:27 PM UTC (495cce0)">Diff</a>