### PR TITLE
Add a context parameter for browsingContext.create

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2876,7 +2876,8 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
       BrowsingContextCreateType = "tab" / "window"
 
       BrowsingContextCreateParameters = {
-        type: BrowsingContextCreateType
+        type: BrowsingContextCreateType,
+        ?referenceContext: BrowsingContext
       }
       </pre>
    </dd>
@@ -2896,6 +2897,19 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |type| be the value of the <code>type</code> field of
      |command parameters|.
 
+  1. Let |reference context id| be the value of the <code>referenceContext</code>
+     field of |command parameters|, if present, or null otherwise.
+
+  1. If |reference context id| is not null, let |reference context| be the
+     result of [=trying=] to [=get a browsing context=] with
+     |reference context id|. Otherwise let |reference context| be null.
+
+ 1. If |reference context| is not null and is not a [=top-level browsing context=],
+    return [=error=] with [=error code=] [=invalid argument=].
+
+  1. If the implementation is unable to create a new browsing context for any
+     reason then return [=error=] with [=error code=] [=unsupported operation=].
+
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->
   1. Create a new [=top-level browsing context=] by running the [=window open
@@ -2903,19 +2917,26 @@ The [=remote end steps=] with |command parameters| are:
      <var ignore>target</var> set to the empty string, and
      <var ignore>features</var> set to "<code>noopener</code>". This must be
      done without invoking the [=/focusing steps=] for the created browsing
-     context. If |type| is "<code>tab</code>", and the implementation supports
-     multiple browsing contexts in the same OS window, the new browsing context
-     should share an OS window with any other [=top-level browsing context=]. If
-     |type| is "<code>window</code>", and the implementation supports multiple
-     browsing contexts in separate OS windows, the created browsing context
-     should be in a new OS window. In all other cases the details of how the
-     browsing context is presented to the user are implementation defined.
+     context. Which OS window the new [=/browsing context=] is created in
+     depends on |type| and |reference context|:
 
-     Issue: HTML's [=window open steps=] depend on the "entry global object"
-     and WebDriver's <a href="https://w3c.github.io/webdriver/#new-window">New
-     Window</a> command depends on the "current browsing context". Given that we
-     don't have any such implicit context here, what OS window should new tabs
-     be opened in?
+     * If |type| is "<code>tab</code>" and the implementation supports
+       multiple browsing contexts in the same OS window:
+
+       * The new browsing context should reuse an existing OS window, if any.
+
+       * If |reference context| is not null, the new browsing context should
+         reuse the window containing |reference context|, if any. If the
+         top-level browsing contexts inside an OS window have a definite ordering,
+         the new browsing context should be immediately after
+         |reference context|'s [=top-level browsing context=] in that ordering.
+
+     * If |type| is "<code>window</code>", and the implementation supports
+       multiple browsing contexts in separate OS windows, the created browsing
+       context should be in a new OS window.
+
+     * Otherwise, the details of how the browsing context is presented to the
+       user are implementation defined.
 
   1. Let |context id| be the [=browsing context id=] of the newly created
      [=/browsing context=].


### PR DESCRIPTION
This is based on @jgraham's suggestion:
https://github.com/w3c/webdriver-bidi/pull/133#discussion_r757432132


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/153.html" title="Last updated on Nov 30, 2021, 3:23 PM UTC (f9f81f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/153/f5ce465...f9f81f6.html" title="Last updated on Nov 30, 2021, 3:23 PM UTC (f9f81f6)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/153.html" title="Last updated on Oct 5, 2022, 10:28 AM UTC (54abb51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/153/01c8d75...54abb51.html" title="Last updated on Oct 5, 2022, 10:28 AM UTC (54abb51)">Diff</a>