### PR TITLE
Support sandboxed script execution

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4029,6 +4029,63 @@ Issue: We might want to have a more sophisticated filter system than just a
 
 ### Events ### {#module-script-events}
 
+#### The script.postMessage Event #### {#event-script-postMessage}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        ScriptPostMessageEvent = {
+         method: "script.postMessage",
+         params: MessageInfo
+       }
+
+       MessageInfo = {
+         realm: Realm,
+         message: RemoteValue
+      }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The [=remote end event trigger=] is the <dfn>script postMessage</dfn> steps given |message| are:
+
+1. Let |serialize result| be the result of [=serialize as a remote value=] given
+   |message|.
+
+1. If |serialize result| is an error, then throw a [=TypeError=] exception and return.
+
+1. Let |serialized message| be |serialize result|'s [=data=].
+
+1. Let |related browsing contexts| be a set containing the
+   {{SandboxGlobalScope}}'s [=asssociated browsing context=].
+
+1. Let |realm| be the {{SandboxGlobalScope}}'s [=relevant realm=].
+
+1. [=Emit an postMessage event=] with |realm|, |serialized message| and |related
+   browsing contexts|.
+
+</div>
+
+<div algorithm>
+To <dfn>emit a postMessage event</dfn> given |realm|, |remote value|, and |related
+browsing contexts|:
+
+1. Let |message info| be a map matching the <code>MessageInfo</code> production,
+   with the <code>realm</code> field set to |realm| and the <code>message</code>
+   field set to |remote value|.
+
+1. Let |body| be a map matching the <code>ScriptPostMessageEvent</code>
+   production, with the <code>params</code> field set to |message info|.
+
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>script.realmpostMessage</code>" and |related browsing contexts|:
+
+  1. [=Emit an event=] with |session| and |body|.
+
+</div>
+
 #### The script.realmCreated Event #### {#event-script-realmCreated}
 
 <dl>

--- a/index.bs
+++ b/index.bs
@@ -1908,7 +1908,7 @@ in general?
 
 Issue: consider deprecate |node details| in favour of |max depth|.
 
-Issue: |children| and |child nodes| are different things. Either <code>childNodeCount</code> should
+Issue: |children| and child nodes are different things. Either <code>childNodeCount</code> should
 reference to <code>childNodes</code>, or it should be renamed to <code>childrenCount</code>.
 
 Issue: <code>nodeValue</code> can be null. Omit the field in such a case, or adjust type to allow
@@ -3824,7 +3824,7 @@ The [=remote end steps=] with |command parameters| are:
    [=Call=](|function object|, |this object|, |deserialized arguments|).
 
 1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is true,
-   and [=IsPromise=](|call evaluation status|.\[[Value]]):
+   and [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to
       <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).

--- a/index.bs
+++ b/index.bs
@@ -932,6 +932,138 @@ requests to start a WebDriver session, it must:
 
 </div>
 
+# Sandboxed Script Execution # {#sandbox}
+
+A common requirements for automation tools is to execute scripts which have
+access to the DOM of a document, but don't have information about any changes to
+the DOM APIs made by scripts running in the browsing context containing the
+document.
+
+A [=BiDi session=] has a <dfn>context sandbox map</dfn> which is a weak map
+in which the keys are [=browsing contexts=] and the values are weak maps between
+strings and {{SandboxWindowProxy}} objects.
+
+Note: The definition of sandboxes here is an attempt to codify the behaviour of
+existing implementations. It exposes parts of the implementations that have
+previously been considered internal by specifications, in particular the
+distinction between the internal state of platform objects (which is typically
+implemented as native objects in the main implementation language of the browser
+engine) and the ECMAScript-visible state. Because existing sandbox
+implementations happen at a low level in the engine, implementations converging
+toward the specficication in all details might be a slow process. In the
+meantime, implementors are encouraged to provide detailed documentation on any
+differences with the specification, and users of this feature are encouraged to
+explicitly test that scripts running in sandboxes work in all implementations.
+
+## Sandbox Realms ## {#sandbox-realm}
+
+Each sandbox is a unique EMCAScript [=Realm=]. However the sandbox realm
+provides access to platform objects in an existing {{Window}} realm via
+{{SandboxProxy}} objects.
+
+<div algorithm>
+To <dfn>get or create a sandbox realm</dfn> given |name| and |source browsing context|:
+
+1. If [=context sandbox map=] does not contain |name|, set |source browsing
+   context|[|name|] to a new map.
+
+1. Let |sandboxes| be [=context sandbox map=][|name|].
+
+1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to [=create
+   a sandbox realm=] with |source browsing context|.
+
+1. Return |sandboxes|[|name|].
+
+</div>
+
+<div algorithm>
+To <dfn>create a sandbox realm</dfn> with |source browsing context|:
+
+1. Let |agent| be
+
+1. Let |realm| be the result of [=creating a new JavaScript realm=] given |agent| and the following customizations:
+
+  * For the global object, create a new {{SandboxWindowProxy}} whose
+    \[[Wrapped]] internal slot is set to |source browsing context|'s {{WindowProxy}}
+
+1. Let |environment settings| be an [=environment settings object=] whose
+   algorithms are defined as follows:
+
+   <dl>
+       <dt>The [=realm execution context=]
+       <dd>
+
+       <dt>The [=module map=]
+       <dd>Issue: Not sure if this ought to be the module map of the assocaited
+       Document, or an empty module map.
+
+       <dt>The [=responsible document=]
+       <dd>Return |source browsing context|'s [=associated {{Document}}=]
+
+       <dt>The [=API URL character encoding=]
+       <dd>Return the current character encoding of |source browsing context|'s [=associated {{Document}}=].
+
+       <dt>The [=API base URL=]
+       <dd>Return the current [=base URL=] of |source browsing context|'s [=associated
+       {{Document}}=].
+
+       <dt>The [=origin=]
+       <dd>Return the [=origin=] of window's [=associated {{Document}}=].
+
+       <dt>The [=policy container=]
+       <dd>Issue: Unsure if we ought to use the same as the spurce browsing
+       context, or if we always want an empty policy container for the sandbox,
+       since e.g. CSP shouldn't apply.
+
+       <dt>The [=cross-origin isolated capability=]
+       <dd>Return the [=cross-origin isolated capability=] of |source browsing
+       context|'s [=associated {{Document}}=]'s [=environment settings object=].
+
+       <dt>The time origin
+       <dd>Return |source browsing context|'s [=associated
+        {{Document}}=]'s [=load timing info=]'s [=navigation start time=].
+  </dl>
+
+1. Set |realm|'s \[[HostDefined]] field to |environment settings|.
+
+1. Return |realm|.
+
+</div>
+
+
+## Sandbox Proxy Objects ## {#sandbox-proxy}
+
+A <dfn>SandboxProxy</dfn> object is an exotic object that mediates sandboxed access to
+objects from another realm. Sandbox proxy objects are designed to enforce the
+following restrictions:
+
+* Platform objects are accessible, but property access returns only
+  WebIDL-defined properties and not ECMAScript defined properties (either
+  "expando" properties that are not present in the underlying interface, or
+  ECMAScript defined properties that shadow a property in the underlying
+  interface.
+
+* Setting a property either runs the WebIDL-defined setter steps, or sets a
+  property on the proxy object. This means that properties written inside the
+  sandbox.
+
+There is no {{SandboxProxy}} interface object.
+
+Every {{SandboxProxy}} object has a \[[Wrapped]] internal slot representing the
+wrapped object.
+
+</div>
+
+## SandboxWindowProxy ## {#sandbox-sandboxwindowproxy}
+
+<xmp class=idl>
+interface SandboxWindowProxy : WindowProxy {};
+</xmp>
+
+A {{SandboxWindowProxy}} is a {{WindowProxy}} object wrapped by a
+{{SandboxProxy}} object.
+
+
 # Common Data Types # {#data-types}
 
 ## Reference ## {#data-types-reference}

--- a/index.bs
+++ b/index.bs
@@ -1052,6 +1052,27 @@ There is no {{SandboxProxy}} interface object.
 Every {{SandboxProxy}} object has a \[[Wrapped]] internal slot representing the
 wrapped object.
 
+Issue: All of the following algorithms are likely wrong.
+
+### \[[GetOwnProperty]] ( P ) ### {#sandbox-proxy-getOwnProperty}
+
+<div algorithm="SandboxProxy.getOwnProperty">
+The \[[GetOwnProperty]] algorithm for a {{SandboxProxy}} object |this|, given |P| is:
+
+1. Let |wrapper property| be `!` [=OrdinaryGetOwnProperty=](|this|, |P|).
+
+1. If |wrapper property| is not <code>undefined</code>, return |wrapper
+   property|.
+
+1. Let |wrapped| be |this|.\[[Wrapped]].
+
+1. If |wrapped| is a [=platform object=]:
+
+  1. If |P| is a [=member=] of an [=interface=] implemented by |wrapped|:
+
+    1. If |P| is an [=atrthtmlibute=], let |getter| be the [=attribute getter=]
+       function that was created on |wrapped| TODO
+
 </div>
 
 ## SandboxWindowProxy ## {#sandbox-sandboxwindowproxy}

--- a/index.bs
+++ b/index.bs
@@ -3586,6 +3586,32 @@ Record=] of type <code>throw</code>, |exception|, is given by:
 
 </div>
 
+#### The script.Result type #### {#type-script-Result}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+ScriptResult = (
+  ScriptResultSuccess //
+  ScriptResultException
+)
+
+ScriptResultSuccess = {
+  result: RemoteValue,
+  realm: Realm
+}
+
+ScriptResultException = {
+  exceptionDetails: ExceptionDetails
+  realm: Realm
+}
+</pre>
+
+The <code>Result</code> type indicates the return value of a command that
+executes script. The <code>ScriptResultSuccess</code> variant is used in cases
+where the script completes normally. and the <code>ScriptResultException</code>
+variant is used in cases where the script completes with a thrown exception.
+
 #### The script.Target type #### {#type-script-Target}
 
 [=Remote end definition=] and [=local end definition=]
@@ -3674,18 +3700,7 @@ argument doesn't affect function's <code>this</code> binding.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      ScriptCallFunctionResult = (
-        ScriptCallFunctionResultSuccess //
-        ScriptCallFunctionResultException
-      )
-
-      ScriptCallFunctionResultSuccess = {
-         result: RemoteValue
-      }
-
-      ScriptCallFunctionResultException = {
-        exceptionDetails: ExceptionDetails
-      }
+      ScriptCallFunctionResult = ScriptResult;
     </pre>
    </dd>
 </dl>
@@ -3789,7 +3804,7 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given
      |evaluation status|.
 
-  1. Return a new map matching the <code>ScriptCallFunctionResultException</code>
+  1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>exceptionDetails</code> field set to
      |exception details|.
 
@@ -3798,7 +3813,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]].
 
-1. Return a new map matching the <code>ScriptCallFunctionResultSuccess</code>
+1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>result</code> field set to |result|.
 
 #### The script.evaluate Command ####  {#command-script-evaluate}
@@ -3831,19 +3846,8 @@ case the resolved value of the promise is returned.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      ScriptEvaluateResult = (
-        ScriptEvaluateResultSuccess //
-        ScriptEvaluateResultException
-      )
-
-      ScriptEvaluateResultSuccess = {
-         result: RemoteValue
-      }
-
-      ScriptEvaluateResultException = {
-        exceptionDetails: ExceptionDetails
-      }
-    </pre>
+    ScriptEvaluateResult = ScriptResult;
+   </pre>
    </dd>
 </dl>
 
@@ -3888,7 +3892,7 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given |evaluation
      status|
 
-  1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+  1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>exceptionDetails</code> field set to |exception
      details|.
 
@@ -3897,7 +3901,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]].
 
-1. Return a new map matching the <code>ScriptEvaluateResultSuccess</code>
+1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>result</code> field set to |result|.
 
 #### The script.getRealms Command ####  {#command-script-getRealms}

--- a/index.bs
+++ b/index.bs
@@ -3752,6 +3752,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.
 
+1. Let |realm id| be |realm|'s [=realm id=].
+
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
@@ -3814,7 +3816,8 @@ The [=remote end steps=] with |command parameters| are:
    |evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
-   production, with the <code>result</code> field set to |result|.
+   production, with the <code>realm</code> field set to |realm id|,
+   and the <code>result</code> field set to |result|.
 
 #### The script.evaluate Command ####  {#command-script-evaluate}
 
@@ -3860,6 +3863,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.
 
+1. Let |realm id| be |realm|'s [=realm id=].
+
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
@@ -3893,8 +3898,8 @@ The [=remote end steps=] with |command parameters| are:
      status|
 
   1. Return a new map matching the <code>ScriptResultException</code>
-     production, with the <code>exceptionDetails</code> field set to |exception
-     details|.
+     production, with the <code>realm</code> field set to |realm id|, and the
+     <code>exceptionDetails</code> field set to |exception details|.
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
@@ -3902,7 +3907,8 @@ The [=remote end steps=] with |command parameters| are:
    |evaluation status|.\[[Value]].
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
-   production, with the <code>result</code> field set to |result|.
+   production, with the with the <code>realm</code> field set to |realm id|, and
+   the <code>result</code> field set to |result|.
 
 #### The script.getRealms Command ####  {#command-script-getRealms}
 

--- a/index.bs
+++ b/index.bs
@@ -3619,7 +3619,10 @@ variant is used in cases where the script completes with a thrown exception.
 <pre class="cddl local-cddl remote-cddl">
 RealmTarget = {realm: Realm};
 
-ContextTarget = {context: BrowsingContext}
+ContextTarget = {
+  context: BrowsingContext,
+  ?sandbox: text
+}
 
 Target = (
   RealmTarget //
@@ -3640,12 +3643,18 @@ To <dfn>get a realm from a target</dfn> given |target|:
   1. Let |context| be the result of [=trying=] to [=get a browsing context=]
      with |target|["<code>context</code>"].
 
-  1. Let |document| be |context|'s [=active document=].
+  1. If |target| does not contain a field named "<code>sandbox</code>":
 
-  1. Let |environment settings| be the [=environment settings object=] whose
-     [=responsible document=] is |document|.
+    1. Let |document| be |context|'s [=active document=].
 
-  1. Let |realm| be |environment settings|' [=realm execution context=]'s Realm component.
+    1. Let |environment settings| be the [=environment settings object=] whose
+       [=responsible document=] is |document|.
+
+    1. Let |realm| be |environment settings|' [=realm execution context=]'s
+       Realm component.
+
+  1. Otherwise: let |realm| be [=get or create a sandbox realm=] given
+     |target|["<code>sandbox</code>"] and |context|.
 
 1. Otherwise:
 


### PR DESCRIPTION
Allow running scripts in a sandbox environment, such that they have access to the DOM of  page, but don't share js-level state with the page.