### PR TITLE
Define the browsingContext.close command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -122,6 +122,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     text: a browsing context is discarded; url: window-object.html#a-browsing-context-is-discarded
+    text: close; url: window-object.html#close-a-browsing-context
     text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
@@ -2270,6 +2271,7 @@ navigation status</dfn> struct, which has the following items:
 <pre class="cddl remote-cddl">
 
 BrowsingContextCommand = (
+    BrowsingContextCloseCommand //
     BrowsingContextCreateCommand //
     BrowsingContextGetTreeCommand //
     BrowsingContextNavigateCommand //
@@ -2535,6 +2537,50 @@ To <dfn>get the navigation info</dfn>, given |context| and |navigation status|:
 </div>
 
 ### Commands ### {#module-browsingContext-commands}
+
+#### The browsingContext.close Command ####  {#command-browsingContext-close}
+
+The <dfn export for=commands>browsingContext.close</dfn> command closes a
+[=top-level browsing context=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      BrowsingContextCloseCommand = {
+        method: "browsingContext.close",
+        params: BrowsingContextCloseParameters
+      }
+
+      BrowsingContextCloseParameters = {
+        context: BrowsingContext
+      }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.close">
+The [=remote end steps=] with |command parameters| are:
+
+  1. Let |context id| be the value of the <code>context</code> field of
+     |command parameters|.
+
+  1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+     with |context id|.
+
+  1. Assert: |context| is not null.
+
+  1. If |context| is not a [=top-level browsing context=], return [=error=] with
+     [=error code=] [=invalid argument=].
+
+  1. [=Close=] |context|.
+
+Issue(w3c/webdriver-bidi#170): There is an open discussion about the behavior
+when closing the last [=top-level browsing context=]. We could expect to close
+the browser, close the session or leave this up to the implementation.
+
+</div>
+
 
 #### The browsingContext.create Command ####  {#command-browsingContext-create}
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver-bidi/issues/170.

This adds the definition for browsingContext.close. I copied and modified existing browsingContext commands and tried to match https://w3c.github.io/webdriver/#close-window.

Opening the PR to get a first round of feedback, thanks in advance!
cc @jgraham  @whimboo


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/172.html" title="Last updated on Feb 23, 2022, 5:44 PM UTC (7e73690)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/172/8b12b43...juliandescottes:7e73690.html" title="Last updated on Feb 23, 2022, 5:44 PM UTC (7e73690)">Diff</a>