### PR TITLE
Line number of stack frame needs to be zero-based

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3065,7 +3065,7 @@ frame</dfn> corresponding to execution of a statement or expression in a script
  <dt><dfn for=stackframe>function</dfn>
  <dd>The name of the function being executed
  <dt><dfn for=stackframe>line number</dfn>
- <dd>The one-based line number of the executed code, relative to the top
+ <dd>The zero-based line number of the executed code, relative to the top
  of the resource containing |script|.
  <dt><dfn for=stackframe>column number</dfn>
  <dd>The zero-based column number of the executed code, relative to the start of


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/154.html" title="Last updated on Dec 2, 2021, 9:03 AM UTC (538c8cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/154/f5ce465...whimboo:538c8cd.html" title="Last updated on Dec 2, 2021, 9:03 AM UTC (538c8cd)">Diff</a>