### PR TITLE
Remove dashes from exported WebDriver-BiDi navigation hooks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2266,7 +2266,7 @@ become inaccessible but not yet get discarded because bfcache.
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2304,7 +2304,7 @@ started</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi fragment
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi fragment
 navigated</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2342,7 +2342,7 @@ navigated</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi DOM content
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi DOM content
 loaded</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2380,7 +2380,7 @@ loaded</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi load
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi load
 complete</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2417,7 +2417,7 @@ complete</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi download
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download
 started</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2454,7 +2454,7 @@ started</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 aborted</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.
@@ -2492,7 +2492,7 @@ aborted</dfn> steps given |context| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver-BiDi navigation
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 failed</dfn> steps given |context| and |navigation status|:
 
  1. If the [=current session=] is null, return.


### PR DESCRIPTION
These are used without the dash in HTML:
https://html.spec.whatwg.org/#webdriver-bidi-navigation-status


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/137.html" title="Last updated on Sep 15, 2021, 10:26 AM UTC (bb4907c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/137/b6bb907...bb4907c.html" title="Last updated on Sep 15, 2021, 10:26 AM UTC (bb4907c)">Diff</a>