### PR TITLE
Add some security checks when handling a websocket connection.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -552,11 +552,37 @@ implementation must proceed according to the WebSocket [=server-side
 requirements=], with the following steps run when deciding whether to
 accept the incoming connection:
 
-1. Let |resource name| be the resource name from [=reading the
-   client's opening handshake=]. If |resource name| is not in
-   |listener|'s [=list of WebSocket resources=], then stop
-   running these steps and act as if the requested service is not
+1. Using the data from [=reading the client's opening handshake=]:
+
+  1. Let |resource name| be the resource name.
+
+  1. Let |host| be the value of the Host header, if any, or undefined otherwise.
+
+  1. Let |origin| the the value of the Origin header, if any, or undefined
+     otherwise.
+
+1. If |resource name| is not in |listener|'s [=list of WebSocket resources=],
+   then stop running these steps and act as if the requested service is not
    available.
+
+1. If |host| is not an IP address, and is not a hostname that matches the
+   hostname of the WebSocket server or another hostname the implementation has
+   been configured to allow, or in any case if the implementation wants to
+   reject connections with |host| as the Host header, then stop running these
+   steps and act as if the requested service is not available.
+
+   Note: rejecting connections with unexpected values in the Host header
+   prevents DNS rebinding attacks. Implementations can opt to provide more
+   stringent controls where appropriate, for example only accepting connections
+   when the |host| value corresponds to a loopback interface [[!RFC5735]].
+
+1. If |origin| is not undefined, and does not match an origin that the
+   implementation has been configured to allow, then stop running these
+   steps and act as if the requested service is not available.
+
+   Note: rejecting connections with unexpected values in the Origin header is
+   necessary to prevent untrusted websites from establishing a WebDriver-BiDi
+   session.
 
 1. If |resource name| is the byte string "<code>/session</code>",
    and the implementation [=supports BiDi-only sessions=]:


### PR DESCRIPTION
Check the Host and Origin headers for the incoming connection to
verify the connection is allowed.

The language is intended to allow the specific behaviour to be largely
implementation defined, whilst recommending a default
behaviour that prevents CSRF-type attacks (reject host headers that
aren't an IP address or the server hostname, reject any requests with
an origin header).

Hopefully adding this text will ensure that implementations consider
the security issues accepting a connection, even though it's not
possible to give precise requirements that apply to all
implementations.