### PR TITLE
Fix some bugs deserializing number primitives

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1110,6 +1110,13 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 
     <dt>|type| is the string "<code>number</code>"
     <dd>
+      1. If [=Type=](|value|) is Number, return [=success=] with data |value|.
+
+      1. Assert: [=Type=](|value|) is String.
+
+      1. If |value| is the string "<code>NaN</code>", return [=success=] with
+         data NaN.
+
       1. Let |number_result| be [=StringToNumber=](|value|).
 
       1. If |number_result| is NaN, return [=error=] with [=error code=] [=invalid argument=]


### PR DESCRIPTION
If the value is already a Number, just return it. If it's "NaN", handle that
explicitly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 14, 2021, 11:48 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2F4c9d79439ce1bd928753051d1cc2add0ed262806%2Findex.bs&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23161.)._
</details>
