### PR TITLE
Give variables a more distinctive style

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -115,6 +115,10 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/
 spec:infra; type:dfn; for:/; text:set
 </pre>
 
+<style>
+var {color: indianred}
+</style>
+
 # Introduction # {#intro}
 
 <em>This section is non-normative.</em>

--- a/index.bs
+++ b/index.bs
@@ -116,7 +116,9 @@ spec:infra; type:dfn; for:/; text:set
 </pre>
 
 <style>
-var {color: indianred}
+var {
+  color: #cd5c5c
+}
 </style>
 
 # Introduction # {#intro}


### PR DESCRIPTION
The fact that we use names with spaces makes it a bit hard to tell
which things are variables. Initially use a colour to help with this,
but we might want to try some other options later.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/126.html" title="Last updated on Aug 6, 2021, 3:38 PM UTC (f5ee01e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/126/d641619...f5ee01e.html" title="Last updated on Aug 6, 2021, 3:38 PM UTC (f5ee01e)">Diff</a>