### PR TITLE
Add reference to readiness state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -54,6 +54,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: no such element; url: dfn-no-such-element
     text: no such frame; url: dfn-no-such-frame
     text: process capabilities; url: dfn-processing-capabilities
+    text: readiness state; url: dfn-readiness-state
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
     text: session ID; url: dfn-session-id
@@ -2034,11 +2035,11 @@ ignore>command parameters</var> are:
 
    <dl>
       <dt>"ready"</dt>
-      <dd>The [=remote end=]’s readiness state.</dd>
+      <dd>The [=remote end=]’s [=readiness state=].</dd>
 
       <dt>"message"</dt>
-      <dd>An implementation-defined string explaining the [=remote end=]’s readiness
-   state.</dd>
+      <dd>An implementation-defined string explaining the [=remote end=]’s
+      [=readiness state=].</dd>
    </dl>
 
 1. Return [=success=] with data |body|


### PR DESCRIPTION
Fixes the remaining issue in #46 by adding a reference to the readiness state. I hope that works given that I cannot figure out how to built the spec locally.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/163.html" title="Last updated on Dec 16, 2021, 11:06 AM UTC (5bbf999)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/163/a2c295b...whimboo:5bbf999.html" title="Last updated on Dec 16, 2021, 11:06 AM UTC (5bbf999)">Diff</a>