### PR TITLE
Small updates for steps of 'update the event map'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1419,16 +1419,16 @@ disabled, the return value is always empty.
 
   1. Let |event map| be a new map.
 
-    1. For each |key| → |value| of the [=browsing context event map=] for
-       |session|:
+  1. For each |key| → |value| of the [=browsing context event map=] for
+     |session|:
 
-      1. Set |event map|[|key|] to a [=set/clone=] of |value|.
+    1. Set |event map|[|key|] to a [=set/clone=] of |value|.
 
   1. Let |event names| be an empty set.
 
-    1. For each entry |name| in |requested event names|,
-       let |event names| be the union of |event names| and the result of
-       [=trying=] to [=obtain a set of event names=] with |name|.
+  1. For each entry |name| in |requested event names|,
+     let |event names| be the union of |event names| and the result of
+     [=trying=] to [=obtain a set of event names=] with |name|.
 
   1. Let |enabled events| be a new map.
 

--- a/index.bs
+++ b/index.bs
@@ -1399,7 +1399,7 @@ SessionResult = (StatusResult)
 <div algorithm>
 
 To <dfn>update the event map</dfn>, given
-|session|, |list of event names|, |browsing contexts|, and |enabled|:
+|session|, |list of requested event names|, |browsing contexts|, and |enabled|:
 
 Note: The return value of this algorithm is a map between event names and
 contexts. When the events are being enabled globally, the contexts in the return
@@ -1413,18 +1413,18 @@ disabled, the return value is always empty.
 
   1. Let |event map| be a new map.
 
-  1. For each |key| → |value| of the [=browsing context event map=] for
-     |session|:
+    1. For each |key| → |value| of the [=browsing context event map=] for
+       |session|:
 
-    1. Set |event map|[|key|] to a [=set/clone=] of |value|.
-
-  1. Let |enabled events| be a new map.
+      1. Set |event map|[|key|] to a [=set/clone=] of |value|.
 
   1. Let |event names| be an empty set.
 
-    1. For each entry |name| in |list of event names|, let |event names| be
-       the union of |event names| and the result of [=trying=] to [=obtain a set
-       of event names=] with |name|.
+    1. For each entry |name| in |list of requested event names|,
+       let |event names| be the union of |event names| and the result of
+       [=trying=] to [=obtain a set of event names=] with |name|.
+
+  1. Let |enabled events| be a new map.
 
   1. If |browsing contexts| is null:
 

--- a/index.bs
+++ b/index.bs
@@ -1405,7 +1405,7 @@ SessionResult = (StatusResult)
 <div algorithm>
 
 To <dfn>update the event map</dfn>, given
-|session|, |list of requested event names|, |browsing contexts|, and |enabled|:
+|session|, |requested event names|, |browsing contexts|, and |enabled|:
 
 Note: The return value of this algorithm is a map between event names and
 contexts. When the events are being enabled globally, the contexts in the return
@@ -1426,7 +1426,7 @@ disabled, the return value is always empty.
 
   1. Let |event names| be an empty set.
 
-    1. For each entry |name| in |list of requested event names|,
+    1. For each entry |name| in |requested event names|,
        let |event names| be the union of |event names| and the result of
        [=trying=] to [=obtain a set of event names=] with |name|.
 


### PR DESCRIPTION
This fixes the confusion around the `event names` map, and the passed in `list of event names`. Further, similar to the steps for `event names` it adds indentation to the `event map` setup.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2021, 2:37 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhimboo%2Fwebdriver-bidi%2Fcd2058fdccf410d8e220d8b990fb0b8fd6e90d4a%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    cli.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 466, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 515, in handleSpec
    lineNumbers=options.lineNumbers,
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 61, in __init__
    self.inputSource = InputSource(inputFilename, chroot=constants.chroot)
  File "/sites/api.csswg.org/bikeshed/bikeshed/InputSource.py", line 51, in __new__
    return UrlInputSource(sourceName, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'chroot'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23129.)._
</details>
