### PR TITLE
Simplify update the event map

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1408,11 +1408,9 @@ To <dfn>update the event map</dfn>, given
 |session|, |requested event names|, |browsing contexts|, and |enabled|:
 
 Note: The return value of this algorithm is a map between event names and
-contexts. When the events are being enabled globally, the contexts in the return
-value are those for which the event was already enabled. When the events are
-enabled for specific contexts, the contexts in the return value are those for
-which the event are now enabled but were not previously. When events are
-disabled, the return value is always empty.
+contexts. When the events are being enabled, the contexts in the return value
+are those for which the event are now enabled but were not previously. When
+events are disabled, the return value is always empty.
 
   1. Let |global event set| be a [=set/clone=] of the [=global event set=] for
      |session|.
@@ -1440,15 +1438,18 @@ disabled, the return value is always empty.
 
            1. If |global event set| doesn't contain |event name|:
 
-             1. Let |event enabled contexts| be the [=event enabled browsing
+             1. Let |already enabled contexts| be the [=event enabled browsing
                 contexts=] given |session| and |event name|
 
              1. Add |event name| to |global event set|.
 
-             1. For each |context| of |event enabled contexts|, remove |event
+             1. For each |context| of |already enabled contexts|, remove |event
                 name| from |event map|[|context|].
 
-             1. Set |enabled events|[|event name|] to |event enabled contexts|.
+             1. Let |newly enabled contexts| be a list of all [=top-level browsing
+                contexts=] that are not contained in |already enabled contexts|,
+
+             1. Set |enabled events|[|event name|] to |newly enabled contexts|.
 
       1. If |enabled| is false:
 
@@ -1615,17 +1616,13 @@ The [=remote end steps=] with |command parameters| are:
     1. Return true if |event one|'s [=subscribe priority=] is less than |event
        two|'s susbscribe priority, or false otherwise.
 
+1. If |list of contexts| is null, let |include global| be true, otherwise let
+   |include global| be false.
+
 1. For each |event name| → |contexts| in |subscribe step events|:
 
-  1. If |list of contexts| is null, let |include contexts| be a list of all
-     [=top-level browsing contexts=] that are not contained in |contexts|, and
-     let |include global| be true.
-
-     Otherwise let |include contexts| be |contexts| and let |include global| be
-     false.
-
   1. Run the [=remote end subscribe steps=] for the [=event=] with [=event name=]
-     |event name| given |include contexts| and |include global|.
+     |event name| given |contexts| and |include global|.
 
 1. Return [=success=] with data null.
 


### PR DESCRIPTION
Ensure that the return value is always a map of event name to a list
of contexts for which the event is now subscribed but wasn't previously.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2021, 3:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2Fce3cee1f343fdf0ad09aaca347438c713088586a%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    cli.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 466, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 515, in handleSpec
    lineNumbers=options.lineNumbers,
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 61, in __init__
    self.inputSource = InputSource(inputFilename, chroot=constants.chroot)
  File "/sites/api.csswg.org/bikeshed/bikeshed/InputSource.py", line 51, in __new__
    return UrlInputSource(sourceName, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'chroot'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23131.)._
</details>
