### PR TITLE
`script.callFunction` spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -91,8 +91,8 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: IsRegExp; url: sec-isregexp
     text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Object; url: sec-object-objects
-    text: InstantiateOrdinaryFunctionObject; url: #sec-runtime-semantics-instantiateordinaryfunctionobject
-    text: EvaluateFunctionBody; url: #sec-runtime-semantics-evaluatefunctionbody
+    text: IsCallable; url: #sec-iscallable
+    text: OrdinaryCallEvaluateBody; url: #sec-ordinarycallevaluatebody
     text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
     text: Set; url: sec-set
     text: ThisTimeValue; url: thistimevalue
@@ -941,7 +941,7 @@ Issue: Defined <dfn>deserialize a reference</dfn> steps.
 
 ### Primitive Protocol Value ### {#data-types-protocolValue-primitiveValue}
 
-<dfn>Primitive Protocol Value</dfn> represents primitive protocol values which can be serialized to /
+Represents primitive protocol values which can be serialized to /
 deserialized from ECMAScript without reference to existing objects.
 
 ```
@@ -3428,6 +3428,28 @@ The <dfn>deserialize an argument value</dfn>(|argumentValue|) is the following:
 1. If |argumentValue| is [=RemoteReference=], return [=deserialize a reference=](|argumentValue|).
 1. Return [=deserialize a local value=](|argumentValue|).
 
+The steps to <dfn>get function object</dfn> with a given |function declaration|,
+|environment settings|, |base URL|, and |options| are the following:
+
+1. Let |function script| be the result of [=create a classic script=] with |function declaration|,
+   |environment settings|, |base URL|, and |options|.
+
+1. [=Prepare to run script=] with |environment settings|.
+
+1. Set |function evaluation status| to [=ScriptEvaluation=](|function script|'s record).
+
+1. [=Clean up after running script=] with |environment settings|.
+
+1. Assert: |function evaluation status|.\[[Type]] is not <code>throw</code>.
+
+1. Let |function object| be |evaluation status|.\[[Value]].
+
+1. Assert [=IsCallable=](|function object|) is true.
+
+1. Return |function object|.
+
+Issue: Define behavior in case of exception during script evaluation.
+
 The [=remote end steps=] with |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
@@ -3435,11 +3457,6 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
-
-1. [=Prepare to run script=] with |environment settings|.
-
-1. Let |function declaration| be the value of the
-   <code>functionDeclaration</code> field of |command parameters|.
 
 1. Let |arguments declaration| be the value of the <code>arguments</code> field
    of |command parameters|.
@@ -3453,11 +3470,16 @@ The [=remote end steps=] with |command parameters| are:
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
-1. Let |function object| be the result of
-   [=InstantiateOrdinaryFunctionObject=](|function declaration|).
+1. Let |function declaration| be the value of the
+   <code>functionDeclaration</code> field of |command parameters|.
+
+1. Let |function object| be the result of [=get function object=](|function declaration|,
+   |environment settings|, |base URL|, and |options|).
+
+1. [=Prepare to run script=] with |environment settings|.
 
 1. Set |function evaluation status| to
-   [=EvaluateFunctionBody=](|function object|, |deserialized arguments list|).
+   [=OrdinaryCallEvaluateBody=](|function object|, |deserialized arguments list|).
 
 1. If |function evaluation status|.\[[Type]] is <code>normal</code>,
    |await promise| is true, and

--- a/index.bs
+++ b/index.bs
@@ -79,7 +79,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Await; url: await
     text: BigInt; url: sec-bigint-constructor
     text: boolean; url: sec-terms-and-definitions-boolean-value
-    text: Call; url: #sec-call
+    text: Call; url: sec-call
     text: Completion Record; url: sec-completion-record-specification-type
     text: CreateArrayFromList; url: sec-createarrayfromlist
     text: CreateArrayIterator; url: sec-createarrayiterator

--- a/index.bs
+++ b/index.bs
@@ -1164,17 +1164,17 @@ SetLocalValue = {
 
 <div algorithm>
 
-To <dfn>map serialized key-value list to deserialized key-value list</dfn> given a
+To <dfn>deserialize key-value list</dfn> given a
 |serialized key-value list|:
 
 1. Let |deserialized key-value list| be a new list.
 
 1. For each |serialized key-value| in the |serialized key-value list|:
 
-   1. If |serialized key-value| has not 2 elements,
+   1. If [=list/size=] of |serialized key-value| is not 2,
       return [=error=] with [=error code=] [=invalid argument=].
 
-   1. Let |serialized key| be the first element of |serialized key-value|.
+   1. Let |serialized key| be |serialized key-value|[0].
 
    1. If |serialized key| is a <code>string</code>,
       let |deserialized key| be |serialized key|.
@@ -1182,7 +1182,7 @@ To <dfn>map serialized key-value list to deserialized key-value list</dfn> given
    1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize local value=]
       with given |serialized key|.
 
-   1. Let |serialized value| be the second element of |serialized key-value|.
+   1. Let |serialized value| be |serialized key-value|[1].
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with given
       |serialized value|.
@@ -1239,15 +1239,15 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
     <dt>|type| is the string "<code>map</code>"
     <dd>
-      1. Let |deserialized key-value list| be a result of [=trying=]
-         [=map serialized key-value list to deserialized key-value list=] with given |value|.
+      1. Let |deserialized key-value list| be a result of [=trying=] to
+         [=deserialize key-value list=] with given |value|.
 
       1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
 
     <dt>|type| is the string "<code>object</code>"
     <dd>
-      1. Let |deserialized key-value list| be a result of [=trying=]
-         [=map serialized key-value list to deserialized key-value list=] with given |value|.
+      1. Let |deserialized key-value list| be a result of [=trying=] to
+         [=deserialize key-value list=] with given |value|.
 
       1. Return [=success=] with data
          <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.

--- a/index.bs
+++ b/index.bs
@@ -3494,105 +3494,6 @@ Issue: This has the wrong error code
 
 ### Commands ### {#module-script-commands}
 
-#### The script.evaluate Command ####  {#command-script-evaluate}
-
-The <dfn export for=commands>script.evaluate</dfn> command evaluates a provided
-script in a given realm. For convenience a browsing context can be provided in
-place of a realm, in which case the realm used is the realm of the browsing
-context's active document.
-
-The method returns the value of executing the provided script, unless it returns
-a promise and <code>awaitPromise</code> is true (which is the default), in which
-case the resolved value of the promise is returned.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-      <pre class="cddl remote-cddl">
-      ScriptEvaluateCommand = {
-        method: "script.evaluate",
-        params: ScriptEvaluateParameters
-      }
-
-      ScriptEvaluateParameters = {
-        expression: text,
-        target: Target,
-        ?awaitPromise: bool,
-      }
-      </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <pre class="cddl local-cddl">
-      ScriptEvaluateResult = (
-        ScriptEvaluateResultSuccess //
-        ScriptEvaluateResultException
-      )
-
-      ScriptEvaluateResultSuccess = {
-         result: RemoteValue
-      }
-
-      ScriptEvaluateResultException = {
-        exceptionDetails: ExceptionDetails
-      }
-    </pre>
-   </dd>
-</dl>
-
-TODO: Add timeout argument. It's not totally clear how this ought to work; in
-Chrome it seems like the timeout doesn't apply to the promise resolve step, but
-that likely isn't what clients want.
-
-The [=remote end steps=] with |command parameters| are:
-
-1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
-   given the value of the <code>target</code> field of |command parameters|.
-
-1. Let |environment settings| be the [=environment settings object=] whose
-   [=realm execution context=]'s Realm component is |realm|.
-
-1. Let |source| be the value of the <code>expression</code> field of |command
-   parameters|.
-
-1. Let |await promise| be the value of the <code>awaitPromise</code> field of
-   |command parameters|, if present, or <code>true</code> otherwise.
-
-1. Let |options| be the [=default classic script fetch options=].
-
-1. Let |base URL| be the [=API base URL=] of |environment settings|.
-
-1. Let |script| be the result of [=create a classic script=] with |source|,
-   |environment settings|, |base URL|, and |options|.
-
-1. [=Prepare to run script=] with |environment settings|.
-
-1. Set |evaluation status| to [=ScriptEvaluation=](|script|'s record).
-
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
-   true, and [=IsPromise=](|evaluation status|.\[[Value]]):
-
-   1. Set |evaluation status| to <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
-
-1. [=Clean up after running script=] with |environment settings|.
-
-1. If |evaluation status|.\[[Type]] is <code>throw</code>:
-
-  1. Let |exception details| be the result of [=get exception details=] given |evaluation
-     status|
-
-  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
-     production, with the <code>exceptionDetails</code> field set to |exception
-     details|.
-
-1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
-
-1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]].
-
-1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
-   production, with the <code>result</code> field set to |result|.
-
 #### The script.callFunction Command ####  {#command-script-callFunction}
 
 The <dfn export for=commands>script.callFunction</dfn> command calls a provided
@@ -3761,6 +3662,105 @@ The [=remote end steps=] with |command parameters| are:
    |evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptCallFunctionResultSuccess</code>
+   production, with the <code>result</code> field set to |result|.
+
+#### The script.evaluate Command ####  {#command-script-evaluate}
+
+The <dfn export for=commands>script.evaluate</dfn> command evaluates a provided
+script in a given realm. For convenience a browsing context can be provided in
+place of a realm, in which case the realm used is the realm of the browsing
+context's active document.
+
+The method returns the value of executing the provided script, unless it returns
+a promise and <code>awaitPromise</code> is true (which is the default), in which
+case the resolved value of the promise is returned.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      ScriptEvaluateCommand = {
+        method: "script.evaluate",
+        params: ScriptEvaluateParameters
+      }
+
+      ScriptEvaluateParameters = {
+        expression: text,
+        target: Target,
+        ?awaitPromise: bool,
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      ScriptEvaluateResult = (
+        ScriptEvaluateResultSuccess //
+        ScriptEvaluateResultException
+      )
+
+      ScriptEvaluateResultSuccess = {
+         result: RemoteValue
+      }
+
+      ScriptEvaluateResultException = {
+        exceptionDetails: ExceptionDetails
+      }
+    </pre>
+   </dd>
+</dl>
+
+TODO: Add timeout argument. It's not totally clear how this ought to work; in
+Chrome it seems like the timeout doesn't apply to the promise resolve step, but
+that likely isn't what clients want.
+
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
+   given the value of the <code>target</code> field of |command parameters|.
+
+1. Let |environment settings| be the [=environment settings object=] whose
+   [=realm execution context=]'s Realm component is |realm|.
+
+1. Let |source| be the value of the <code>expression</code> field of |command
+   parameters|.
+
+1. Let |await promise| be the value of the <code>awaitPromise</code> field of
+   |command parameters|, if present, or <code>true</code> otherwise.
+
+1. Let |options| be the [=default classic script fetch options=].
+
+1. Let |base URL| be the [=API base URL=] of |environment settings|.
+
+1. Let |script| be the result of [=create a classic script=] with |source|,
+   |environment settings|, |base URL|, and |options|.
+
+1. [=Prepare to run script=] with |environment settings|.
+
+1. Set |evaluation status| to [=ScriptEvaluation=](|script|'s record).
+
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
+   true, and [=IsPromise=](|evaluation status|.\[[Value]]):
+
+   1. Set |evaluation status| to <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
+
+1. [=Clean up after running script=] with |environment settings|.
+
+1. If |evaluation status|.\[[Type]] is <code>throw</code>:
+
+  1. Let |exception details| be the result of [=get exception details=] given |evaluation
+     status|
+
+  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+     production, with the <code>exceptionDetails</code> field set to |exception
+     details|.
+
+1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
+
+1. Let |result| be the result of [=serialize as a remote value=] given
+   |evaluation status|.\[[Value]].
+
+1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
    production, with the <code>result</code> field set to |result|.
 
 #### The script.getRealms Command ####  {#command-script-getRealms}

--- a/index.bs
+++ b/index.bs
@@ -1369,13 +1369,13 @@ SymbolRemoteValue = {
    objectId: ObjectId,
 }
 
-ArrayValue = {
+ArrayRemoteValue = {
   type: "array",
   objectId: ObjectId,
   ?value: ListRemoteValue,
 }
 
-ObjectValue = {
+ObjectRemoteValue = {
   type: "object",
   objectId: ObjectId,
   ?value: MappingRemoteValue,
@@ -1418,8 +1418,23 @@ WeakSetRemoteValue = {
   objectId: ObjectId,
 }
 
+IteratorRemoteValue = {
+  type: "iterator",
+  objectId: ObjectId,
+}
+
+GeneratorRemoteValue = {
+  type: "generator",
+  objectId: ObjectId,
+}
+
 ErrorRemoteValue = {
   type: "error",
+  objectId: ObjectId,
+}
+
+ProxyRemoteValue = {
+  type: "proxy",
   objectId: ObjectId,
 }
 
@@ -1464,6 +1479,12 @@ WindowProxyRemoteValue = {
 Issue: Add WASM types?
 
 Issue: Should WindowProxy get attributes in a similar style to Node?
+
+Issue: Describe `IteratorRemoteValue` deserialization.
+
+Issue: Describe `GeneratorRemoteValue` deserialization.
+
+Issue: Describe `ProxyRemoteValue` deserialization.
 
 Issue: handle String / Number / etc. wrapper objects specially?
 
@@ -3549,7 +3570,10 @@ The [=remote end steps=] with |command parameters| are:
 The <dfn export for=commands>script.callFunction</dfn> command calls a provided
 function with given arguments in a given realm.
 
- <code>RealmInfo</code> can be either a realm or a browsing context.
+<code>RealmInfo</code> can be either a realm or a browsing context.
+
+Note: <code>this</code> argument is ignore in case of arrow function in
+<code>functionDeclaration</code>.
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -1020,7 +1020,7 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
 1. Let |remote value| be undefined.
 
 1. In the following list of conditions and associated steps, run the first set
-   of steps for which the associated condition is true:
+   of steps for which the associated condition is true, if any:
 
   <dl>
     <dt>[=Type=](|value|) is undefined
@@ -1235,8 +1235,6 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 1. In the following list of conditions and associated steps, run the first set of steps for which
    the associated condition is true. If this throws exception, return [=error=] with [=error code=]
    [=invalid argument=]:
-
-  Issue: TODO: add regex options.
 
   <dl>
 

--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Type; url: sec-ecmascript-data-types-and-values
     text: current realm record; url: current-realm
     text: internal slot; url: sec-object-internal-methods-and-internal-slots
-    text: primitive value; url: sec-primitive-value
+    text: primitive ECMAScript value; url: sec-primitive-value
     text: realm; url: sec-code-realms
     text: running execution context; url: running-execution-context
     text: time value; url: sec-time-values-and-time-range
@@ -937,11 +937,11 @@ RemoteReference = {
 
 Issue: Defined <dfn>deserialize a reference</dfn> steps.
 
-## Value ## {#data-types-value}
+## Protocol Value ## {#data-types-protocolValue}
 
-### Primitive Value ### {#data-types-value-PrimitiveValue}
+### Primitive Protocol Value ### {#data-types-protocolValue-primitiveValue}
 
-<dfn>Primitive Value</dfn> represents primitive values which can be serialized to /
+<dfn>Primitive Protocol Value</dfn> represents primitive protocol values which can be serialized to /
 deserialized from ECMAScript without reference to existing objects.
 
 ```
@@ -987,7 +987,7 @@ BigIntValue = {
 
 <div algorithm>
 
-To <dfn>serialize primitive value</dfn> given a |value|:
+To <dfn>serialize primitive protocol value</dfn> given a |value|:
 
 1. Let |remote value| be undefined.
 
@@ -1047,16 +1047,16 @@ To <dfn>serialize primitive value</dfn> given a |value|:
 
 </div>
 
-### Local Value ### {#data-types-value-LocalValue}
+### Local Value ### {#data-types-protocolValue-LocalValue}
 
-Represents both primitive and non-primitive values which can be
+Represents both primitive and non-primitive protocol values which can be
 deserialized to ECMAScript without reference to existing objects.
 
 Issue: Define <dfn>deserialize a local value</dfn> steps.
 
 ```
 LocalValue = {
-  PrimitiveValue //
+  PrimitiveProtocolValue //
   ArrayLocalValue //
   ObjectLocalValue //
   MapLocalValue //
@@ -1100,7 +1100,7 @@ SetLocalValue = {
 }
 ```
 
-### Remote Value ### {#data-types-value-RemoteValue}
+### Remote Value ### {#data-types-protocolValue-RemoteValue}
 
 Values accessible from the ECMAScript runtime are represented by a mirror
 object, specified as <code>RemoteValue</code>. The value's type is specified in
@@ -1165,7 +1165,7 @@ Issue: This error code isn't right.
 [=remote end definition=] and [=local end definition=]
 ```
 RemoteValue = {
-  PrimitiveValue //
+  PrimitiveProtocolValue //
   SymbolRemoteValue //
   ArrayRemoteValue //
   ObjectRemoteValue //
@@ -1299,7 +1299,7 @@ Issue: handle String / Number / etc. wrapper objects specially?
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 |node details|, and a |set of known objects|:
 
-1. Let |remote value| be a result of [=serialize primitive value=]
+1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
 
 1. If |remote value| is not undefined, return |remote value|.
@@ -3892,7 +3892,7 @@ ignore>options</var>:
 
   1. If |arg| is not the first entry in |args|, append a U+0020 SPACE to |text|.
 
-  1. If |arg| is a [=primitive value=], append [=ToString=](|arg|) to
+  1. If |arg| is a [=primitive ECMAScript value=], append [=ToString=](|arg|) to
      |text|. Otherwise append an implementation-defined string to |text|.
 
 1. Let |serialized args| be a new list.

--- a/index.bs
+++ b/index.bs
@@ -1103,7 +1103,7 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
     <dd>Return [=success=] with data [=null=].
 
     <dt>|type| is the string "<code>string</code>"
-    <dd>Return [=success=] with data [=String=](|value|).
+    <dd>Return [=success=] with data |value|.
 
     <dt>|type| is the string "<code>number</code>"
     <dd>Return [=success=] with data [=Number=](|value|).

--- a/index.bs
+++ b/index.bs
@@ -923,7 +923,7 @@ requests to start a WebDriver session, it must:
 
 ## Reference ## {#data-types-reference}
 
-|Reference| represents reference to existing ECMAScript object in
+<dfn>RemoteReference</dfn> represents reference to existing ECMAScript object in
 [=object id map=].
 
 ```
@@ -934,6 +934,8 @@ RemoteReference = {
    *text => any,
 }
 ```
+
+Issue: Defined <dfn>deserialize a reference</dfn> steps.
 
 ## Value ## {#data-types-value}
 
@@ -987,13 +989,13 @@ BigIntValue = {
 
 To <dfn>serialize primitive value</dfn> given a |value|:
 
-1. Let |remote value| be |undefined|.
+1. Let |remote value| be undefined.
 
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
   <dl>
-    <dt>[=Type=](|value|) is Undefined
+    <dt>[=Type=](|value|) is undefined
     <dd>Let |remote value| be a map matching the <code>UndefinedValue</code>
     production in the [=local end definition=].
 
@@ -1047,10 +1049,10 @@ To <dfn>serialize primitive value</dfn> given a |value|:
 
 ### Local Value ### {#data-types-value-LocalValue}
 
-|Local Value| represents both primitive and non-primitive values which can be
+Represents both primitive and non-primitive values which can be
 deserialized to ECMAScript without reference to existing objects.
 
-Issue: Defined |deserialize local value| steps.
+Issue: Define <dfn>deserialize a local value</dfn> steps.
 
 ```
 LocalValue = {
@@ -1300,7 +1302,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 1. Let |remote value| be a result of [=serialize primitive value=]
    given a |value|.
 
-1. If |remote value| is not |undefined|, return |remote value|.
+1. If |remote value| is not undefined, return |remote value|.
 
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
@@ -3378,17 +3380,6 @@ function with given arguments in a given realm.
 
  <code>RealmInfo</code> can be either a realm or a browsing context.
 
-```
-ArgumentValue = (
-   RemoteReference //
-   LocalValue
-);
-```
-
-Issue: declare `RemoteValueArgument`.
-
-Issue: declare `LocalValueArgument`.
-
 <dl>
    <dt>Command Type</dt>
    <dd>
@@ -3400,26 +3391,17 @@ Issue: declare `LocalValueArgument`.
 
       ScriptCallFunctionParameters = {
         functionDeclaration: text;
-        arguments: [CallFunctionArgument];
+        arguments: [ArgumentValue];
         ?awaitPromise: bool;
         target: Target;
       }
 
-      CallFunctionArgument = (
-        RemoteValueArgument //
-        LocalValueArgument
+      ArgumentValue = (
+        RemoteReference //
+        LocalValue
       );
 
-      RemoteValueArgument = {
-        objectId: string;
-      };
-
-      LocalValueArgument = {
-        type: string;
-        value: any;
-      };
-
-      </pre>
+    </pre>
    </dd>
    <dt>Return Type</dt>
    <dd>
@@ -3442,6 +3424,10 @@ Issue: declare `LocalValueArgument`.
 
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
+The <dfn>deserialize an argument value</dfn>(|argumentValue|) is the following:
+1. If |argumentValue| is [=RemoteReference=], return [=deserialize a reference=](|argumentValue|).
+1. Return [=deserialize a local value=](|argumentValue|).
+
 The [=remote end steps=] with |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
@@ -3458,22 +3444,20 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |arguments declaration| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |JS arguments list| be an empty list.
+1. Let |deserialized arguments list| be an empty list.
 
-1. For each |argument declaration| of |arguments declaration|:
+1. For each |argument| of |arguments declaration|:
 
-  Issue: describe |deserialize CallFunctionArgument|.
+  1. Let |deserialized argument| be the result of
+     [=deserialize an argument value=](|argument|).
 
-  1. Let |JS arg| be the result of
-     |deserialize CallFunctionArgument|(|argument declaration|).
+  1. Append |deserialized argument| to the |deserialized arguments list|.
 
-  1. Append |JS arg| to the |JS arguments list|.
-
-1. Let |JS function object| be the result of
+1. Let |function object| be the result of
    [=InstantiateOrdinaryFunctionObject=](|function declaration|).
 
 1. Set |function evaluation status| to
-   [=EvaluateFunctionBody=](|JS function object|, |JS arguments list|).
+   [=EvaluateFunctionBody=](|function object|, |deserialized arguments list|).
 
 1. If |function evaluation status|.\[[Type]] is <code>normal</code>,
    |await promise| is true, and

--- a/index.bs
+++ b/index.bs
@@ -969,7 +969,7 @@ Represents primitive protocol values which can be serialized to /
 deserialized from ECMAScript without reference to existing objects.
 
 ```
-PrimitiveProtocolValue = {
+PrimitiveValue = {
   UndefinedValue //
   NullValue //
   StringValue //
@@ -1119,7 +1119,7 @@ deserialized to ECMAScript without reference to existing objects.
 
 ```
 LocalValue = {
-  PrimitiveProtocolValue //
+  PrimitiveValue //
   ArrayLocalValue //
   DateLocalValue //
   MapLocalValue //
@@ -1218,7 +1218,7 @@ To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
-1. If |local protocol value| matches the <code>PrimitiveProtocolValue</code> production, return
+1. If |local protocol value| matches the <code>PrimitiveValue</code> production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
 
 1. Let |type| be the value of the <code>type</code> field of |local protocol value|.
@@ -1239,7 +1239,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=] with
          given |value|.
 
-      1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
+      1. Return [=success=] with data <code>new [=Array=](|deserialized value list|)</code>.
 
     <dt>|type| is the string "<code>date</code>"
     <dd>
@@ -1270,7 +1270,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Let |deserialized value list| be a result of [=trying=] to
          [=deserialize value list=] with |value|.
 
-      1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
+      1. Return [=success=] with data <code>new [=Set=](|deserialized value list|)</code>.
 
     <dt>otherwise
     <dd>Return [=error=] with [=error code=] [=invalid argument=].
@@ -1323,7 +1323,7 @@ To get the <dfn>object id for an object</dfn> given a |session| and |object|:
 [=remote end definition=] and [=local end definition=]
 ```
 RemoteValue = {
-  PrimitiveProtocolValue //
+  PrimitiveValue //
   SymbolRemoteValue //
   ArrayRemoteValue //
   ObjectRemoteValue //

--- a/index.bs
+++ b/index.bs
@@ -91,6 +91,8 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: IsRegExp; url: sec-isregexp
     text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Object; url: sec-object-objects
+    text: InstantiateOrdinaryFunctionObject; url: #sec-runtime-semantics-instantiateordinaryfunctionobject
+    text: EvaluateFunctionBody; url: #sec-runtime-semantics-evaluatefunctionbody
     text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
     text: Set; url: sec-set
     text: ThisTimeValue; url: thistimevalue
@@ -3344,68 +3346,53 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
-1. Let |function declaration| be the value of the <code>functionDeclaration</code> field of |command
-   parameters|.
+1. [=Prepare to run script=] with |environment settings|.
 
-1. Let |arguments declaration| be the value of the <code>arguments</code> field of |command
-   parameters|.
+1. Let |function declaration| be the value of the
+   <code>functionDeclaration</code> field of |command parameters|.
 
-1. Let |await promise| be the value of the <code>awaitPromise</code> field of
-   |command parameters|, if present, or <code>true</code> otherwise.
+1. Let |arguments declaration| be the value of the <code>arguments</code> field
+   of |command parameters|.
 
-1. Let |options| be the [=default classic script fetch options=].
-
-1. Let |base URL| be the [=API base URL=] of |environment settings|.
-
-1. Let |function script| be the result of [=create a classic script=] with |function declaration|,
-   |environment settings|, |base URL|, and |options|.
-
-1. [=Prepare to run function script=] with |environment settings|.
-
-1. Set |function evaluation status| to [=ScriptEvaluation=](|function script|'s record).
-
-1. If |function evaluation status|.\[[Type]] is <code>throw</code>:
-
-  1. Let |exception details| be the result of [=get exception details=] given |function evaluation status|
-
-  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
-     production, with the <code>exceptionDetails</code> field set to |exception details|.
-
-1. Let |script arguments| be an empty list.
+1. Let |JS arguments list| be an empty list.
 
 1. For each |arg declaration| of |arguments declaration|:
 
-  Issue: describe |deserialize form CallFunctionArgument|.
+  Issue: describe |deserialize CallFunctionArgument|.
 
-  1. Let |script arg| be the result of |deserialize form CallFunctionArgument|(|arg declaration|).
+  1. Let |JS arg| be the result of
+     |deserialize CallFunctionArgument|(|arg declaration|).
 
-  1. Append |script arg| to the |script arguments|.
+  1. Append |JS arg| to the |JS arguments list|.
 
-Issue: describe |make function with arguments|.
+1. Let |JS function object| be the result of
+   [=InstantiateOrdinaryFunctionObject=](|function declaration|).
 
-1. Set |call function with arguments| to |make function with arguments| with |function| and |script arguments|.
+1. Set |function evaluation status| to
+   [=EvaluateFunctionBody=](|JS function object|, |JS arguments list|).
 
-1. Set |call evaluation status| to [=ScriptEvaluation=]|call function with arguments|.
+1. If |function evaluation status|.\[[Type]] is <code>normal</code>,
+   |await promise| is true, and
+   [=IsPromise=](|call evaluation status|.\[[Value]]):
 
-1. If |call evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
-   true, and [=IsPromise=](|call evaluation status|.\[[Value]]):
-
-   1. Set |call evaluation status| to <a spec=ECMASCRIPT>Await</a>(|call evaluation status|.\[[Value]]).
+   1. Set |function evaluation status| to
+      <a spec=ECMASCRIPT>Await</a>(|call evaluation status|.\[[Value]]).
 
 1. [=Clean up after running script=] with |environment settings|.
 
-1. If |call evaluation status|.\[[Type]] is <code>throw</code>:
+1. If |function evaluation status|.\[[Type]] is <code>throw</code>:
 
-  1. Let |exception details| be the result of [=get exception details=] given |call evaluation status|.
+  1. Let |exception details| be the result of [=get exception details=] given
+     |function evaluation status|.
 
   1. Return a new map matching the <code>ScriptEvaluateResultException</code>
-     production, with the <code>exceptionDetails</code> field set to |exception
-     details|.
+     production, with the <code>exceptionDetails</code> field set to
+     |exception details|.
 
-1. Assert: |call evaluation status|.\[[Type]] is <code>normal</code>.
+1. Assert: |function evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |call evaluation status|.\[[Value]].
+   |function evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
    production, with the <code>result</code> field set to |result|.

--- a/index.bs
+++ b/index.bs
@@ -1085,25 +1085,23 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
    of steps for which the associated condition is true:
 
   <dl>
-    <dt>|type| is undefined
-    <dd>Return [=error=] with [=error code=] [=invalid argument=].
 
-    <dt>|type| equals <code>UndefinedValue.type</code>
+    <dt>|type| is the string "<code>undefined</code>"
     <dd>Return [=success=] with data <code>undefined</code>.
 
-    <dt>|type| equals <code>NullValue.type</code>
+    <dt>|type| is the string "<code>null</code>"
     <dd>Return [=success=] with data <code>null</code>.
 
-    <dt>|type| equals <code>StringValue.type</code>
+    <dt>|type| is the string "<code>string</code>"
     <dd>Return [=success=] with data <code>[=new String=](|value|)</code>.
 
-    <dt>|type| equals <code>NumberValue.type</code>
+    <dt>|type| is the string "<code>number</code>"
     <dd>Return [=success=] with data <code>[=new Number=](|value|)</code>.
 
-    <dt>|type| equals <code>BooleanValue.type</code>
+    <dt>|type| is the string "<code>boolean</code>"
     <dd>Return [=success=] with data |value|.
 
-    <dt>|type| equals <code>BigIntValue.type</code>
+    <dt>|type| is the string "<code>bigint</code>"
     <dd>Return [=success=] with data <code>[=new BigInt=](|value|)</code>.
 
   </dl>
@@ -1229,24 +1227,24 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
   <dl>
 
-    <dt>|type| equals <code>ArrayLocalValue.type</code>
+    <dt>|type| is the string "<code>array</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to
          [=map serialized value list to deserialized value list=] with given |value|.
 
       1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
 
-    <dt>|type| equals <code>DateLocalValue.type</code>
+    <dt>|type| is the string "<code>date</code>"
     <dd>Return [=success=] with data <code>new [=Date=](|value|)</code>.
 
-    <dt>|type| equals <code>MapLocalValue.type</code>
+    <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=]
          [=map serialized key-value list to deserialized key-value list=] with given |value|.
 
       1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
 
-    <dt>|type| equals <code>ObjectLocalValue.type</code>
+    <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=]
          [=map serialized key-value list to deserialized key-value list=] with given |value|.
@@ -1254,10 +1252,10 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Return [=success=] with data
          <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.
 
-    <dt>|type| equals <code>RegExpLocalValue.type</code>
+    <dt>|type| is the string "<code>regexp</code>"
     <dd>Return [=success=] with data <code>new [=RegExp=](|value|)</code>.
 
-    <dt>|type| equals <code>SetLocalValue.type</code>
+    <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=]
          [=map serialized value list to deserialized value list=] with given |value|.

--- a/index.bs
+++ b/index.bs
@@ -82,6 +82,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: CreateListFromArrayLike; url: sec-createlistfromarraylike
     text: CreateMapIterator; url: sec-createmapiterator
     text: CreateSetIterator; url: sec-createsetiterator
+    text: Date.ToDateString; url: sec-todatestring
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
     text: HasProperty; url: sec-hasproperty
@@ -90,13 +91,17 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: IsPromise; url: sec-ispromise
     text: IsRegExp; url: sec-isregexp
     text: LengthOfArrayLike; url: sec-lengthofarraylike
+    text: new BigInt; url: sec-bigint-constructor
+    text: new Number; url: sec-number-constructor
+    text: new String; url: sec-string-constructor
     text: Object; url: sec-object-objects
+    text: Object.fromEntries; url: sec-object.fromentries
     text: IsCallable; url: #sec-iscallable
     text: Call; url: #sec-call
     text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
     text: Set; url: sec-set
+    text: RegExp; url: sec-regexp-pattern-flags
     text: ThisTimeValue; url: thistimevalue
-    text: ToDateString; url: sec-todatestring
     text: ToString; url: sec-tostring
     text: Type; url: sec-ecmascript-data-types-and-values
     text: current realm record; url: current-realm
@@ -926,6 +931,11 @@ requests to start a WebDriver session, it must:
 <dfn>RemoteReference</dfn> represents reference to existing ECMAScript object in
 [=object id map=].
 
+A [=BiDi session=] has an <dfn>object id map</dfn>. This is a weak map
+from objects to their corresponding id.
+
+Issue: Should this be explicitly per realm?
+
 ```
 ObjectId = text;
 
@@ -935,7 +945,19 @@ RemoteReference = {
 }
 ```
 
-Issue: Defined <dfn>deserialize a reference</dfn> steps.
+<div algorithm>
+To <dfn>deserialize a remote reference</dfn> given a |remote reference|:
+
+1. Let |object id| be the value of the <code>objectId</code> field of |remote reference|.
+
+1. For each |object| → |id value| of [=object id map=]:
+
+  1. If |id value| is equal to |object id|, return [=success=] with data
+     |object|
+
+1. Return [=error=] with [=error code=] [=invalid argument=].
+
+</div>
 
 ## Protocol Value ## {#data-types-protocolValue}
 
@@ -945,7 +967,7 @@ Represents primitive protocol values which can be serialized to /
 deserialized from ECMAScript without reference to existing objects.
 
 ```
-PrimitiveValue = {
+PrimitiveProtocolValue = {
   UndefinedValue //
   NullValue //
   StringValue //
@@ -1047,44 +1069,75 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
 
 </div>
 
+<div algorithm>
+
+To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol value|:
+
+1. Let |type| be the value of the <code>type</code> field of |primitive protocol value|.
+
+1. Let |value| be undefined.
+
+1. If |primitive protocol value| has field <code>value</code>:
+   1. Let |value| be the value of the <code>value</code> field of |primitive protocol value|.
+
+1. In the following list of conditions and associated steps, run the first set
+   of steps for which the associated condition is true:
+
+  <dl>
+    <dt>|type| is undefined
+    <dd>Return [=error=] with [=error code=] [=invalid argument=].
+
+    <dt>|type| equals <code>UndefinedValue.type</code>
+    <dd>Return [=success=] with data <code>undefined</code>.
+
+    <dt>|type| equals <code>NullValue.type</code>
+    <dd>Return [=success=] with data <code>null</code>.
+
+    <dt>|type| equals <code>StringValue.type</code>
+    <dd>Return [=success=] with data <code>[=new String=](|value|)</code>.
+
+    <dt>|type| equals <code>NumberValue.type</code>
+    <dd>Return [=success=] with data <code>[=new Number=](|value|)</code>.
+
+    <dt>|type| equals <code>BooleanValue.type</code>
+    <dd>Return [=success=] with data |value|.
+
+    <dt>|type| equals <code>BigIntValue.type</code>
+    <dd>Return [=success=] with data <code>[=new BigInt=](|value|)</code>.
+
+  </dl>
+
+1. Return [=error=] with [=error code=] [=invalid argument=]
+
+</div>
+
 ### Local Value ### {#data-types-protocolValue-LocalValue}
 
 Represents both primitive and non-primitive protocol values which can be
 deserialized to ECMAScript without reference to existing objects.
 
-Issue: Define <dfn>deserialize a local value</dfn> steps.
 
 ```
 LocalValue = {
   PrimitiveProtocolValue //
   ArrayLocalValue //
-  ObjectLocalValue //
-  MapLocalValue //
-  SetLocalValue //
-  RegExpLocalValue //
   DateLocalValue //
+  MapLocalValue //
+  ObjectLocalValue //
+  RegExpLocalValue //
+  SetLocalValue //
 }
 
 ListLocalValue = [*LocalValue];
-
-RegExpLocalValue = {
-  type: "regexp",
-  value: text
-}
-
-DateLocalValue = {
-  type: "date",
-  value: text
-}
 
 ArrayLocalValue = {
   type: "array",
   value: ListLocalValue,
 }
 
-ObjectLocalValue = {
-  type: "object",
-  value: MappingLocalValue,
+DateLocalValue = {
+  type: "date",
+  value: text
 }
 
 MappingLocalValue = [*[(LocalValue / text), LocalValue]];
@@ -1094,11 +1147,142 @@ MapLocalValue = {
   value: MappingLocalValue,
 }
 
+ObjectLocalValue = {
+  type: "object",
+  value: MappingLocalValue,
+}
+
+RegExpLocalValue = {
+  type: "regexp",
+  value: text
+}
+
 SetLocalValue = {
   type: "set",
   value: ListLocalValue
 }
 ```
+
+<div algorithm>
+
+To <dfn>map serialized key-value list to deserialized key-value list</dfn> given a
+|serialized key-value list|:
+
+1. Let |deserialized key-value list| be a new list.
+
+1. For each |serialized key-value| in the |serialized key-value list|:
+
+   1. If |serialized key-value| has not 2 elements,
+      return [=error=] with [=error code=] [=invalid argument=].
+
+   1. Let |serialized key| be the first element of |serialized key-value|.
+
+   1. If |serialized key| is a <code>string</code>,
+      let |deserialized key| be |serialized key|.
+
+   1. Otherwise let |deserialized key| be result of [=try=] to [=deserialize a local value=] with
+      given |serialized key|.
+
+   1. If |deserialized key| is [=error=], return |deserialized key|.
+
+   1. Let |serialized value| be the second element of |serialized key-value|.
+
+   1. Let |deserialized value| be result of [=try=] to [=deserialize a local value=] with given
+      |serialized value|.
+
+   1. If |deserialized value| is [=error=], return |deserialized value|.
+
+   1. Append a <code>new [=Array=](|deserialized key|, |deserialized value|)</code>
+      to |deserialized key-value list|.
+
+1. Return [=success=] with data |deserialized key-value list|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>map serialized value list to deserialized value list</dfn> given a |serialized value list|:
+
+1. Let |deserialized values| be a new list.
+
+1. For each |serialized value| in the |serialized value list|:
+
+   1. Let |deserialized value| be result of [=try=] to [=deserialize a local value=] with given
+      |serialized value|.
+
+   1. If |deserialized value| is [=error=], return |deserialized value|.
+
+   1. Append |deserialized value| to |deserialized values|;
+
+1. Return [=success=] with data |deserialized values|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>deserialize a local value</dfn> given a |local protocol value|:
+
+1. If is <code>PrimitiveProtocolValue</code>, return [=deserialize primitive protocol value=]
+   of |local protocol value|.
+
+1. Let |type| be the value of the <code>type</code> field of |local protocol value|.
+
+1. Let |value| be the value of the <code>value</code> field of |local protocol value|.
+
+1. In the following list of conditions and associated steps, run the first set of steps for which
+   the associated condition is true:
+
+  <dl>
+    <dt>|type| is undefined
+    <dd>Return [=error=] with [=error code=] [=invalid argument=].
+
+    <dt>|type| equals <code>ArrayLocalValue.type</code>
+    <dd>
+      1. Let |deserialized value list| be a result of [=try=] to
+         [=map serialized value list to deserialized value list=] with given |value|.
+
+      1. If |deserialized value| is [=error=], return |deserialized value|.
+
+      1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
+
+    <dt>|type| equals <code>DateLocalValue.type</code>
+    <dd>Return [=success=] with data <code>new [=Date=](|value|)</code>.
+
+    <dt>|type| equals <code>MapLocalValue.type</code>
+    <dd>
+      1. Let |deserialized key-value list| be a result of [=try=]
+         [=map serialized key-value list to deserialized key-value list=] with given |value|.
+
+      1. If |deserialized key-value list| is [=error=], return |deserialized key-value list|.
+
+      1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
+
+    <dt>|type| equals <code>ObjectLocalValue.type</code>
+    <dd>
+      1. Let |deserialized key-value list| be a result of [=try=]
+         [=map serialized key-value list to deserialized key-value list=] with given |value|.
+
+      1. If |deserialized key-value list| is [=error=], return |deserialized key-value list|.
+
+      1. Return [=success=] with data
+         <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.
+
+    <dt>|type| equals <code>RegExpLocalValue.type</code>
+    <dd>Return [=success=] with data <code>new [=RegExp=](|value|)</code>.
+
+    <dt>|type| equals <code>SetLocalValue.type</code>
+    <dd>
+      1. Let |deserialized value list| be a result of [=try=]
+         [=map serialized value list to deserialized value list=] with given |value|.
+
+      1. If |deserialized value| is [=error=], return |deserialized value|.
+
+      1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
+  </dl>
+
+1. Return [=error=] with [=error code=] [=invalid argument=]
+
+</div>
 
 ### Remote Value ### {#data-types-protocolValue-RemoteValue}
 
@@ -1124,11 +1308,6 @@ Note: mirror objects do not keep the original object alive in the runtime. If an
 object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
-A [=BiDi session=] has an <dfn>object id map</dfn>. This is a weak map
-from objects to their corresponding id.
-
-Issue: Should this be explicitly per realm?
-
 <div algorithm>
 To get the <dfn>object id for an object</dfn> given a |session| and |object|:
 
@@ -1146,21 +1325,6 @@ To get the <dfn>object id for an object</dfn> given a |session| and |object|:
    id map=].
 
 </div>
-
-<!--
-<div algorithm>
-To get the <dfn>object for an object id</dfn> given an |object id|:
-
-1. For each |object| → |id value| of [=object id map=]:
-
-  1. If |id value| is equal to |object id|, return [=success=] with data
-     |object|
-
-1. Return [=error=] with [=error code=] [=no such element=]
-
-Issue: This error code isn't right.
-</div>
--->
 
 [=remote end definition=] and [=local end definition=]
 ```
@@ -1345,7 +1509,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>
-      1. Let |serialized| be [=ToDateString=]([=thisTimeValue=](|value|)).
+      1. Let |serialized| be [=Date.ToDateString=]([=thisTimeValue=](|value|)).
 
       1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
@@ -1432,11 +1596,9 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
           1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
 
-
             1. Set |serialized|["<code>localName</code>"] to [=Get=](|value|, "localName").
 
             1. Set |serialized|["<code>namespaceURI</code>"] to [=Get=](|value|, "namespaceURI")
-
 
           1. Let |child node count| be the [=list/size=] of |serialized|'s [=children=].
 
@@ -3426,29 +3588,39 @@ function with given arguments in a given realm.
 
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
-The <dfn>deserialize an argument value</dfn>(|argumentValue|) is the following:
+<div algorithm>
+To <dfn>deserialize an argument value</dfn> given an |serialized argument|:
 
-1. If |argumentValue| is [=RemoteReference=], return [=deserialize a reference=](|argumentValue|).
+1. If |serialized argument| is [=RemoteReference=], return [=deserialize a remote reference=] of
+   |serialized argument|.
 
-1. Return [=deserialize a local value=](|argumentValue|).
+1. Return [=deserialize a local value=] of |serialized argument|.
 
-The <dfn>deserialize arguments</dfn>(|arguments|) is the following:
+</div>
 
-1. Let |deserialized arguments| be an empty list.
+<div algorithm>
 
-1. For each |argument| of |arguments declaration|:
+To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of
-     [=deserialize an argument value=](|argument|).
+1. Let |deserialized arguments list| be an empty list.
 
-  1. Append |deserialized argument| to the |deserialized arguments|.
+1. For each |serialized argument| of |serialized arguments list|:
 
-1. Return |deserialized arguments|.
+  1. Let |deserialized argument| be the result of [=try=] to [=deserialize an argument value=] with
+     given |serialized argument|.
+
+  1. If |deserialized argument| is [=error=], return |deserialized argument|.
+
+  1. Append |deserialized argument| to the |deserialized arguments list|.
+
+1. Return [=success=] with data |deserialized arguments list|.
 
 Issue: Clarify behaviour in case of deserialization failed.
+</div>
 
-The steps to <dfn>evaluate function body</dfn> with a given |function declaration|,
-|environment settings|, |base URL|, and |options| are the following:
+<div algorithm>
+To <dfn>evaluate function body</dfn> with a given |function declaration|,
+|environment settings|, |base URL|, and |options|:
 
 Note: the |function declaration| is parenthesized and evaluated.
 
@@ -3464,6 +3636,8 @@ Note: the |function declaration| is parenthesized and evaluated.
 1. Return |function body evaluation status|.
 
 Issue: Define behavior in case of exception during script evaluation.
+</div>
+
 
 The [=remote end steps=] with |command parameters| are:
 
@@ -3473,11 +3647,13 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
-1. Let |arguments declaration| be the value of the <code>arguments</code> field
+1. Let |command arguments| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |deserialized arguments| be the result of
-   [=deserialize arguments=](|arguments declaration|)
+1. Let |deserialized arguments| be the result of [=try=] to [=deserialize arguments=] with given
+   |command arguments|.
+
+1. If |deserialized arguments| is [=error=], return |deserialized arguments|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
@@ -3490,7 +3666,7 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given
      |function body evaluation status|.
 
-  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+  1. Return a new map matching the <code>ScriptCallFunctionResultException</code>
      production, with the <code>exceptionDetails</code> field set to
      |exception details|.
 
@@ -3518,7 +3694,7 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given
      |evaluation status|.
 
-  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+  1. Return a new map matching the <code>ScriptCallFunctionResultException</code>
      production, with the <code>exceptionDetails</code> field set to
      |exception details|.
 
@@ -3527,7 +3703,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]].
 
-1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
+1. Return a new map matching the <code>ScriptCallFunctionResultSuccess</code>
    production, with the <code>result</code> field set to |result|.
 
 #### The script.getRealms Command ####  {#command-script-getRealms}

--- a/index.bs
+++ b/index.bs
@@ -1639,7 +1639,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
           1. Set |serialized|["<code>nodeType</code>"] to [=Get=](|value|, "nodeType").
 
-          1. Set |serialized|["<code>NodeRemoteValue</code>"] to [=Get=](|value|, "nodeValue")
+          1. Set |serialized|["<code>nodeValue</code>"] to [=Get=](|value|, "nodeValue")
 
           1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
 
@@ -1741,6 +1741,17 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
 Issue: Does it make sense to use the same depth parameter for nodes and objects
 in general?
+
+Issue: consider deprecate |node details| in favour of |max depth|.
+
+Issue: |children| and |child nodes| are different things. Either <code>childNodeCount</code> should
+reference to <code>childNodes</code>, or it should be renamed to <code>childrenCount</code>.
+
+Issue: <code>nodeValue</code> can be null. Omit the field in such a case, or adjust type to allow
+null value.
+
+Issue: <code>shadowRoot</code> field is optional. Omit it in case of |shadow root| is null, or
+remove optional flag from the field.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2839,7 +2839,7 @@ relating to script realms and execution.
 
 ScriptCommand = (
   ScriptEvaluateCommand //
-  ScriptInvokeCommand //
+  ScriptCallFunctionCommand //
   ScriptGetRealmsCommand
 )
 
@@ -2851,7 +2851,7 @@ ScriptCommand = (
 
 ScriptResult = (
   ScriptEvaluateResult //
-  ScriptInvokeResult //
+  ScriptCallFunctionResult //
   ScriptGetRealmsResult
 )
 
@@ -3272,9 +3272,9 @@ The [=remote end steps=] with |command parameters| are:
 1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
    production, with the <code>result</code> field set to |result|.
 
-#### The script.invoke Command ####  {#command-script-invoke}
+#### The script.callFunction Command ####  {#command-script-callFunction}
 
-The <dfn export for=commands>script.invoke</dfn> command invokes a provided
+The <dfn export for=commands>script.callFunction</dfn> command calls a provided
 function with given arguments in a given realm.
 
  <code>RealmInfo</code> can be either a realm or a browsing context.
@@ -3287,29 +3287,27 @@ Issue: declare `LocalValueArgument`.
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      ScriptInvokeCommand = {
-        method: "script.invoke",
-        params: ScriptInvokeParameters
+      ScriptCallFunctionCommand = {
+        method: "script.callFunction",
+        params: ScriptCallFunctionParameters
       }
 
-      ScriptInvokeParameters = {
+      ScriptCallFunctionParameters = {
         functionDeclaration: text;
-        arguments: [InvokeArgument];
+        arguments: [CallFunctionArgument];
         ?awaitPromise: bool;
         target: Target;
       }
 
-      InvokeArgument = (
+      CallFunctionArgument = (
         RemoteValueArgument //
         LocalValueArgument
       );
 
-      // TODO: declare.
       RemoteValueArgument = {
         objectId: string;
       };
 
-      // TODO: declare.
       LocalValueArgument = {
         type: string;
         value: any;
@@ -3320,16 +3318,16 @@ Issue: declare `LocalValueArgument`.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      ScriptInvokeResult = (
-        ScriptInvokeResultSuccess //
-        ScriptInvokeResultException
+      ScriptCallFunctionResult = (
+        ScriptCallFunctionResultSuccess //
+        ScriptCallFunctionResultException
       )
 
-      ScriptInvokeResultSuccess = {
+      ScriptCallFunctionResultSuccess = {
          result: RemoteValue
       }
 
-      ScriptInvokeResultException = {
+      ScriptCallFunctionResultException = {
         exceptionDetails: ExceptionDetails
       }
     </pre>
@@ -3377,9 +3375,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. For each |arg declaration| of |arguments declaration|:
 
-  Issue: describe |deserialize form InvokeArgument|.
+  Issue: describe |deserialize form CallFunctionArgument|.
 
-  1. Let |script arg| be the result of |deserialize form InvokeArgument|(|arg declaration|).
+  1. Let |script arg| be the result of |deserialize form CallFunctionArgument|(|arg declaration|).
 
   1. Append |script arg| to the |script arguments|.
 

--- a/index.bs
+++ b/index.bs
@@ -1226,6 +1226,8 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 1. In the following list of conditions and associated steps, run the first set of steps for which
    the associated condition is true:
 
+  Issue: TODO: define via `script.evaluate` to provide proper parse or runtime error handling.
+
   <dl>
 
     <dt>|type| is the string "<code>array</code>"

--- a/index.bs
+++ b/index.bs
@@ -1372,13 +1372,13 @@ SymbolRemoteValue = {
 ArrayValue = {
   type: "array",
   objectId: ObjectId,
-  value?: ListRemoteValue,
+  ?value: ListRemoteValue,
 }
 
 ObjectValue = {
   type: "object",
   objectId: ObjectId,
-  value?: MappingRemoteValue,
+  ?value: MappingRemoteValue,
 }
 
 FunctionRemoteValue = {
@@ -1441,18 +1441,18 @@ ArrayBufferRemoteValue = {
 NodeRemoteValue = {
   type: "node",
   objectId: ObjectId,
-  value?: NodeProperties,
+  ?value: NodeProperties,
 }
 
 NodeProperties = {
   nodeType: uint,
   nodeValue: text,
-  localName?: text,
-  namespaceURI?: text,
+  ?localName: text,
+  ?namespaceURI: text,
   childNodeCount: uint,
-  children?: [*NodeRemoteValue],
-  attributes?: {*text => text},
-  shadowRoot?: NodeRemoteValue / null,
+  ?children: [*NodeRemoteValue],
+  ?attributes: {*text => text},
+  ?shadowRoot: NodeRemoteValue / null,
 }
 
 WindowProxyRemoteValue = {
@@ -3546,8 +3546,6 @@ The [=remote end steps=] with |command parameters| are:
 
 #### The script.callFunction Command ####  {#command-script-callFunction}
 
-Issue: Add `this` parameter.
-
 The <dfn export for=commands>script.callFunction</dfn> command calls a provided
 function with given arguments in a given realm.
 
@@ -3565,6 +3563,7 @@ function with given arguments in a given realm.
       ScriptCallFunctionParameters = {
         functionDeclaration: text;
         arguments: [ArgumentValue];
+        ?this: ArgumentValue;
         ?awaitPromise: bool;
         target: Target;
       }
@@ -3598,12 +3597,12 @@ function with given arguments in a given realm.
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 <div algorithm>
-To <dfn>deserialize an argument value</dfn> given an |serialized argument|:
+To <dfn>deserialize a parameter value</dfn> given an |serialized value|:
 
-1. If |serialized argument| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] of |serialized argument|.
+1. If |serialized value| matches the [=RemoteReference=] production, return
+   [=deserialize remote reference=] of |serialized value|.
 
-1. Return [=deserialize local value=] of |serialized argument|.
+1. Return [=deserialize local value=] of |serialized value|.
 
 </div>
 
@@ -3615,7 +3614,7 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
 1. For each |serialized argument| of |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize an argument value=]
+  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize a parameter value=]
      with |serialized argument|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
@@ -3661,6 +3660,12 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |deserialized arguments| be the result of [=trying=] to [=deserialize arguments=] with
    |command arguments|.
 
+1. Let |this parameter| be the value of the <code>this</code> field
+   of |command parameters|.
+
+1. Let |this object| be the result of [=trying=] to [=deserialize a parameter value=]
+   with |this parameter|.
+
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
@@ -3678,11 +3683,11 @@ The [=remote end steps=] with |command parameters| are:
 
 1. [=Prepare to run script=] with |environment settings|.
 
-1. Set |evaluation status| to [=Call=](|function object|, |null|, |deserialized arguments|).
+1. Set |evaluation status| to
+   [=Call=](|function object|, |this object|, ...|deserialized arguments|).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>,
-   |await promise| is true, and
-   [=IsPromise=](|call evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is true,
+   and [=IsPromise=](|call evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to
       <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).

--- a/index.bs
+++ b/index.bs
@@ -83,6 +83,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: CreateListFromArrayLike; url: sec-createlistfromarraylike
     text: CreateMapIterator; url: sec-createmapiterator
     text: CreateSetIterator; url: sec-createsetiterator
+    text: Date Time String Format; url: sec-date-time-string-format
     text: Date.ToDateString; url: sec-todatestring
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
@@ -1235,7 +1236,10 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
 
     <dt>|type| is the string "<code>date</code>"
-    <dd>Return [=success=] with data <code>new [=Date=](|value|)</code>.
+    <dd>
+      1. If |value| matches [=Date Time String Format=], return [=success=] with data <code>new [=Date=](|value|)</code>.
+
+      1. Otherwise return [=error=] with [=error code=] [=invalid argument=].
 
     <dt>|type| is the string "<code>map</code>"
     <dd>
@@ -1261,9 +1265,10 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
          [=map serialized value list to deserialized value list=] with given |value|.
 
       1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
-  </dl>
 
-1. Return [=error=] with [=error code=] [=invalid argument=]
+    <dt>otherwise
+    <dd>Return [=error=] with [=error code=] [=invalid argument=].
+  </dl>
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -62,6 +62,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: set a property; url: dfn-set-a-property
     text: success; url: dfn-success
     text: try; url: dfn-try
+    text: trying; url: dfn-try
     text: unknown command; url: dfn-unknown-command
     text: unknown error; url: dfn-unknown-error
     text: web element reference; url: dfn-web-element-reference
@@ -1180,17 +1181,13 @@ To <dfn>map serialized key-value list to deserialized key-value list</dfn> given
    1. If |serialized key| is a <code>string</code>,
       let |deserialized key| be |serialized key|.
 
-   1. Otherwise let |deserialized key| be result of [=try=] to [=deserialize a local value=] with
-      given |serialized key|.
-
-   1. If |deserialized key| is [=error=], return |deserialized key|.
+   1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize a local value=]
+      with given |serialized key|.
 
    1. Let |serialized value| be the second element of |serialized key-value|.
 
-   1. Let |deserialized value| be result of [=try=] to [=deserialize a local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize a local value=] with given
       |serialized value|.
-
-   1. If |deserialized value| is [=error=], return |deserialized value|.
 
    1. Append a <code>new [=Array=](|deserialized key|, |deserialized value|)</code>
       to |deserialized key-value list|.
@@ -1207,10 +1204,8 @@ To <dfn>map serialized value list to deserialized value list</dfn> given a |seri
 
 1. For each |serialized value| in the |serialized value list|:
 
-   1. Let |deserialized value| be result of [=try=] to [=deserialize a local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize a local value=] with given
       |serialized value|.
-
-   1. If |deserialized value| is [=error=], return |deserialized value|.
 
    1. Append |deserialized value| to |deserialized values|;
 
@@ -1238,10 +1233,8 @@ To <dfn>deserialize a local value</dfn> given a |local protocol value|:
 
     <dt>|type| equals <code>ArrayLocalValue.type</code>
     <dd>
-      1. Let |deserialized value list| be a result of [=try=] to
+      1. Let |deserialized value list| be a result of [=trying=] to
          [=map serialized value list to deserialized value list=] with given |value|.
-
-      1. If |deserialized value| is [=error=], return |deserialized value|.
 
       1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
 
@@ -1250,19 +1243,15 @@ To <dfn>deserialize a local value</dfn> given a |local protocol value|:
 
     <dt>|type| equals <code>MapLocalValue.type</code>
     <dd>
-      1. Let |deserialized key-value list| be a result of [=try=]
+      1. Let |deserialized key-value list| be a result of [=trying=]
          [=map serialized key-value list to deserialized key-value list=] with given |value|.
-
-      1. If |deserialized key-value list| is [=error=], return |deserialized key-value list|.
 
       1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
 
     <dt>|type| equals <code>ObjectLocalValue.type</code>
     <dd>
-      1. Let |deserialized key-value list| be a result of [=try=]
+      1. Let |deserialized key-value list| be a result of [=trying=]
          [=map serialized key-value list to deserialized key-value list=] with given |value|.
-
-      1. If |deserialized key-value list| is [=error=], return |deserialized key-value list|.
 
       1. Return [=success=] with data
          <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.
@@ -1272,10 +1261,8 @@ To <dfn>deserialize a local value</dfn> given a |local protocol value|:
 
     <dt>|type| equals <code>SetLocalValue.type</code>
     <dd>
-      1. Let |deserialized value list| be a result of [=try=]
+      1. Let |deserialized value list| be a result of [=trying=]
          [=map serialized value list to deserialized value list=] with given |value|.
-
-      1. If |deserialized value| is [=error=], return |deserialized value|.
 
       1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
   </dl>
@@ -3606,10 +3593,8 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
 1. For each |serialized argument| of |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of [=try=] to [=deserialize an argument value=] with
-     given |serialized argument|.
-
-  1. If |deserialized argument| is [=error=], return |deserialized argument|.
+  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize an argument value=]
+     with given |serialized argument|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -3650,10 +3635,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |command arguments| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |deserialized arguments| be the result of [=try=] to [=deserialize arguments=] with given
+1. Let |deserialized arguments| be the result of [=trying=] to [=deserialize arguments=] with given
    |command arguments|.
-
-1. If |deserialized arguments| is [=error=], return |deserialized arguments|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -947,7 +947,7 @@ RemoteReference = {
 ```
 
 <div algorithm>
-To <dfn>deserialize a remote reference</dfn> given a |remote reference|:
+To <dfn>deserialize remote reference</dfn> given a |remote reference|:
 
 1. Let |object id| be the value of the <code>objectId</code> field of |remote reference|.
 
@@ -1181,12 +1181,12 @@ To <dfn>map serialized key-value list to deserialized key-value list</dfn> given
    1. If |serialized key| is a <code>string</code>,
       let |deserialized key| be |serialized key|.
 
-   1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize a local value=]
+   1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize local value=]
       with given |serialized key|.
 
    1. Let |serialized value| be the second element of |serialized key-value|.
 
-   1. Let |deserialized value| be result of [=trying=] to [=deserialize a local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with given
       |serialized value|.
 
    1. Append a <code>new [=Array=](|deserialized key|, |deserialized value|)</code>
@@ -1204,7 +1204,7 @@ To <dfn>map serialized value list to deserialized value list</dfn> given a |seri
 
 1. For each |serialized value| in the |serialized value list|:
 
-   1. Let |deserialized value| be result of [=trying=] to [=deserialize a local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with given
       |serialized value|.
 
    1. Append |deserialized value| to |deserialized values|;
@@ -1215,10 +1215,10 @@ To <dfn>map serialized value list to deserialized value list</dfn> given a |seri
 
 <div algorithm>
 
-To <dfn>deserialize a local value</dfn> given a |local protocol value|:
+To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
-1. If is <code>PrimitiveProtocolValue</code>, return [=deserialize primitive protocol value=]
-   of |local protocol value|.
+1. If |local protocol value| matches the <code>PrimitiveProtocolValue</code> production, return
+   [=deserialize primitive protocol value=] with |local protocol value|.
 
 1. Let |type| be the value of the <code>type</code> field of |local protocol value|.
 
@@ -1228,8 +1228,6 @@ To <dfn>deserialize a local value</dfn> given a |local protocol value|:
    the associated condition is true:
 
   <dl>
-    <dt>|type| is undefined
-    <dd>Return [=error=] with [=error code=] [=invalid argument=].
 
     <dt>|type| equals <code>ArrayLocalValue.type</code>
     <dd>
@@ -3578,10 +3576,10 @@ Issue: TODO: Add timeout argument as described in the script.evaluate.
 <div algorithm>
 To <dfn>deserialize an argument value</dfn> given an |serialized argument|:
 
-1. If |serialized argument| is [=RemoteReference=], return [=deserialize a remote reference=] of
-   |serialized argument|.
+1. If |serialized argument| matches the [=RemoteReference=] production, return
+   [=deserialize remote reference=] of |serialized argument|.
 
-1. Return [=deserialize a local value=] of |serialized argument|.
+1. Return [=deserialize local value=] of |serialized argument|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1197,7 +1197,7 @@ To <dfn>deserialize key-value list</dfn> given a
 
 <div algorithm>
 
-To <dfn>map serialized value list to deserialized value list</dfn> given a |serialized value list|:
+To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 1. Let |deserialized values| be a new list.
 
@@ -1230,8 +1230,8 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
     <dt>|type| is the string "<code>array</code>"
     <dd>
-      1. Let |deserialized value list| be a result of [=trying=] to
-         [=map serialized value list to deserialized value list=] with given |value|.
+      1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=] with
+         given |value|.
 
       1. Return [=success=] with data <code>new [=Array=](|deserialized values|)</code>.
 
@@ -1261,8 +1261,8 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
     <dt>|type| is the string "<code>set</code>"
     <dd>
-      1. Let |deserialized value list| be a result of [=trying=]
-         [=map serialized value list to deserialized value list=] with given |value|.
+      1. Let |deserialized value list| be a result of [=trying=] to
+         [=deserialize value list=] with given |value|.
 
       1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -951,6 +951,8 @@ RemoteReference = {
 }
 ```
 
+Issue: handle "stale object reference" case.
+
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given a |remote reference|:
 
@@ -1086,28 +1088,31 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
    1. Let |value| be the value of the <code>value</code> field of |primitive protocol value|.
 
 1. In the following list of conditions and associated steps, run the first set of steps for which
-   the associated condition is true. If this throws exception, return [=error=] with [=error code=]
-   [=invalid argument=]:
+   the associated condition is true:
 
   <dl>
 
     <dt>|type| is the string "<code>undefined</code>"
-    <dd>Return [=success=] with data set to [=undefined=].
+    <dd>Return [=success=] with data [=undefined=].
 
     <dt>|type| is the string "<code>null</code>"
-    <dd>Return [=success=] with data set to [=null=].
+    <dd>Return [=success=] with data [=null=].
 
     <dt>|type| is the string "<code>string</code>"
-    <dd>Return [=success=] with data set to a new [=String=] with |value|.
+    <dd>Return [=success=] with data [=String=](|value|).
 
     <dt>|type| is the string "<code>number</code>"
-    <dd>Return [=success=] with data set to a new [=Number=] with |value|.
+    <dd>Return [=success=] with data [=Number=](|value|).
 
     <dt>|type| is the string "<code>boolean</code>"
-    <dd>Return [=success=] with data set to a [=boolean=] |value|.
+    <dd>Return [=success=] with data |value|.
 
     <dt>|type| is the string "<code>bigint</code>"
-    <dd>Return [=success=] with data set to a new [=BigInt=] with |value|.
+    <dd>
+      1. Let |bigint_result| be [=BigInt=](|value|). If this throws exception, return [=error=]
+         with [=error code=] [=invalid argument=]
+
+      1. Return [=success=] with data |bigint_result|.
 
   </dl>
 
@@ -1192,10 +1197,10 @@ To <dfn>deserialize key-value list</dfn> given a |serialized key-value list|:
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
       |serialized value|.
 
-   1. Append a <code>new [=Array=](|deserialized key|, |deserialized value|)</code>
-      to |deserialized key-value list|.
+   1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
+      |deserialized key-value list|.
 
-1. Return [=success=] with data |deserialized key-value list|.
+1. Return [=success=] with data [=CreateArrayFromList=](|deserialized key-value list|).
 
 </div>
 
@@ -1232,8 +1237,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
    if no such a field.
 
 1. In the following list of conditions and associated steps, run the first set of steps for which
-   the associated condition is true. If this throws exception, return [=error=] with [=error code=]
-   [=invalid argument=]:
+   the associated condition is true:
 
   <dl>
 
@@ -1242,32 +1246,32 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=] with
          given |value|.
 
-      1. Return [=success=] with data set to a new [=Array=] object constructed with
-         |deserialized value list| as <code>values</code>.
+      1. Return [=success=] with data [=CreateArrayFromList=](|deserialized value list|).
 
     <dt>|type| is the string "<code>date</code>"
     <dd>
       1. If |value| does not match [=Date Time String Format=], return [=error=] with
          [=error code=] [=invalid argument=].
 
-      1. Return [=success=] with data set to a result of [=Date.parse=] with |value| as
-         <code>string</code>.
+      1. Return [=success=] with data [=Date.parse=](|value|).
 
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
          [=deserialize key-value list=] with |value|.
 
-      1. Return [=success=] with data set to a new [=Map=] object constructed with
-         |deserialized key-value list| as <code>iterable</code>.
+      1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
+
+      1. Return [=success=] with data [=Map=](|iterable|).
 
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
          [=deserialize key-value list=] with |value|.
 
-      1. Return [=success=] with data set to a result of [=Object.fromEntries=] with
-         |deserialized key-value list| as <code>iterable</code>.
+      1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
+
+      1. Return [=success=] with data [=Object.fromEntries=](|iterable|).
 
     <dt>|type| is the string "<code>regexp</code>"
     <dd>
@@ -1276,16 +1280,19 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Let |flags| be the value of the <code>flags</code> field of |local protocol value| or
          undefined if no such a field.
 
-      1. Return [=success=] with data set to a new [=RegExp=] object constructed with |pattern| and
-         |flags|.
+      1. Let |regex_result| be [=Regexp=](|pattern|, |flags|). If this throws exception, return [=error=]
+         with [=error code=] [=invalid argument=].
+
+      1. Return [=success=] with data |regex_result|.
 
     <dt>|type| is the string "<code>set</code>"
     <dd>
-      1. Let |deserialized value list| be a result of [=trying=] to
-         [=deserialize value list=] with |value|.
+      1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
+         with |value|.
 
-      1. Return [=success=] with data set to a new [=Set object=] constructed with
-         |deserialized value list| as <code>[iterable]</code>.
+      1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
+
+      1. Return [=success=] with data [=Set object=](|iterable|).
 
     <dt>otherwise
     <dd>Return [=error=] with [=error code=] [=invalid argument=].
@@ -1312,6 +1319,8 @@ cycle, or otherwise when the maximum serialization depth is reached.
 
 [=Nodes=] are also represented by <code>RemoteValue</code> instances. These have
 a partial serialization of the node in the value property.
+
+Issue: reconsider mirror objects' lifecycle.
 
 Note: mirror objects do not keep the original object alive in the runtime. If an
 object is discarded in the runtime, subsequent attempts to access it via the
@@ -3572,8 +3581,8 @@ function with given arguments in a given realm.
 
 <code>RealmInfo</code> can be either a realm or a browsing context.
 
-Note: <code>this</code> argument is ignore in case of arrow function in
-<code>functionDeclaration</code>.
+Note: In case of an arrow function in <code>functionDeclaration</code>, the <code>this</code>
+argument doesn't affect function's <code>this</code> binding.
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -3600,7 +3600,6 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
 1. Return [=success=] with data |deserialized arguments list|.
 
-Issue: Clarify behaviour in case of deserialization failed.
 </div>
 
 <div algorithm>
@@ -3609,8 +3608,11 @@ To <dfn>evaluate function body</dfn> with a given |function declaration|,
 
 Note: the |function declaration| is parenthesized and evaluated.
 
+1. Let |parenthesized function declaration| be [=concatenate=]
+   «"<code>(</code>", |function declaration|, "<code>)</code>"»
+
 1. Let |function script| be the result of [=create a classic script=] with
-   <code>(</code> + |function declaration| + <code>)</code>, |environment settings|, |base URL|, and |options|.
+   |parenthesized function declaration|, |environment settings|, |base URL|, and |options|.
 
 1. [=Prepare to run script=] with |environment settings|.
 

--- a/index.bs
+++ b/index.bs
@@ -102,9 +102,11 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: null; url: sec-null-value
     text: Object; url: sec-object-objects
     text: Object.fromEntries; url: sec-object.fromentries
-    text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
+    text: ScriptEvaluation; url: sec-runtime-semantics-scriptevaluation
     text: Set object; url: sec-set-objects
     text: String; url: sec-string-constructor
+    text: StringToBigInt; url: sec-stringtobigint
+    text: StringToNumber; url: sec-stringtonumber
     text: RegExp; url: sec-regexp-pattern-flags
     text: ThisTimeValue; url: thistimevalue
     text: ToString; url: sec-tostring
@@ -1107,15 +1109,21 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
     <dd>Return [=success=] with data |value|.
 
     <dt>|type| is the string "<code>number</code>"
-    <dd>Return [=success=] with data [=Number=](|value|).
+    <dd>
+      1. Let |number_result| be [=StringToNumber=](|value|).
+
+      1. If |number_result| is NaN, return [=error=] with [=error code=] [=invalid argument=]
+
+      1. Return [=success=] with data |number_result|.
 
     <dt>|type| is the string "<code>boolean</code>"
     <dd>Return [=success=] with data |value|.
 
     <dt>|type| is the string "<code>bigint</code>"
     <dd>
-      1. Let |bigint_result| be [=BigInt=](|value|). If this throws exception, return [=error=]
-         with [=error code=] [=invalid argument=]
+      1. Let |bigint_result| be [=StringToBigInt=](|value|).
+
+      1. If |bigint_result| is undefined, return [=error=] with [=error code=] [=invalid argument=]
 
       1. Return [=success=] with data |bigint_result|.
 
@@ -1342,10 +1350,9 @@ To get the <dfn>object id for an object</dfn> given a |session| and |object|:
 1. If |session|'s [=object id map=] does not contain |object|, run the
    following steps:
 
-  1. Let |object id| be a new, unique, string identifier for |object|. If
-     |object| is an [=/element=] this must be the [=web element reference=] for
-     |object|; if it's a {{WindowProxy}} object, this must be the [=window
-     handle=] for |object|.
+  1. Let |object id| be a new, unique, string identifier for |object|. If |object| is an
+     [=/element=] this must be the [=web element reference=] for |object|; if it's a {{WindowProxy}}
+     object, this must be the [=browsing context id=] for |object|.
 
   1. Set the value of |object| in |session|'s [=object id map=] to |object id|.
 
@@ -3635,7 +3642,7 @@ The [=remote end steps=] with |command parameters| are:
 1. [=Prepare to run script=] with |environment settings|.
 
 1. Set |evaluation status| to
-   [=Call=](|function object|, |this object|, ...|deserialized arguments|).
+   [=Call=](|function object|, |this object|, |deserialized arguments|).
 
 1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is true,
    and [=IsPromise=](|call evaluation status|.\[[Value]]):

--- a/index.bs
+++ b/index.bs
@@ -92,7 +92,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Object; url: sec-object-objects
     text: IsCallable; url: #sec-iscallable
-    text: OrdinaryCallEvaluateBody; url: #sec-ordinarycallevaluatebody
+    text: Call; url: #sec-call
     text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
     text: Set; url: sec-set
     text: ThisTimeValue; url: thistimevalue
@@ -3375,6 +3375,8 @@ The [=remote end steps=] with |command parameters| are:
 
 #### The script.callFunction Command ####  {#command-script-callFunction}
 
+Issue: Add `this` parameter.
+
 The <dfn export for=commands>script.callFunction</dfn> command calls a provided
 function with given arguments in a given realm.
 
@@ -3425,28 +3427,41 @@ function with given arguments in a given realm.
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 The <dfn>deserialize an argument value</dfn>(|argumentValue|) is the following:
+
 1. If |argumentValue| is [=RemoteReference=], return [=deserialize a reference=](|argumentValue|).
+
 1. Return [=deserialize a local value=](|argumentValue|).
 
-The steps to <dfn>get function object</dfn> with a given |function declaration|,
+The <dfn>deserialize arguments</dfn>(|arguments|) is the following:
+
+1. Let |deserialized arguments| be an empty list.
+
+1. For each |argument| of |arguments declaration|:
+
+  1. Let |deserialized argument| be the result of
+     [=deserialize an argument value=](|argument|).
+
+  1. Append |deserialized argument| to the |deserialized arguments|.
+
+1. Return |deserialized arguments|.
+
+Issue: Clarify behaviour in case of deserialization failed.
+
+The steps to <dfn>evaluate function body</dfn> with a given |function declaration|,
 |environment settings|, |base URL|, and |options| are the following:
 
-1. Let |function script| be the result of [=create a classic script=] with |function declaration|,
-   |environment settings|, |base URL|, and |options|.
+Note: the |function declaration| is parenthesized and evaluated.
+
+1. Let |function script| be the result of [=create a classic script=] with
+   <code>(</code> + |function declaration| + <code>)</code>, |environment settings|, |base URL|, and |options|.
 
 1. [=Prepare to run script=] with |environment settings|.
 
-1. Set |function evaluation status| to [=ScriptEvaluation=](|function script|'s record).
+1. Let |function body evaluation status| be [=ScriptEvaluation=](|function script|'s record).
 
 1. [=Clean up after running script=] with |environment settings|.
 
-1. Assert: |function evaluation status|.\[[Type]] is not <code>throw</code>.
-
-1. Let |function object| be |evaluation status|.\[[Value]].
-
-1. Assert [=IsCallable=](|function object|) is true.
-
-1. Return |function object|.
+1. Return |function body evaluation status|.
 
 Issue: Define behavior in case of exception during script evaluation.
 
@@ -3461,48 +3476,56 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |arguments declaration| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |deserialized arguments list| be an empty list.
-
-1. For each |argument| of |arguments declaration|:
-
-  1. Let |deserialized argument| be the result of
-     [=deserialize an argument value=](|argument|).
-
-  1. Append |deserialized argument| to the |deserialized arguments list|.
+1. Let |deserialized arguments| be the result of
+   [=deserialize arguments=](|arguments declaration|)
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
-1. Let |function object| be the result of [=get function object=](|function declaration|,
-   |environment settings|, |base URL|, and |options|).
+1. Let |function body evaluation status| be the result of [=evaluate function body=]
+   (|function declaration|, |environment settings|, |base URL|, and |options|).
 
-1. [=Prepare to run script=] with |environment settings|.
-
-1. Set |function evaluation status| to
-   [=OrdinaryCallEvaluateBody=](|function object|, |deserialized arguments list|).
-
-1. If |function evaluation status|.\[[Type]] is <code>normal</code>,
-   |await promise| is true, and
-   [=IsPromise=](|call evaluation status|.\[[Value]]):
-
-   1. Set |function evaluation status| to
-      <a spec=ECMASCRIPT>Await</a>(|call evaluation status|.\[[Value]]).
-
-1. [=Clean up after running script=] with |environment settings|.
-
-1. If |function evaluation status|.\[[Type]] is <code>throw</code>:
+1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |function evaluation status|.
+     |function body evaluation status|.
 
   1. Return a new map matching the <code>ScriptEvaluateResultException</code>
      production, with the <code>exceptionDetails</code> field set to
      |exception details|.
 
-1. Assert: |function evaluation status|.\[[Type]] is <code>normal</code>.
+1. Let |function object| be |function body evaluation status|.\[[Value]].
+
+1. If [=IsCallable=](|function object|) is <code>false</code>:
+
+   1. Return an [=error=] with [=error code=] [=Invalid Argument=]
+
+1. [=Prepare to run script=] with |environment settings|.
+
+1. Set |evaluation status| to [=Call=](|function object|, |null|, |deserialized arguments|).
+
+1. If |evaluation status|.\[[Type]] is <code>normal</code>,
+   |await promise| is true, and
+   [=IsPromise=](|call evaluation status|.\[[Value]]):
+
+   1. Set |evaluation status| to
+      <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
+
+1. [=Clean up after running script=] with |environment settings|.
+
+1. If |evaluation status|.\[[Type]] is <code>throw</code>:
+
+  1. Let |exception details| be the result of [=get exception details=] given
+     |evaluation status|.
+
+  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+     production, with the <code>exceptionDetails</code> field set to
+     |exception details|.
+
+1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |function evaluation status|.\[[Value]].
+   |evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
    production, with the <code>result</code> field set to |result|.

--- a/index.bs
+++ b/index.bs
@@ -3159,8 +3159,8 @@ relating to script realms and execution.
 <pre class="cddl remote-cddl">
 
 ScriptCommand = (
-  ScriptEvaluateCommand //
   ScriptCallFunctionCommand //
+  ScriptEvaluateCommand //
   ScriptGetRealmsCommand
 )
 

--- a/index.bs
+++ b/index.bs
@@ -967,13 +967,12 @@ To <dfn>deserialize remote reference</dfn> given a |remote reference|:
 
 ## Protocol Value ## {#data-types-protocolValue}
 
-### Primitive Protocol Value ### {#data-types-protocolValue-primitiveValue}
+### Primitive Protocol Value ### {#data-types-protocolValue-primitiveProtocolValue}
 
-Represents primitive protocol values which can be serialized to /
-deserialized from ECMAScript without reference to existing objects.
+Represents primitive protocol values which can only be represented by value, never by reference..
 
 ```
-PrimitiveValue = {
+PrimitiveProtocolValue = {
   UndefinedValue //
   NullValue //
   StringValue //
@@ -1124,7 +1123,7 @@ deserialized to ECMAScript without reference to existing objects.
 
 ```
 LocalValue = {
-  PrimitiveValue //
+  PrimitiveProtocolValue //
   ArrayLocalValue //
   DateLocalValue //
   MapLocalValue //
@@ -1160,7 +1159,7 @@ ObjectLocalValue = {
 RegExpLocalValue = {
   type: "regexp",
   pattern: text,
-  flags?: text
+  ?flags: text
 }
 
 SetLocalValue = {
@@ -1223,7 +1222,7 @@ To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
-1. If |local protocol value| matches the <code>PrimitiveValue</code> production, return
+1. If |local protocol value| matches the <code>PrimitiveProtocolValue</code> production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
 
 1. Let |type| be the value of the <code>type</code> field of |local protocol value| or undefined if
@@ -1339,7 +1338,7 @@ To get the <dfn>object id for an object</dfn> given a |session| and |object|:
 [=remote end definition=] and [=local end definition=]
 ```
 RemoteValue = {
-  PrimitiveValue //
+  PrimitiveProtocolValue //
   SymbolRemoteValue //
   ArrayRemoteValue //
   ObjectRemoteValue //

--- a/index.bs
+++ b/index.bs
@@ -1014,6 +1014,8 @@ BigIntValue = {
 }
 ```
 
+#### Serialization #### {#data-types-protocolValue-primitiveProtocolValue-serialization}
+
 <div algorithm>
 
 To <dfn>serialize primitive protocol value</dfn> given a |value|:
@@ -1075,6 +1077,8 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
 1. Return |remote value|
 
 </div>
+
+#### Deserialization #### {#data-types-protocolValue-primitiveProtocolValue-deserialization}
 
 <div algorithm>
 
@@ -1172,6 +1176,8 @@ SetLocalValue = {
   value: ListLocalValue
 }
 ```
+
+#### Deserialization #### {#data-types-protocolValue-LocalValue-deserialization}
 
 <div algorithm>
 
@@ -1489,13 +1495,15 @@ Issue: Add WASM types?
 
 Issue: Should WindowProxy get attributes in a similar style to Node?
 
-Issue: Describe `IteratorRemoteValue` deserialization.
+Issue: Describe `IteratorRemoteValue` serialization.
 
-Issue: Describe `GeneratorRemoteValue` deserialization.
+Issue: Describe `GeneratorRemoteValue` serialization.
 
-Issue: Describe `ProxyRemoteValue` deserialization.
+Issue: Describe `ProxyRemoteValue` serialization.
 
 Issue: handle String / Number / etc. wrapper objects specially?
+
+#### Serialization #### {#data-types-protocolValue-RemoteValue-serialization}
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -77,6 +77,9 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
     text: Array; url: sec-array-objects
     text: Await; url: await
+    text: BigInt; url: sec-bigint-constructor
+    text: boolean; url: sec-terms-and-definitions-boolean-value
+    text: Call; url: #sec-call
     text: Completion Record; url: sec-completion-record-specification-type
     text: CreateArrayFromList; url: sec-createarrayfromlist
     text: CreateArrayIterator; url: sec-createarrayiterator
@@ -85,6 +88,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: CreateSetIterator; url: sec-createsetiterator
     text: Date Time String Format; url: sec-date-time-string-format
     text: Date.ToDateString; url: sec-todatestring
+    text: Date.parse; url: sec-date.parse
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
     text: HasProperty; url: sec-hasproperty
@@ -93,19 +97,19 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: IsPromise; url: sec-ispromise
     text: IsRegExp; url: sec-isregexp
     text: LengthOfArrayLike; url: sec-lengthofarraylike
-    text: new BigInt; url: sec-bigint-constructor
-    text: new Number; url: sec-number-constructor
-    text: new String; url: sec-string-constructor
+    text: Map; url: sec-map-objects
+    text: Number; url: sec-number-constructor
+    text: null; url: sec-null-value
     text: Object; url: sec-object-objects
     text: Object.fromEntries; url: sec-object.fromentries
-    text: IsCallable; url: #sec-iscallable
-    text: Call; url: #sec-call
     text: ScriptEvaluation; url: #sec-runtime-semantics-scriptevaluation
-    text: Set; url: sec-set
+    text: Set object; url: sec-set-objects
+    text: String; url: sec-string-constructor
     text: RegExp; url: sec-regexp-pattern-flags
     text: ThisTimeValue; url: thistimevalue
     text: ToString; url: sec-tostring
     text: Type; url: sec-ecmascript-data-types-and-values
+    text: undefined; url: sec-undefined-value
     text: current realm record; url: current-realm
     text: internal slot; url: sec-object-internal-methods-and-internal-slots
     text: primitive ECMAScript value; url: sec-primitive-value
@@ -1082,28 +1086,29 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 1. If |primitive protocol value| has field <code>value</code>:
    1. Let |value| be the value of the <code>value</code> field of |primitive protocol value|.
 
-1. In the following list of conditions and associated steps, run the first set
-   of steps for which the associated condition is true:
+1. In the following list of conditions and associated steps, run the first set of steps for which
+   the associated condition is true. If this throws exception, return [=error=] with [=error code=]
+   [=invalid argument=]:
 
   <dl>
 
     <dt>|type| is the string "<code>undefined</code>"
-    <dd>Return [=success=] with data <code>undefined</code>.
+    <dd>Return [=success=] with data set to [=undefined=].
 
     <dt>|type| is the string "<code>null</code>"
-    <dd>Return [=success=] with data <code>null</code>.
+    <dd>Return [=success=] with data set to [=null=].
 
     <dt>|type| is the string "<code>string</code>"
-    <dd>Return [=success=] with data <code>[=new String=](|value|)</code>.
+    <dd>Return [=success=] with data set to a new [=String=] with |value|.
 
     <dt>|type| is the string "<code>number</code>"
-    <dd>Return [=success=] with data <code>[=new Number=](|value|)</code>.
+    <dd>Return [=success=] with data set to a new [=Number=] with |value|.
 
     <dt>|type| is the string "<code>boolean</code>"
-    <dd>Return [=success=] with data |value|.
+    <dd>Return [=success=] with data set to a [=boolean=] |value|.
 
     <dt>|type| is the string "<code>bigint</code>"
-    <dd>Return [=success=] with data <code>[=new BigInt=](|value|)</code>.
+    <dd>Return [=success=] with data set to a new [=BigInt=] with |value|.
 
   </dl>
 
@@ -1154,7 +1159,8 @@ ObjectLocalValue = {
 
 RegExpLocalValue = {
   type: "regexp",
-  value: text
+  pattern: text,
+  flags?: text
 }
 
 SetLocalValue = {
@@ -1165,8 +1171,7 @@ SetLocalValue = {
 
 <div algorithm>
 
-To <dfn>deserialize key-value list</dfn> given a
-|serialized key-value list|:
+To <dfn>deserialize key-value list</dfn> given a |serialized key-value list|:
 
 1. Let |deserialized key-value list| be a new list.
 
@@ -1221,14 +1226,15 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 1. If |local protocol value| matches the <code>PrimitiveValue</code> production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
 
-1. Let |type| be the value of the <code>type</code> field of |local protocol value|.
+1. Let |type| be the value of the <code>type</code> field of |local protocol value| or undefined if
+   no such a field.
 
-1. Let |value| be the value of the <code>value</code> field of |local protocol value|.
+1. Let |value| be the value of the <code>value</code> field of |local protocol value| or undefined
+   if no such a field.
 
 1. In the following list of conditions and associated steps, run the first set of steps for which
-   the associated condition is true:
-
-  Issue: TODO: define via `script.evaluate` to provide proper parse or runtime error handling.
+   the associated condition is true. If this throws exception, return [=error=] with [=error code=]
+   [=invalid argument=]:
 
   Issue: TODO: add regex options.
 
@@ -1239,38 +1245,50 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=] with
          given |value|.
 
-      1. Return [=success=] with data <code>new [=Array=](|deserialized value list|)</code>.
+      1. Return [=success=] with data set to a new [=Array=] object constructed with
+         |deserialized value list| as <code>values</code>.
 
     <dt>|type| is the string "<code>date</code>"
     <dd>
-      1. If |value| matches [=Date Time String Format=], return [=success=] with data <code>new [=Date=](|value|)</code>.
+      1. If |value| does not match [=Date Time String Format=], return [=error=] with
+         [=error code=] [=invalid argument=].
 
-      1. Otherwise return [=error=] with [=error code=] [=invalid argument=].
+      1. Return [=success=] with data set to a result of [=Date.parse=] with |value| as
+         <code>string</code>.
 
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
          [=deserialize key-value list=] with |value|.
 
-      1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
+      1. Return [=success=] with data set to a new [=Map=] object constructed with
+         |deserialized key-value list| as <code>iterable</code>.
 
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
          [=deserialize key-value list=] with |value|.
 
-      1. Return [=success=] with data
-         <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.
+      1. Return [=success=] with data set to a result of [=Object.fromEntries=] with
+         |deserialized key-value list| as <code>iterable</code>.
 
     <dt>|type| is the string "<code>regexp</code>"
-    <dd>Return [=success=] with data <code>new [=RegExp=](|value|)</code>.
+    <dd>
+      1. Let |pattern| be the value of the <code>pattern</code> field of |local protocol value|.
+
+      1. Let |flags| be the value of the <code>flags</code> field of |local protocol value| or
+         undefined if no such a field.
+
+      1. Return [=success=] with data set to a new [=RegExp=] object constructed with |pattern| and
+         |flags|.
 
     <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to
          [=deserialize value list=] with |value|.
 
-      1. Return [=success=] with data <code>new [=Set=](|deserialized value list|)</code>.
+      1. Return [=success=] with data set to a new [=Set object=] constructed with
+         |deserialized value list| as <code>[iterable]</code>.
 
     <dt>otherwise
     <dd>Return [=error=] with [=error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -3515,7 +3515,7 @@ argument doesn't affect function's <code>this</code> binding.
 
       ScriptCallFunctionParameters = {
         functionDeclaration: text;
-        arguments: [ArgumentValue];
+        ?arguments: [ArgumentValue];
         ?this: ArgumentValue;
         ?awaitPromise: bool;
         target: Target;
@@ -3610,14 +3610,18 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |command arguments| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |deserialized arguments| be the result of [=trying=] to [=deserialize arguments=] with
-   |command arguments|.
+1. Let |deserialized arguments| be an empty list.
+
+1. If |command arguments| is not null, set |deserialized arguments| to the result of [=trying=] to
+   [=deserialize arguments=] with |command arguments|.
 
 1. Let |this parameter| be the value of the <code>this</code> field
    of |command parameters|.
 
-1. Let |this object| be the result of [=trying=] to [=deserialize a parameter value=]
-   with |this parameter|.
+1. Let |this object| be null.
+
+1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
+   [=deserialize a parameter value=] with |this parameter|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -2839,6 +2839,7 @@ relating to script realms and execution.
 
 ScriptCommand = (
   ScriptEvaluateCommand //
+  ScriptInvokeCommand //
   ScriptGetRealmsCommand
 )
 
@@ -2850,6 +2851,7 @@ ScriptCommand = (
 
 ScriptResult = (
   ScriptEvaluateResult //
+  ScriptInvokeResult //
   ScriptGetRealmsResult
 )
 
@@ -3266,6 +3268,146 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]].
+
+1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
+   production, with the <code>result</code> field set to |result|.
+
+#### The script.invoke Command ####  {#command-script-invoke}
+
+The <dfn export for=commands>script.invoke</dfn> command invokes a provided
+function with given arguments in a given realm.
+
+ <code>RealmInfo</code> can be either a realm or a browsing context.
+
+Issue: declare `RemoteValueArgument`.
+
+Issue: declare `LocalValueArgument`.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      ScriptInvokeCommand = {
+        method: "script.invoke",
+        params: ScriptInvokeParameters
+      }
+
+      ScriptInvokeParameters = {
+        functionDeclaration: text;
+        arguments: [InvokeArgument];
+        ?awaitPromise: bool;
+        target: Target;
+      }
+
+      InvokeArgument = (
+        RemoteValueArgument //
+        LocalValueArgument
+      );
+
+      // TODO: declare.
+      RemoteValueArgument = {
+        objectId: string;
+      };
+
+      // TODO: declare.
+      LocalValueArgument = {
+        type: string;
+        value: any;
+      };
+
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      ScriptInvokeResult = (
+        ScriptInvokeResultSuccess //
+        ScriptInvokeResultException
+      )
+
+      ScriptInvokeResultSuccess = {
+         result: RemoteValue
+      }
+
+      ScriptInvokeResultException = {
+        exceptionDetails: ExceptionDetails
+      }
+    </pre>
+   </dd>
+</dl>
+
+Issue: TODO: Add timeout argument as described in the script.evaluate.
+
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
+   given the value of the <code>target</code> field of |command parameters|.
+
+1. Let |environment settings| be the [=environment settings object=] whose
+   [=realm execution context=]'s Realm component is |realm|.
+
+1. Let |function declaration| be the value of the <code>functionDeclaration</code> field of |command
+   parameters|.
+
+1. Let |arguments declaration| be the value of the <code>arguments</code> field of |command
+   parameters|.
+
+1. Let |await promise| be the value of the <code>awaitPromise</code> field of
+   |command parameters|, if present, or <code>true</code> otherwise.
+
+1. Let |options| be the [=default classic script fetch options=].
+
+1. Let |base URL| be the [=API base URL=] of |environment settings|.
+
+1. Let |function script| be the result of [=create a classic script=] with |function declaration|,
+   |environment settings|, |base URL|, and |options|.
+
+1. [=Prepare to run function script=] with |environment settings|.
+
+1. Set |function evaluation status| to [=ScriptEvaluation=](|function script|'s record).
+
+1. If |function evaluation status|.\[[Type]] is <code>throw</code>:
+
+  1. Let |exception details| be the result of [=get exception details=] given |function evaluation status|
+
+  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+     production, with the <code>exceptionDetails</code> field set to |exception details|.
+
+1. Let |script arguments| be an empty list.
+
+1. For each |arg declaration| of |arguments declaration|:
+
+  Issue: describe |deserialize form InvokeArgument|.
+
+  1. Let |script arg| be the result of |deserialize form InvokeArgument|(|arg declaration|).
+
+  1. Append |script arg| to the |script arguments|.
+
+Issue: describe |make function with arguments|.
+
+1. Set |call function with arguments| to |make function with arguments| with |function| and |script arguments|.
+
+1. Set |call evaluation status| to [=ScriptEvaluation=]|call function with arguments|.
+
+1. If |call evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
+   true, and [=IsPromise=](|call evaluation status|.\[[Value]]):
+
+   1. Set |call evaluation status| to <a spec=ECMASCRIPT>Await</a>(|call evaluation status|.\[[Value]]).
+
+1. [=Clean up after running script=] with |environment settings|.
+
+1. If |call evaluation status|.\[[Type]] is <code>throw</code>:
+
+  1. Let |exception details| be the result of [=get exception details=] given |call evaluation status|.
+
+  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+     production, with the <code>exceptionDetails</code> field set to |exception
+     details|.
+
+1. Assert: |call evaluation status|.\[[Type]] is <code>normal</code>.
+
+1. Let |result| be the result of [=serialize as a remote value=] given
+   |call evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
    production, with the <code>result</code> field set to |result|.

--- a/index.bs
+++ b/index.bs
@@ -934,7 +934,7 @@ requests to start a WebDriver session, it must:
 
 ## Reference ## {#data-types-reference}
 
-<dfn>RemoteReference</dfn> represents reference to existing ECMAScript object in
+<dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
 [=object id map=].
 
 A [=BiDi session=] has an <dfn>object id map</dfn>. This is a weak map
@@ -971,7 +971,8 @@ To <dfn>deserialize remote reference</dfn> given a |remote reference|:
 
 ### Primitive Protocol Value ### {#data-types-protocolValue-primitiveProtocolValue}
 
-Represents primitive protocol values which can only be represented by value, never by reference.
+<dfn>PrimitiveProtocolValue</dfn> represents values which can only be represented by value, never
+by reference.
 
 ```
 PrimitiveProtocolValue = {
@@ -1126,8 +1127,8 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 
 ### Local Value ### {#data-types-protocolValue-LocalValue}
 
-Represents both primitive and non-primitive protocol values which can be
-deserialized to ECMAScript without reference to existing objects.
+<dfn>LocalValue</dfn> represents both primitive and non-primitive values which can be deserialized
+to ECMAScript without reference to existing objects.
 
 
 ```
@@ -1233,7 +1234,10 @@ To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
-1. If |local protocol value| matches the <code>PrimitiveProtocolValue</code> production, return
+1. If |local protocol value| matches the [=RemoteReference=] production, return
+   [=deserialize remote reference=] of |local protocol value|.
+
+1. If |local protocol value| matches the [=PrimitiveProtocolValue=] production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
 
 1. Let |type| be the value of the <code>type</code> field of |local protocol value| or undefined if
@@ -3550,16 +3554,6 @@ argument doesn't affect function's <code>this</code> binding.
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 <div algorithm>
-To <dfn>deserialize a parameter value</dfn> given an |serialized value|:
-
-1. If |serialized value| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] of |serialized value|.
-
-1. Return [=deserialize local value=] of |serialized value|.
-
-</div>
-
-<div algorithm>
 
 To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
@@ -3567,7 +3561,7 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
 1. For each |serialized argument| of |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize a parameter value=]
+  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize local value=]
      with |serialized argument|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
@@ -3621,7 +3615,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |this object| be null.
 
 1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
-   [=deserialize a parameter value=] with |this parameter|.
+   [=deserialize local value=] with |this parameter|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -971,7 +971,7 @@ To <dfn>deserialize remote reference</dfn> given a |remote reference|:
 
 ### Primitive Protocol Value ### {#data-types-protocolValue-primitiveProtocolValue}
 
-Represents primitive protocol values which can only be represented by value, never by reference..
+Represents primitive protocol values which can only be represented by value, never by reference.
 
 ```
 PrimitiveProtocolValue = {

--- a/index.bs
+++ b/index.bs
@@ -3171,8 +3171,8 @@ ScriptCommand = (
 <pre class="cddl local-cddl">
 
 ScriptResult = (
-  ScriptEvaluateResult //
   ScriptCallFunctionResult //
+  ScriptEvaluateResult //
   ScriptGetRealmsResult
 )
 

--- a/index.bs
+++ b/index.bs
@@ -921,7 +921,184 @@ requests to start a WebDriver session, it must:
 
 # Common Data Types # {#data-types}
 
-## Remote Value ## {#type-common-RemoteValue}
+## Reference ## {#data-types-reference}
+
+|Reference| represents reference to existing ECMAScript object in
+[=object id map=].
+
+```
+ObjectId = text;
+
+RemoteReference = {
+   objectId: ObjectId,
+   *text => any,
+}
+```
+
+## Value ## {#data-types-value}
+
+### Primitive Value ### {#data-types-value-PrimitiveValue}
+
+<dfn>Primitive Value</dfn> represents primitive values which can be serialized to /
+deserialized from ECMAScript without reference to existing objects.
+
+```
+PrimitiveValue = {
+  UndefinedValue //
+  NullValue //
+  StringValue //
+  NumberValue //
+  BooleanValue //
+  BigIntValue //
+}
+
+UndefinedValue = {
+  type: "undefined",
+}
+
+NullValue = {
+  type: "null",
+}
+
+StringValue = {
+  type: "string",
+  value: text,
+}
+
+SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
+
+NumberValue = {
+  type: "number",
+  value: number / SpecialNumber,
+}
+
+BooleanValue = {
+  type: "boolean",
+  value: bool,
+}
+
+BigIntValue = {
+  type: "bigint",
+  value: text,
+}
+```
+
+<div algorithm>
+
+To <dfn>serialize primitive value</dfn> given a |value|:
+
+1. Let |remote value| be |undefined|.
+
+1. In the following list of conditions and associated steps, run the first set
+   of steps for which the associated condition is true:
+
+  <dl>
+    <dt>[=Type=](|value|) is Undefined
+    <dd>Let |remote value| be a map matching the <code>UndefinedValue</code>
+    production in the [=local end definition=].
+
+    <dt>[=Type=](|value|) is Null
+    <dd>Let |remote value| be a map matching the <code>NullValue</code>
+    production in the [=local end definition=].
+
+    <dt>[=Type=](|value|) is String
+    <dd>Let |remote value| be a map matching the <code>StringValue</code>
+    production in the [=local end definition=], with the <code>value</code>
+    property set to |value|.
+
+    Issue: This doesn't handle lone surrogates
+
+    <dt>[=Type=](|value|) is Number
+    <dd>
+    1. Switch on the value of |value|:
+      <dl>
+        <dt>NaN
+        <dd>Let |serialized| be <code>"NaN"</code>
+        <dt>-0
+        <dd>Let |serialized| be <code>"-0"</code>
+        <dt>+Infinity
+        <dd>Let |serialized| be <code>"+Infinity"</code>
+        <dt>-Infinity
+        <dd>Let |serialized| be <code>"-Infinity"</code>
+        <dt>Otherwise:
+        <dd>Let |serialized| be |value|
+      </dl>
+
+    1. Let |remote value| be a map matching the <code>NumberValue</code>
+       production in the [=local end definition=], with the <code>value</code>
+       property set to |serialized|.
+
+    <dt>[=Type=](|value|) is Boolean
+    <dd>Let |remote value| be a map matching the <code>BooleanValue</code>
+        production in the [=local end definition=], with the <code>value</code>
+        property set to |value|.
+
+    <dt>[=Type=](|value|) is BigInt
+    <dd>Let |remote value| be a map matching the <code>BigIntValue</code>
+        production in the [=local end definition=], with the <code>value</code>
+        property set to the result of running the [=ToString=] operation on
+        |value|.
+
+  </dl>
+
+1. Return |remote value|
+
+</div>
+
+### Local Value ### {#data-types-value-LocalValue}
+
+|Local Value| represents both primitive and non-primitive values which can be
+deserialized to ECMAScript without reference to existing objects.
+
+Issue: Defined |deserialize local value| steps.
+
+```
+LocalValue = {
+  PrimitiveValue //
+  ArrayLocalValue //
+  ObjectLocalValue //
+  MapLocalValue //
+  SetLocalValue //
+  RegExpLocalValue //
+  DateLocalValue //
+}
+
+ListLocalValue = [*LocalValue];
+
+RegExpLocalValue = {
+  type: "regexp",
+  value: text
+}
+
+DateLocalValue = {
+  type: "date",
+  value: text
+}
+
+ArrayLocalValue = {
+  type: "array",
+  value: ListLocalValue,
+}
+
+ObjectLocalValue = {
+  type: "object",
+  value: MappingLocalValue,
+}
+
+MappingLocalValue = [*[(LocalValue / text), LocalValue]];
+
+MapLocalValue = {
+  type: "map",
+  value: MappingLocalValue,
+}
+
+SetLocalValue = {
+  type: "set",
+  value: ListLocalValue
+}
+```
+
+### Remote Value ### {#data-types-value-RemoteValue}
 
 Values accessible from the ECMAScript runtime are represented by a mirror
 object, specified as <code>RemoteValue</code>. The value's type is specified in
@@ -986,146 +1163,107 @@ Issue: This error code isn't right.
 [=remote end definition=] and [=local end definition=]
 ```
 RemoteValue = {
-  UndefinedValue //
-  NullValue //
-  StringValue //
-  NumberValue //
-  BooleanValue //
-  BigIntValue //
-  SymbolValue //
-  ArrayValue //
-  ObjectValue //
-  FunctionValue //
-  RegExpValue //
-  DateValue //
-  MapValue //
-  SetValue //
-  WeakMapValue //
-  WeakSetValue //
-  IteratorValue //
-  GeneratorValue //
-  ErrorValue //
-  ProxyValue //
-  PromiseValue //
-  TypedArrayValue //
-  ArrayBufferValue //
-  NodeValue //
-  WindowProxyValue //
+  PrimitiveValue //
+  SymbolRemoteValue //
+  ArrayRemoteValue //
+  ObjectRemoteValue //
+  FunctionRemoteValue //
+  RegExpRemoteValue //
+  DateRemoteValue //
+  MapRemoteValue //
+  SetRemoteValue //
+  WeakMapRemoteValue //
+  WeakSetRemoteValue //
+  IteratorRemoteValue //
+  GeneratorRemoteValue //
+  ErrorRemoteValue //
+  ProxyRemoteValue //
+  PromiseRemoteValue //
+  TypedArrayRemoteValue //
+  ArrayBufferRemoteValue //
+  NodeRemoteValue //
+  WindowProxyRemoteValue //
 }
 
-ObjectId = text;
+ListRemoteValue = [*RemoteValue];
 
-ListValue = [*RemoteValue];
+MappingRemoteValue = [*[(RemoteValue / text), RemoteValue]];
 
-MappingValue = [*[(RemoteValue / text), RemoteValue]];
-
-UndefinedValue = {
-  type: "undefined",
-}
-
-NullValue = {
-  type: "null",
-}
-
-StringValue = {
-  type: "string",
-  value: text,
-}
-
-SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
-
-NumberValue = {
-  type: "number",
-  value: number / SpecialNumber,
-}
-
-BooleanValue = {
-  type: "boolean",
-  value: bool,
-}
-
-BigIntValue = {
-  type: "bigint",
-  value: text,
-}
-
-SymbolValue = {
-  type: "symbol",
-  objectId: ObjectId,
+SymbolRemoteValue = {
+   type: "symbol",
+   objectId: ObjectId,
 }
 
 ArrayValue = {
   type: "array",
   objectId: ObjectId,
-  value?: ListValue,
+  value?: ListRemoteValue,
 }
 
 ObjectValue = {
   type: "object",
   objectId: ObjectId,
-  value?: MappingValue,
+  value?: MappingRemoteValue,
 }
 
-FunctionValue = {
-  type: "function",
+FunctionRemoteValue = {
+   type: "function",
+   objectId: ObjectId,
+}
+
+RegExpRemoteValue = {
+   RegExpLocalValue,
+   objectId: ObjectId,
+}
+
+DateRemoteValue = {
+  DateLocalValue,
   objectId: ObjectId,
 }
 
-RegExpValue = {
-  type: "regexp",
-  objectId: ObjectId,
-  value: text
-}
-
-DateValue = {
-  type: "date",
-  objectId: ObjectId,
-  value: text
-}
-
-MapValue = {
+MapRemoteValue = {
   type: "map",
   objectId: ObjectId,
-  value?: MappingValue,
+  value: MappingRemoteValue,
 }
 
-SetValue = {
+SetRemoteValue = {
   type: "set",
   objectId: ObjectId,
-  value?: ListValue
+  value: ListRemoteValue
 }
 
-WeakMapValue = {
+WeakMapRemoteValue = {
   type: "weakmap",
   objectId: ObjectId,
 }
 
-WeakSetValue = {
+WeakSetRemoteValue = {
   type: "weakset",
   objectId: ObjectId,
 }
 
-ErrorValue = {
+ErrorRemoteValue = {
   type: "error",
   objectId: ObjectId,
 }
 
-PromiseValue = {
+PromiseRemoteValue = {
   type: "promise",
   objectId: ObjectId,
 }
 
-TypedArrayValue = {
+TypedArrayRemoteValue = {
   type: "typedarray",
   objectId: ObjectId,
 }
 
-ArrayBufferValue = {
+ArrayBufferRemoteValue = {
   type: "arraybuffer",
   objectId: ObjectId,
 }
 
-NodeValue = {
+NodeRemoteValue = {
   type: "node",
   objectId: ObjectId,
   value?: NodeProperties,
@@ -1137,12 +1275,12 @@ NodeProperties = {
   localName?: text,
   namespaceURI?: text,
   childNodeCount: uint,
-  children?: [*NodeValue],
+  children?: [*NodeRemoteValue],
   attributes?: {*text => text},
-  shadowRoot?: NodeValue / null,
+  shadowRoot?: NodeRemoteValue / null,
 }
 
-WindowProxyValue = {
+WindowProxyRemoteValue = {
   type: "window",
   objectId: ObjectId,
 }
@@ -1156,61 +1294,20 @@ Issue: handle String / Number / etc. wrapper objects specially?
 
 <div algorithm>
 
-To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
+To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 |node details|, and a |set of known objects|:
+
+1. Let |remote value| be a result of [=serialize primitive value=]
+   given a |value|.
+
+1. If |remote value| is not |undefined|, return |remote value|.
 
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
   <dl>
-    <dt>[=Type=](|value|) is Undefined
-    <dd>Let |remote value| be a map matching the <code>UndefinedValue</code>
-    production in the [=local end definition=].
-
-    <dt>[=Type=](|value|) is Null
-    <dd>Let |remote value| be a map matching the <code>NullValue</code>
-    production in the [=local end definition=].
-
-    <dt>[=Type=](|value|) is String
-    <dd>Let |remote value| be a map matching the <code>StringValue</code>
-    production in the [=local end definition=], with the <code>value</code>
-    property set to |value|.
-
-    Issue: This doesn't handle lone surrogates
-
-    <dt>[=Type=](|value|) is Number
-    <dd>
-    1. Switch on the value of |value|:
-      <dl>
-        <dt>NaN
-        <dd>Let |serialized| be <code>"NaN"</code>
-        <dt>-0
-        <dd>Let |serialized| be <code>"-0"</code>
-        <dt>+Infinity
-        <dd>Let |serialized| be <code>"+Infinity"</code>
-        <dt>-Infinity
-        <dd>Let |serialized| be <code>"-Infinity"</code>
-        <dt>Otherwise:
-        <dd>Let |serialized| be |value|
-      </dl>
-
-    1. Let |remote value| be a map matching the <code>NumberValue</code>
-       production in the [=local end definition=], with the <code>value</code>
-       property set to |serialized|.
-
-    <dt>[=Type=](|value|) is Boolean
-    <dd>Let |remote value| be a map matching the <code>BooleanValue</code>
-        production in the [=local end definition=], with the <code>value</code>
-        property set to |value|.
-
-    <dt>[=Type=](|value|) is BigInt
-    <dd>Let |remote value| be a map matching the <code>BigIntValue</code>
-        production in the [=local end definition=], with the <code>value</code>
-        property set to the result of running the [=ToString=] operation on
-        |value|.
-
     <dt>[=Type=](|value|) is Symbol
-    <dd>Let |remote value| be a map matching the <code>SymbolValue</code>
+    <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
@@ -1226,7 +1323,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
               [=CreateArrayIterator=](|value|, value), |max depth|, |node details| and
               |set of known objects|.
 
-    1. Let |remote value| be a map matching the <code>ArrayValue</code> production
+    1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code> production
        in the [=local end definition=], with the <code>objectId</code> property set
        to the [=object id for an object=] |value|, and the <code>value</code>
        field set to |serialized| if it's not null, or ommitted otherwise.
@@ -1239,7 +1336,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
         1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
 
-        1. Let |remote value| be a map matching the <code>RegExpValue</code>
+        1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
            set to |serialized|
@@ -1248,7 +1345,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
     <dd>
       1. Let |serialized| be [=ToDateString=]([=thisTimeValue=](|value|)).
 
-      1. Let |remote value| be a map matching the <code>DateValue</code>
+      1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
          property set to the [=object id for an object=] |object| and the value
          set to |serialized|.
@@ -1265,7 +1362,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
               [=CreateMapIterator=](|value|, key+value), |max depth|, |node details| and
               |set of known objects|.
 
-    1. Let |remote value| be a map matching the <code>MapValue</code>
+    1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
        <code>objectId</code> property set to the [=object id for an object=]
        |value|, and the <code>value</code> field set to |serialized| if it's
@@ -1283,39 +1380,39 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
               [=CreateSetIterator=](|value|, value), |max depth|, |node details| and
               |set of known objects|.
 
-     1. Let |remote value| be a map matching the <code>SetValue</code>
+     1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
         <code>objectId</code> property set to the [=object id for an object=]
         |value|, and the <code>value</code> field set to |serialized| if it's
         not null, or ommitted otherwise.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
-    <dd>Let |remote value| be a map matching the <code>WeakMapValue</code>
+    <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
-    <dd>Let |remote value| be a map matching the <code>WeakSetValue</code>
+    <dd>Let |remote value| be a map matching the <code>WeakSetRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
-    <dd>Let |remote value| be a map matching the <code>ErrorValue</code>
+    <dd>Let |remote value| be a map matching the <code>ErrorRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
     <dt>[=IsPromise=](|value|)
-    <dd>Let |remote value| be a map matching the <code>PromiseValue</code>
+    <dd>Let |remote value| be a map matching the <code>PromiseRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
-    <dd>Let |remote value| be a map matching the <code>TypedArrayValue</code>
+    <dd>Let |remote value| be a map matching the <code>TypedArrayRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
-    <dd>Let |remote value| be a map matching the <code>ArrayBufferValue</code>
+    <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
         property set to the [=object id for an object=] |value|.
 
@@ -1329,7 +1426,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
           1. Set |serialized|["<code>nodeType</code>"] to [=Get=](|value|, "nodeType").
 
-          1. Set |serialized|["<code>nodeValue</code>"] to [=Get=](|value|, "nodeValue")
+          1. Set |serialized|["<code>NodeRemoteValue</code>"] to [=Get=](|value|, "nodeValue")
 
           1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
 
@@ -1389,7 +1486,7 @@ To <dfn>serialize as a remote value</dfn> given an |value|, a |max depth|,
 
              1. Set |serialized|["<code>shadowRoot</code>"] to |serialized shadow|.
 
-      1. Let |remote value| be a map matching the <code>NodeValue</code>
+      1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
          property set to the [=object id for an object=] |value|, and <code>value</code>
          set to |serialized|, if |serialized| is not null.
@@ -3281,6 +3378,13 @@ function with given arguments in a given realm.
 
  <code>RealmInfo</code> can be either a realm or a browsing context.
 
+```
+ArgumentValue = (
+   RemoteReference //
+   LocalValue
+);
+```
+
 Issue: declare `RemoteValueArgument`.
 
 Issue: declare `LocalValueArgument`.
@@ -3356,12 +3460,12 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |JS arguments list| be an empty list.
 
-1. For each |arg declaration| of |arguments declaration|:
+1. For each |argument declaration| of |arguments declaration|:
 
   Issue: describe |deserialize CallFunctionArgument|.
 
   1. Let |JS arg| be the result of
-     |deserialize CallFunctionArgument|(|arg declaration|).
+     |deserialize CallFunctionArgument|(|argument declaration|).
 
   1. Append |JS arg| to the |JS arguments list|.
 

--- a/index.bs
+++ b/index.bs
@@ -1181,11 +1181,11 @@ To <dfn>deserialize key-value list</dfn> given a
       let |deserialized key| be |serialized key|.
 
    1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize local value=]
-      with given |serialized key|.
+      with |serialized key|.
 
    1. Let |serialized value| be |serialized key-value|[1].
 
-   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
       |serialized value|.
 
    1. Append a <code>new [=Array=](|deserialized key|, |deserialized value|)</code>
@@ -1197,13 +1197,15 @@ To <dfn>deserialize key-value list</dfn> given a
 
 <div algorithm>
 
+Issue: TODO distinguish between `List` and `Array`.
+
 To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 1. Let |deserialized values| be a new list.
 
 1. For each |serialized value| in the |serialized value list|:
 
-   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with given
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
       |serialized value|.
 
    1. Append |deserialized value| to |deserialized values|;
@@ -1228,6 +1230,8 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
 
   Issue: TODO: define via `script.evaluate` to provide proper parse or runtime error handling.
 
+  Issue: TODO: add regex options.
+
   <dl>
 
     <dt>|type| is the string "<code>array</code>"
@@ -1246,14 +1250,14 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with given |value|.
+         [=deserialize key-value list=] with |value|.
 
       1. Return [=success=] with data <code>new [=Map=](|deserialized key-value list|)</code>.
 
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with given |value|.
+         [=deserialize key-value list=] with |value|.
 
       1. Return [=success=] with data
          <code>[=Object.fromEntries=](|deserialized key-value list|)</code>.
@@ -1264,7 +1268,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to
-         [=deserialize value list=] with given |value|.
+         [=deserialize value list=] with |value|.
 
       1. Return [=success=] with data <code>new [=Set=](|deserialized values|)</code>.
 
@@ -3597,7 +3601,7 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 1. For each |serialized argument| of |serialized arguments list|:
 
   1. Let |deserialized argument| be the result of [=trying=] to [=deserialize an argument value=]
-     with given |serialized argument|.
+     with |serialized argument|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -3625,7 +3629,6 @@ Note: the |function declaration| is parenthesized and evaluated.
 
 1. Return |function body evaluation status|.
 
-Issue: Define behavior in case of exception during script evaluation.
 </div>
 
 
@@ -3640,7 +3643,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |command arguments| be the value of the <code>arguments</code> field
    of |command parameters|.
 
-1. Let |deserialized arguments| be the result of [=trying=] to [=deserialize arguments=] with given
+1. Let |deserialized arguments| be the result of [=trying=] to [=deserialize arguments=] with
    |command arguments|.
 
 1. Let |function declaration| be the value of the

--- a/index.bs
+++ b/index.bs
@@ -3649,14 +3649,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |function body evaluation status| be the result of [=evaluate function body=]
    (|function declaration|, |environment settings|, |base URL|, and |options|).
 
-1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
-
-  1. Let |exception details| be the result of [=get exception details=] given
-     |function body evaluation status|.
-
-  1. Return a new map matching the <code>ScriptCallFunctionResultException</code>
-     production, with the <code>exceptionDetails</code> field set to
-     |exception details|.
+1. If |function body evaluation status|.\[[Type]] is <code>throw</code>, return [=error=] with
+   [=error code=] [=invalid argument=].
 
 1. Let |function object| be |function body evaluation status|.\[[Value]].
 


### PR DESCRIPTION
Specification of the `script.callFunction` command #140.
* #136 used as a blue print for `callFunction` steps.
* `RemoteValue` is split into `PrimitiveProtocolValue` and `RemoteValue`.
* Described `PrimitiveProtocolValue` deserialization.
* Introduced `LocalValue` type.
* Described `LocalValue` deserialization.
* Calling function is done in 3 steps: 
  1. Deserialize arguments.
  1. Evaluate function declaration.
  1. Call function with arguments.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver-bidi/pull/142.html" title="Last updated on Dec 2, 2021, 4:22 PM UTC (7c73549)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/142/f5ce465...sadym-chromium:7c73549.html" title="Last updated on Dec 2, 2021, 4:22 PM UTC (7c73549)">Diff</a>