### PR TITLE
Editorial: use HTML multipage URLs everywhere

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,25 +103,24 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: realm; url: sec-code-realms
     text: running execution context; url: running-execution-context
     text: time value; url: sec-time-values-and-time-range
-spec: HTML; urlPrefix: https://html.spec.whatwg.org/
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
-    text: WindowProxy; url: windowproxy
-    text: a browsing context is discarded; url: a-browsing-context-is-discarded
-    text: create a classic script; url: creating-a-classic-script
-    text: create a new browsing context; url: creating-a-new-browsing-context
-    text: default classic script fetch options; url: default-classic-script-fetch-options
-    text: environment settings object's Realm; url: environment-settings-object's-realm
-    text: handled; url: concept-error-handled
-    text: history handling behavior; url: history-handling-behavior
-    text: navigation id; url: concept-navigation-id
-    text: report an error; url: report-the-error
-    text: remove a browsing context; url: bcg-remove
-    text: session history; url: session-history
-    text: set up a window environment settings object; url: set-up-a-window-environment-settings-object
-    text: set up a worker environment settings object; url: set-up-a-worker-environment-settings-object
-    text: set up a worklet environment settings object; url: set-up-a-worklet-environment-settings-object
-    text: worker event loop; url: worker-event-loop-2
-    text: worklet global scopes; url: concept-document-worklet-global-scopes
+    text: a browsing context is discarded; url: window-object.html#a-browsing-context-is-discarded
+    text: create a classic script; url: multipage/webappapis.html#creating-a-classic-script
+    text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
+    text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
+    text: environment settings object's Realm; url: webappapis.html#environment-settings-object's-realm
+    text: handled; url: webappapis.html#concept-error-handled
+    text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
+    text: navigation id; url: browsing-the-web.html#navigation-id
+    text: report an error; url: webappapis.html#report-the-error
+    text: remove a browsing context; url: browsers.html#bcg-remove
+    text: session history; url: history.html#session-history
+    text: set up a window environment settings object; url: window-object.html#set-up-a-window-environment-settings-object
+    text: set up a worker environment settings object; url: workers.html#set-up-a-worker-environment-settings-object
+    text: set up a worklet environment settings object; url: worklets.html#set-up-a-worklet-environment-settings-object
+    text: worker event loop; url: webappapis.html#worker-event-loop-2
+    text: worklet global scopes; url: worklets.html#concept-document-worklet-global-scopes
 </pre>
 
 <pre class="link-defaults">

--- a/index.bs
+++ b/index.bs
@@ -106,7 +106,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     text: a browsing context is discarded; url: window-object.html#a-browsing-context-is-discarded
-    text: create a classic script; url: multipage/webappapis.html#creating-a-classic-script
+    text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
     text: environment settings object's Realm; url: webappapis.html#environment-settings-object's-realm


### PR DESCRIPTION
All automatically linked terms use the multipage URLs, so do that for
our custom terms as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/152.html" title="Last updated on Nov 30, 2021, 12:39 PM UTC (326d772)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/152/c0e2c44...326d772.html" title="Last updated on Nov 30, 2021, 12:39 PM UTC (326d772)">Diff</a>