### PR TITLE
Only emit a stack trace for console.trace()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3054,7 +3054,9 @@ ignore>options</var>:
 
 1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
 
-1. Let |stack| be the [=current stack trace=].
+1. If |method| is "<code>assert</code>", "<code>error</code>",
+   "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
+   stack trace=]. Otherwise let |stack| be null.
 
 1. Let |entry| be a map matching the <code>ConsoleLogEntry</code> production,
    with the the <code>level</code> field set to |level|, the <code>text</code>


### PR DESCRIPTION
Not for every console.* method


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/135.html" title="Last updated on Sep 22, 2021, 1:31 PM UTC (2b64d8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/135/916796d...2b64d8d.html" title="Last updated on Sep 22, 2021, 1:31 PM UTC (2b64d8d)">Diff</a>