### PR TITLE
`SharedReference` serialization + deserialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1636,7 +1636,7 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To get <dfn>shared id for a node</dfn> given |realm| and |node|:
+To get <dfn>shared id for a node</dfn> given |session|, |realm| and |node|:
 
 1. Let |node| be [=unwrapped=] |node|.
 
@@ -1646,8 +1646,8 @@ To get <dfn>shared id for a node</dfn> given |realm| and |node|:
 
 1. If |browsing context| is <code>null</code>, return <code>null</code>.
 
-1. Return [=get or create a node reference=] with [=current session=],
-   |browsing context| and |node|.
+1. Return [=get or create a node reference=] with |session|, |browsing context| and
+   |node|.
 
 </div>
 
@@ -1874,8 +1874,8 @@ Issue: handle String / Number / etc. wrapper objects specially?
 
 <div algorithm>
 
-To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-an |ownership type|, a |serialization internal map| and a |realm|:
+To <dfn>serialize as a remote value</dfn> given a |session|, a |value|,
+a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1900,7 +1900,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
-    <dd>Let |remote value| be [=serialize an Array-like=] with
+    <dd>Let |remote value| be [=serialize an Array-like=] with |session|,
         <code>ArrayRemoteValue</code>, |handle id|, |known object|, |value|,
         |max depth|, |ownership type|, |serialization internal map|, and |realm|.
 
@@ -1946,8 +1946,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     1. If |known object| is <code>false</code>, and |max depth| is not 0, run
        the following steps:
 
-       1. Let |serialized| be the result of [=serialize as a mapping=] given
-          [=CreateMapIterator=](|value|, key+value), |max depth|,
+       1. Let |serialized| be the result of [=serialize as a mapping=] with
+          |session|, [=CreateMapIterator=](|value|, key+value), |max depth|,
           |ownership type|, |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -1968,8 +1968,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     1. If |known object| is <code>false</code>, and |max depth| is not 0, run
        the following steps:
 
-       1. Let |serialized| be the result of [=serialize as a list=] given
-          [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
+       1. Let |serialized| be the result of [=serialize as a list=] with
+          |session|, [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
           |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -2018,7 +2018,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be [=shared id for a node=] given |realm| and
+      1. Let |shared id| be [=shared id for a node=] given |session|, |realm| and
          |value|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
@@ -2060,7 +2060,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
             1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
-               with |child|, |child depth|, |ownership type|,
+               with |session|, |child|, |child depth|, |ownership type|,
                |serialization internal map| and |realm|.
 
             1. Append |serialized| to |children|.
@@ -2090,7 +2090,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
                   null, or null otherwise.
 
                1. Let |serialized shadow| be the result of
-                  [=serialize as a remote value=] with |shadow root|, |child depth|,
+                  [=serialize as a remote value=] with |session|, |shadow root|, |child depth|,
                   false, |ownership type|, |serialization internal map| and |realm|.
 
                 Note: this means the <code>handle</code> for the shadow root
@@ -2133,8 +2133,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     1. If |known object| is <code>false</code>, and |max depth| is not 0, run
        the following steps:
 
-       1. Let |serialized| be the result of [=serialize as a mapping=] given
-          [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
+       1. Let |serialized| be the result of [=serialize as a mapping=] with
+          |session|, [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
           |ownership type|, |serialization internal map| and
           |realm|.
 
@@ -2160,7 +2160,7 @@ remove optional flag from the field.
 </div>
 
 <div algorithm>
-To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known object|,
+To <dfn>serialize an Array-like</dfn> given |session|, |production|, |handle id|, |known object|,
 |value|, |max depth|, |ownership type|, |serialization internal map|, and |realm|:
 
 1. Let |remote value| be a map matching |production|, with the
@@ -2184,7 +2184,7 @@ To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known ob
 </div>
 
 <div algorithm>
-To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |ownership type|,
+To <dfn>serialize as a list</dfn> given |session|, |iterable|, |max depth|, |ownership type|,
 |serialization internal map| and |realm|:
 
   1. Let |serialized| be a new list.
@@ -2195,7 +2195,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |ownership type
        otherwise.
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
-       with arguments |child value|, |child depth|, |ownership type|,
+       with |session|, |child value|, |child depth|, |ownership type|,
        |serialization internal map| and |realm|.
 
     1. Append |serialized child| to |serialized|.
@@ -2206,7 +2206,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |ownership type
 Issue: this assumes for-in works on iterators
 
 <div algorithm>
-To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
+To <dfn>serialize as a mapping</dfn> given |session|, |iterable|, |max depth|,
 |ownership type|, |serialization internal map| and |realm|:
 
 1. Let |serialized| be a new list.
@@ -2226,11 +2226,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with arguments |child key|, |child depth|, |ownership type|,
+     with |session|, |child key|, |child depth|, |ownership type|,
      |serialization internal map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with arguments |value|, |child depth|, |ownership type|,
+     with |session|, |value|, |child depth|, |ownership type|,
      |serialization internal map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
@@ -4052,8 +4052,8 @@ The <code>script.ExceptionDetails</code> type represents a JavaScript exception.
 
 <div algorithm>
 
-To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
-|record| and an |ownership type|:
+To <dfn>get exception details</dfn> given a |session|, a |realm|,
+a [=completion record=] |record| and an |ownership type|:
 
 1. Assert: |record|.\[[Type]] is <code>throw</code>.
 
@@ -4063,7 +4063,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
    TODO: Tighten up the requirements here; people will probably try to parse
    this data with regex or something equally bad.
 
-1. Let |exception| be the result of [=serialize as a remote value=] given
+1. Let |exception| be the result of [=serialize as a remote value=] with |session|,
    |record|.\[[Value]], <code>1</code> as max depth, |ownership type|,
    a new [=Map=] as serialization internal map and |realm|.
 
@@ -4796,7 +4796,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
 
    1. Let |exception details| be the result of [=get exception details=] given
-      |realm|, |function body evaluation status| and |result ownership|.
+      |session|, |realm|, |function body evaluation status| and |result ownership|.
 
    1. Return a new map matching the <code>script.EvaluateResultException</code>
       production, with the <code>exceptionDetails</code> field set to
@@ -4824,7 +4824,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |realm|, |evaluation status| and |result ownership|.
+     |session|, |realm|, |evaluation status| and |result ownership|.
 
   1. Return a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>exceptionDetails</code> field set to
@@ -4832,8 +4832,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
+1. Let |result| be the result of [=serialize as a remote value=] with
+   |session|, |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
    ownership|, <code>new map</code> as |serialization internal map| and |realm|.
 
 1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
@@ -4880,7 +4880,7 @@ TODO: Add timeout argument. It's not totally clear how this ought to work; in
 Chrome it seems like the timeout doesn't apply to the promise resolve step, but
 that likely isn't what clients want.
 
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.
@@ -4920,7 +4920,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |realm|, |evaluation status| and |result ownership|.
+     |session|, |realm|, |evaluation status| and |result ownership|.
 
   1. Return a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>realm</code> field set to |realm id|, and the
@@ -4928,8 +4928,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
+1. Let |result| be the result of [=serialize as a remote value=] with
+   |session|, |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
    ownership|, <code>new map</code> as |serialization internal map| and |realm|.
 
 1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
@@ -5368,7 +5368,7 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for log.entryAdded">
 
-Define the following [=console steps=] with |method|, |args|, and <var
+Define the following [=console steps=] with |session|, |method|, |args|, and <var
 ignore>options</var>:
 
 1. If |method| is "<code>error</code>" or "<code>assert</code>", let |level| be
@@ -5399,8 +5399,8 @@ ignore>options</var>:
 1. Let |serialized args| be a new list.
 
 1. For each |arg| of |args|:
-   1. Let |serialized arg| be the result of [=serialize as a remote value=] given
-      |arg| as value, <code>1</code> as max depth, <code>none</code> as
+   1. Let |serialized arg| be the result of [=serialize as a remote value=] with
+      |session|, |arg| as value, <code>1</code> as max depth, <code>none</code> as
       ownership type, a new [=Map=] as serialization internal map, and
       |realm|.
 
@@ -5550,11 +5550,14 @@ Other specifications can define <dfn>console steps</dfn>. When any method of the
 {{console}} interface is called, with method name
 |method| and argument |args|:
 
-1. If that method does not call the [=Printer=] operation, call any [=console
-   steps=] defined in external specification with arguments |method|, |args|,
-   and undefined.
+1. For each |session| in [=active BiDI sessions=]:
 
-   Otherwise, at the point when the [=Printer=] operation is called with
-   arguments |name|, |printerArgs| and |options| (which is undefined if the
-   argument is not provided), call any [=console steps=] defined in
-   external specification with arguments |name|, |printerArgs|, and |options|.
+  1. If that method does not call the [=Printer=] operation, call any [=console
+     steps=] defined in external specification with arguments |session|, |method|,
+     |args|, and undefined.
+
+     Otherwise, at the point when the [=Printer=] operation is called with
+     arguments |name|, |printerArgs| and |options| (which is undefined if the
+     argument is not provided), call any [=console steps=] defined in
+     external specification with arguments |session|, |name|, |printerArgs|, and
+     |options|.

--- a/index.bs
+++ b/index.bs
@@ -70,6 +70,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: session not created; url: dfn-session-not-created
     text: session; url: dfn-sessions
     text: set a property; url: dfn-set-a-property
+    text: shadow root reference; url: dfn-shadow-root-reference
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: trying; url: dfn-try

--- a/index.bs
+++ b/index.bs
@@ -427,6 +427,16 @@ with the following additional codes:
   <dd>Tried to remove an unknown [=preload script=].
 </dl>
 
+<dl>
+  <dt><dfn>No such handle</dfn>
+  <dd>Tried to deserialize an unknown <code>RemoteObjectReference</code>.
+</dl>
+
+<dl>
+  <dt><dfn>No such node</dfn>
+  <dd>Tried to deserialize an unknown <code>SharedReference</code>.
+</dl>
+
 <pre class="cddl local-cddl">
 ErrorCode = ("invalid argument" /
              "invalid session id" /

--- a/index.bs
+++ b/index.bs
@@ -1200,9 +1200,6 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.
 
-1. If |shared id| is <code>null</code>, return [=error=] with [=error code=]
-   [=invalid argument=].
-
 1. Let |node| be result of [=trying=] to [=get a node=] given [=current session=],
    |browsing context| and |shared id|.
 

--- a/index.bs
+++ b/index.bs
@@ -40,16 +40,20 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
     text: create a session; url: dfn-create-a-session
+    text: current session; url: dfn-current-session
     text: draw a bounding box from the framebuffer; url: dfn-draw-a-bounding-box-from-the-framebuffer
     text: encode a canvas as Base64; url: dfn-encoding-a-canvas-as-base64
     text: endpoint node; url: dfn-endpoint-node
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
+    text: get a node; url: dfn-get-a-node
+    text: get or create a node reference; url: dfn-get-or-create-a-node-reference
     text: getting a property; url: dfn-get-a-property
     text: http session; url: dfn-http-session
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: invalid session id; url: dfn-invalid-session-id
+    text: is stale; url: dfn-is-stale
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
     text: maximum active sessions; url: dfn-maximum-active-sessions
@@ -1161,7 +1165,8 @@ To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
 1. If |remote value| is <code>null</code> and |remote reference| matches the
   <code>SharedReference</code> production, set |remote value| to the result of
-  [=deserialize shared reference=] given |realm| and |remote reference|.
+  [=trying=] to [=deserialize shared reference=] given |realm| and
+  |remote reference|.
 
 1. If |remote value| is <code>null</code>, return [=error=] with [=error code=]
    [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -1218,15 +1218,22 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 1. If |node| is <code>null</code>, return [=error=] with [=error code=]
    [=no such node=].
 
+1. Let |environment settings| be the [=environment settings object=] whose
+   [=realm execution context=]'s Realm component is |realm|.
+
+1. If |node|'s [=node document=]'s [=document/origin=] is not [=same origin
+   domain=] with |environment settings|'s [=environment settings/origin=] then
+   return null.
+
+   Note: This ensures that WebDriver-BiDi can not be used to pass objects
+   between realms that do not otherwise permit script access.
+
 1. Let |realm global object| be the [=realm/global object=] of the |realm|.
 
 1. If the |realm global object| is {{SandboxWindowProxy}} object, set
    |node| to the {{SandboxProxy}} wrapping |node| in the |realm|.
 
 1. Return [=success=] with data |node|.
-
-TODO: Add check that `|node|`'s `ownerDocument`'s origin is same origin-domain with
-|browsing context|'s associated Document.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1205,15 +1205,14 @@ To <dfn>find platform object by shared reference</dfn> given |realm| and
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.
 
-1. If |browser context|'s [=list of known elements=] contains an |element|, which
+1. If |browser context|'s [=list of known elements=] contains an item, which
    [=web element reference=] equals to |shared id|, return the result of [=trying=]
    to [=get a known connected element=] with argument |shared id| and
    |browsing context|.
 
-1. If |browser context|'s [=list of known shadow roots=] contains an |element|, which
-   [=web element reference=] equals to |shared id|, return the result of [=trying=]
-   to [=get a known connected element=] with argument |shared id| and
-   |browsing context|.
+1. If |browser context|'s [=list of known shadow roots=] contains an item, which
+   [=shadow root reference=] equals to |shared id|, return the result of [=trying=]
+   to [=get a known shadow root=] with argument |shared id| and |browsing context|.
 
 1. Let |window| be the result of [=getting the top level window=] of the |realm|.
 

--- a/index.bs
+++ b/index.bs
@@ -1466,12 +1466,12 @@ To <dfn>deserialize key-value list</dfn> given |session|, |realm| and
       let |deserialized key| be |serialized key|.
 
    1. Otherwise let |deserialized key| be result of [=trying=] to
-      [=deserialize local value=] with |session|, |realm| and |serialized key|.
+      [=deserialize local value=] with |serialized key|, |realm| and |session|.
 
    1. Let |serialized value| be |serialized key-value|[1].
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
-      with |session|, |realm| and |serialized value|.
+      with |serialized value|, |realm| and |session|.
 
    1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
       |deserialized key-value list|.
@@ -1492,7 +1492,7 @@ To <dfn>deserialize value list</dfn> given |session|, |realm| and
 1. For each |serialized value| in the |serialized value list|:
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
-      with |session|, |realm| and |serialized value|.
+      with |serialized value|, |realm| and |session|.
 
    1. Append |deserialized value| to |deserialized values|;
 
@@ -1502,8 +1502,8 @@ To <dfn>deserialize value list</dfn> given |session|, |realm| and
 
 <div algorithm>
 
-To <dfn>deserialize local value</dfn> with given |session|, |realm| and
-|local protocol value|:
+To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm| and
+|session|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return
    [=deserialize remote reference=] with |session|, |realm| and
@@ -1636,7 +1636,7 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To get <dfn>shared id for a node</dfn> given |session|, |realm| and |node|:
+To get <dfn>shared id for a node</dfn> given |node|, |realm| and |session|:
 
 1. Let |node| be [=unwrapped=] |node|.
 
@@ -1874,8 +1874,8 @@ Issue: handle String / Number / etc. wrapper objects specially?
 
 <div algorithm>
 
-To <dfn>serialize as a remote value</dfn> given a |session|, a |value|,
-a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|:
+To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
+an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1947,8 +1947,8 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
        the following steps:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] with
-          |session|, [=CreateMapIterator=](|value|, key+value), |max depth|,
-          |ownership type|, |serialization internal map| and |realm|.
+          [=CreateMapIterator=](|value|, key+value), |max depth|,
+          |ownership type|, |serialization internal map|, |realm|, and |session|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
@@ -1970,7 +1970,7 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
 
        1. Let |serialized| be the result of [=serialize as a list=] with
           |session|, [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
-          |serialization internal map| and |realm|.
+          |serialization internal map|, |realm|, and |session|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
@@ -2018,8 +2018,8 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be [=shared id for a node=] given |session|, |realm| and
-         |value|.
+      1. Let |shared id| be [=shared id for a node=] given |value|, |realm| and
+         |session|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>sharedId</code>
@@ -2061,7 +2061,7 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
                with |session|, |child|, |child depth|, |ownership type|,
-               |serialization internal map| and |realm|.
+               |serialization internal map|, |realm|, and |session|.
 
             1. Append |serialized| to |children|.
 
@@ -2091,7 +2091,8 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |session|, |shadow root|, |child depth|,
-                  false, |ownership type|, |serialization internal map| and |realm|.
+                  false, |ownership type|, |serialization internal map|,
+                  |realm|, and |session|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -2135,8 +2136,8 @@ a |max depth|, an |ownership type|, a |serialization internal map| and a |realm|
 
        1. Let |serialized| be the result of [=serialize as a mapping=] with
           |session|, [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |ownership type|, |serialization internal map| and
-          |realm|.
+          |ownership type|, |serialization internal map|,
+          |realm|, and |session|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
@@ -2160,8 +2161,8 @@ remove optional flag from the field.
 </div>
 
 <div algorithm>
-To <dfn>serialize an Array-like</dfn> given |session|, |production|, |handle id|, |known object|,
-|value|, |max depth|, |ownership type|, |serialization internal map|, and |realm|:
+To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known object|,
+|value|, |max depth|, |ownership type|, |serialization internal map|, |realm|, and |session|:
 
 1. Let |remote value| be a map matching |production|, with the
    <code>handle</code> property set to |handle id| if it's not null, or omitted
@@ -2174,7 +2175,7 @@ To <dfn>serialize an Array-like</dfn> given |session|, |production|, |handle id|
 
   1. Let |serialized| be the result of [=serialize as a list=] given
      [=CreateArrayIterator=](|value|, value), |max depth|, |ownership type|,
-     |serialization internal map| and |realm|.
+     |serialization internal map|, |realm|, and |session|.
 
   1. If |serialized| is not null, set field <code>value</code> of |remote value| to
      |serialized|.
@@ -2184,8 +2185,8 @@ To <dfn>serialize an Array-like</dfn> given |session|, |production|, |handle id|
 </div>
 
 <div algorithm>
-To <dfn>serialize as a list</dfn> given |session|, |iterable|, |max depth|, |ownership type|,
-|serialization internal map| and |realm|:
+To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |ownership type|,
+|serialization internal map|, |realm|, and |session|:
 
   1. Let |serialized| be a new list.
 
@@ -2195,8 +2196,8 @@ To <dfn>serialize as a list</dfn> given |session|, |iterable|, |max depth|, |own
        otherwise.
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
-       with |session|, |child value|, |child depth|, |ownership type|,
-       |serialization internal map| and |realm|.
+       with |child value|, |child depth|, |ownership type|,
+       |serialization internal map|, |realm|, and |session|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -2206,8 +2207,8 @@ To <dfn>serialize as a list</dfn> given |session|, |iterable|, |max depth|, |own
 Issue: this assumes for-in works on iterators
 
 <div algorithm>
-To <dfn>serialize as a mapping</dfn> given |session|, |iterable|, |max depth|,
-|ownership type|, |serialization internal map| and |realm|:
+To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
+|ownership type|, |serialization internal map|, |realm|, and |session|:
 
 1. Let |serialized| be a new list.
 
@@ -2226,12 +2227,12 @@ To <dfn>serialize as a mapping</dfn> given |session|, |iterable|, |max depth|,
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with |session|, |child key|, |child depth|, |ownership type|,
-     |serialization internal map| and |realm|.
+     with |child key|, |child depth|, |ownership type|,
+     |serialization internal map|, |realm|, and |session|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with |session|, |value|, |child depth|, |ownership type|,
-     |serialization internal map| and |realm|.
+     with |value|, |child depth|, |ownership type|,
+     |serialization internal map|, |realm|, and |session|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
@@ -4052,8 +4053,8 @@ The <code>script.ExceptionDetails</code> type represents a JavaScript exception.
 
 <div algorithm>
 
-To <dfn>get exception details</dfn> given a |session|, a |realm|,
-a [=completion record=] |record| and an |ownership type|:
+To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
+|record|, an |ownership type| and a |session|:
 
 1. Assert: |record|.\[[Type]] is <code>throw</code>.
 
@@ -4063,9 +4064,9 @@ a [=completion record=] |record| and an |ownership type|:
    TODO: Tighten up the requirements here; people will probably try to parse
    this data with regex or something equally bad.
 
-1. Let |exception| be the result of [=serialize as a remote value=] with |session|,
+1. Let |exception| be the result of [=serialize as a remote value=] with
    |record|.\[[Value]], <code>1</code> as max depth, |ownership type|,
-   a new [=Map=] as serialization internal map and |realm|.
+   a new [=Map=] as serialization internal map, |realm| and |session|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -4716,15 +4717,15 @@ Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 <div algorithm>
 
-To <dfn>deserialize arguments</dfn> with given |session|, |realm| and
-|serialized arguments list|:
+To <dfn>deserialize arguments</dfn> with given |realm|, |serialized arguments list|
+and |session|:
 
 1. Let |deserialized arguments list| be an empty list.
 
 1. For each |serialized argument| of |serialized arguments list|:
 
   1. Let |deserialized argument| be the result of [=trying=] to
-     [=deserialize local value=] with |session|, |realm| and |serialized argument|.
+     [=deserialize local value=] with |serialized argument|, |realm| and |session|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -4771,7 +4772,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |deserialized arguments| be an empty list.
 
 1. If |command arguments| is not null, set |deserialized arguments| to the result of [=trying=] to
-   [=deserialize arguments=] with |session|, |realm| and |command arguments|.
+   [=deserialize arguments=] with |realm|, |command arguments| and |session|.
 
 1. Let |this parameter| be the value of the <code>this</code> field
    of |command parameters|.
@@ -4779,7 +4780,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |this object| be null.
 
 1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
-   [=deserialize local value=] with |session|, |realm| and |this parameter|.
+   [=deserialize local value=] with |this parameter|, |realm| and |session|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
@@ -4796,7 +4797,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
 
    1. Let |exception details| be the result of [=get exception details=] given
-      |session|, |realm|, |function body evaluation status| and |result ownership|.
+      |realm|, |function body evaluation status|, |result ownership| and |session|.
 
    1. Return a new map matching the <code>script.EvaluateResultException</code>
       production, with the <code>exceptionDetails</code> field set to
@@ -4824,7 +4825,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |session|, |realm|, |evaluation status| and |result ownership|.
+     |realm|, |evaluation status|, |result ownership| and |session|.
 
   1. Return a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>exceptionDetails</code> field set to
@@ -4833,8 +4834,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] with
-   |session|, |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
-   ownership|, <code>new map</code> as |serialization internal map| and |realm|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|,
+   |result ownership|, <code>new map</code> as |serialization internal map|, |realm|
+   and |session|.
 
 1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -4920,7 +4922,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |session|, |realm|, |evaluation status| and |result ownership|.
+     |realm|, |evaluation status|, |result ownership| and |session|.
 
   1. Return a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>realm</code> field set to |realm id|, and the
@@ -4929,8 +4931,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] with
-   |session|, |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
-   ownership|, <code>new map</code> as |serialization internal map| and |realm|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|,
+   <code>new map</code> as |serialization internal map|, |realm| and |session|.
 
 1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and
@@ -5368,8 +5370,8 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for log.entryAdded">
 
-Define the following [=console steps=] with |session|, |method|, |args|, and <var
-ignore>options</var>:
+Define the following [=console steps=] with |method|, |args|, |session| and
+<var ignore>options</var>:
 
 1. If |method| is "<code>error</code>" or "<code>assert</code>", let |level| be
    "<code>error</code>". If |method| is "<code>debug</code>" or "<code>trace</code>"
@@ -5400,9 +5402,9 @@ ignore>options</var>:
 
 1. For each |arg| of |args|:
    1. Let |serialized arg| be the result of [=serialize as a remote value=] with
-      |session|, |arg| as value, <code>1</code> as max depth, <code>none</code> as
-      ownership type, a new [=Map=] as serialization internal map, and
-      |realm|.
+      |arg| as value, <code>1</code> as max depth, <code>none</code> as
+      ownership type, a new [=Map=] as serialization internal map, |realm| and
+      |session|.
 
    1. Add |serialized arg| to |serialized args|.
 
@@ -5553,11 +5555,11 @@ Other specifications can define <dfn>console steps</dfn>. When any method of the
 1. For each |session| in [=active BiDI sessions=]:
 
   1. If that method does not call the [=Printer=] operation, call any [=console
-     steps=] defined in external specification with arguments |session|, |method|,
-     |args|, and undefined.
+     steps=] defined in external specification with arguments |method|,
+     |args|, |session| and undefined.
 
      Otherwise, at the point when the [=Printer=] operation is called with
      arguments |name|, |printerArgs| and |options| (which is undefined if the
      argument is not provided), call any [=console steps=] defined in
-     external specification with arguments |session|, |name|, |printerArgs|, and
+     external specification with arguments |name|, |printerArgs|, |session| and
      |options|.

--- a/index.bs
+++ b/index.bs
@@ -1218,7 +1218,7 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 1. If the |realm global object| is {{SandboxWindowProxy}} object, set
    |node| to the {{SandboxProxy}} wrapping |node| in the |realm|.
 
-1. Return |node|.
+1. Return [=success=] with data |node|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -432,7 +432,8 @@ ErrorCode = ("invalid argument" /
              "invalid session id" /
              "no such alert" /
              "no such frame" /
-             "no such reference" /
+             "no such handle" /
+             "no such node" /
              "no such script" /
              "session not created" /
              "unknown command" /
@@ -1179,7 +1180,7 @@ To <dfn>deserialize remote object reference</dfn> given |remote object reference
 1. Let |handle map| be |realm|'s [=handle object map=]
 
 1. If |handle map| does not contain |handle id|, then return [=error=] with
-   [=error code=] [=no such reference=].
+   [=error code=] [=no such handle=].
 
 1. Return [=success=] with data |handle map|[|handle id|].
 
@@ -1203,7 +1204,7 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
    |browsing context| and |shared id|.
 
 1. If |node| is <code>null</code>, return [=error=] with [=error code=]
-   [=no such reference=].
+   [=no such node=].
 
 1. Let |realm global object| be the [=realm/global object=] of the |realm|.
 

--- a/index.bs
+++ b/index.bs
@@ -2082,7 +2082,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
             1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
-               with |session|, |child|, |child depth|, |ownership type|,
+               with |child|, |child depth|, |ownership type|,
                |serialization internal map|, |realm|, and |session|.
 
             1. Append |serialized| to |children|.
@@ -2112,7 +2112,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
                   null, or null otherwise.
 
                1. Let |serialized shadow| be the result of
-                  [=serialize as a remote value=] with |session|, |shadow root|, |child depth|,
+                  [=serialize as a remote value=] with |shadow root|, |child depth|,
                   false, |ownership type|, |serialization internal map|,
                   |realm|, and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -1082,6 +1082,16 @@ There is no {{SandboxProxy}} interface object.
 
 Issue: Define in detail how {{SandboxProxy}} works
 
+<div algorithm>
+To get <dfn>unwrapped</dfn> |object|, get the result of the following steps:
+
+1. While |object| is {{SandboxProxy}}, set |object| to it's wrapped object.
+
+1. Return |object|.
+
+</div>
+
+
 ## SandboxWindowProxy ## {#sandbox-sandboxwindowproxy}
 
 A <dfn interface>SandboxWindowProxy</dfn> is an exotic object that represents a
@@ -1097,37 +1107,107 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
+Each {{Window}} has a corresponding <dfn>platform objects map</dfn>. This is a strong
+map from shared ids to their corresponding [=platform object=].
+
 <pre class="cddl remote-cddl">
 OwnershipModel = "root" / "none";
 </pre>
 
-<dfn>RemoteReference</dfn> represents a remote reference to an existing ECMAScript
-object in [=handle object map=] in the given [=Realm=].
+<dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
+representing a remote reference to an existing ECMAScript object in
+[=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
+representing a reference to a [=platform object=] in [=platform objects map=] in the
+given {{Window}}.
+
+In [=BiDi session=]:
+ * Each realm has an <dfn>object id map</dfn>, a weak map from objects to their
+   corresponding id. The [=object id map=] is unique per realm.
+ * Each {{Window}} has a <dfn>shared id map</dfn>, a weak map from
+   [=platform object=] to their corresponding shared id. The [=shared id map=] is
+   shared among all of the realms of the {{Window}}.
 
 <pre class="cddl remote-cddl local-cddl">
+RemoteReference = {
+  RemoteObjectReference //
+  SharedReference
+}
+
 Handle = text;
 
-RemoteReference = {
+RemoteObjectReference = {
    handle: Handle,
    Extensible
+}
+
+SharedId = text;
+
+SharedReference = {
+   sharedId: SharedId,
+   *text => any,
 }
 </pre>
 
 Issue: handle "stale object reference" case.
 
+Note: if the provided reference has both <code>handle</code> and
+<code>sharedId</code>, the algorithm will first try to resolve <code>handle</code>,
+then <code>sharedId</code>, and if non of that succeeded, return a error.
+
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
-1. Let |handle id| be the value of the <code>handle</code> field of |remote reference|.
+1. Let |remote value| be <code>null</code>.
+
+1. If |remote reference| matches the <code>RemoteObjectReference</code>
+   production, set |remote value| to the result of
+   [=deserialize remote object reference=] given |realm| and |remote reference|.
+
+1. If |remote value| is <code>null</code> and |remote reference| matches the
+  <code>SharedReference</code> production, set |remote value| to the result of
+  [=deserialize shared reference=] given |realm| and |remote reference|.
+
+1. If |remote value| is <code>null</code>, return [=error=] with [=error code=]
+   [=invalid argument=].
+
+1. Return [=success=] with data |remote value|.
+
+</div>
+
+<div algorithm>
+To <dfn>deserialize remote object reference</dfn> given |realm| and
+|remote object reference|:
+
+1. Let |handle id| be the value of the <code>handle</code> field of
+   |remote object reference|.
 
 1. Let |handle map| be |realm|'s [=handle object map=]
 
-1. If |handle map| does not contain |handle id|, then return [=error=] with
-   [=error code=] [=invalid argument=].
+1. If |handle map| does not contain |handle id|, then return <code>null</code>.
 
 1. Return |handle map|[|handle id|].
 
 </div>
+
+<div algorithm>
+To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
+
+1. Let |window| be the result of [=get the window=] of the |realm|.
+
+1. If |window| is <code>null</code>, return <code>null</code>.
+
+1. Let |shared id| be the value of the <code>sharedId</code> field of
+   |shared reference|.
+
+1. Let |platform objects map| be |window|'s [=platform objects map=].
+
+1. If |platform objects map| does not contain key |shared id|, then return
+   <code>null</code>.
+
+1. Return |platform objects map|[|shared id|].
+
+</div>
+
 
 ## Protocol Value ## {#data-types-protocolValue}
 
@@ -1543,6 +1623,32 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
+To get the <dfn>shared id for an object</dfn> given a |realm|, |ownership type|  and
+|object|:
+
+1. If |ownership type| is equal "<code>none</code>", return <code>null</code>.
+
+1. If |object| is not a [=platform object=], return <code>null</code>.
+
+1. Let |window| be the result of [=get the window=] of the |realm|.
+
+1. If |window| is <code>null</code>, return <code>null</code>.
+
+1. Let |platform objects map| be |window|'s [=platform objects map=].
+
+1. If |platform objects map| contains value |object|, then return |object|'s key in
+   |platform objects map| as a result.
+
+1. Let |shared id| be a new, unique, string handle for |object|.
+
+1. Set |platform objects map|[|shared id|] to |object|.
+
+1. Return |shared id| as a result.
+
+</div>
+
+
+<div algorithm>
 To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
 |remote value| and |object|:
 
@@ -1905,11 +2011,16 @@ an |ownership type|, a |serialization internal map| and a |realm|:
         |max depth|, |ownership type|, |known object|, |serialization internal map|,
         and |realm|.
 
-    <dt>|value| is a [=platform object=] that implements [=Node=]
+    <dt>[=unwrapped=] |value| is a [=platform object=] that implements [=Node=]
     <dd>
+      1. Let |shared id| be the [=shared id for an object=] given |realm|,
+         |ownership type| and |value|.
+
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle id| if it's not null, or omitted otherwise.
+         property set to |handle id| if it's not null, or omitted otherwise, and with
+         the <code>sharedId</code> property set to |shared id| if it's not null, or
+         omitted otherwise.
 
       1. [=Set internal ids if needed=] given |serialization internal map|,
          |remote value| and |value|.
@@ -4083,6 +4194,19 @@ Note: there's a 1:1 relationship between the <code>script.RealmInfo</code>
       <a href="#type-script-RealmType"><code>script.RealmType</code></a>.
 
 The <code>script.RealmInfo</code> type represents the properties of a realm.
+
+<div algorithm>
+To <dfn>get the window</dfn> of the given |realm|:
+
+1. Let |global object| be the [=realm/global object=] of the |realm|.
+
+1. Let |global object| be [=unwrapped=] |global object|.
+
+1. If |global object| is a {{Window}} object, return |global object|.
+
+1. Return <code>null</code>.
+
+</div
 
 <div algorithm>
 To <dfn>get the realm info</dfn> given |environment settings|:

--- a/index.bs
+++ b/index.bs
@@ -1506,7 +1506,7 @@ To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
 |session|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] with |local protocol value|, |realm| and
+   [=deserialize remote reference=] of given |local protocol value|, |realm| and
    |session|.
 
 1. If |local protocol value| matches the [=PrimitiveProtocolValue=] production, return
@@ -1544,7 +1544,7 @@ To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with |value|, |realm| and |session|.
+         [=deserialize key-value list=] given |value|, |realm| and |session|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 

--- a/index.bs
+++ b/index.bs
@@ -1623,10 +1623,7 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To get the <dfn>shared id for an object</dfn> given a |realm|, |ownership type|  and
-|object|:
-
-1. If |ownership type| is equal "<code>none</code>", return <code>null</code>.
+To get the <dfn>shared id for an object</dfn> given a |realm| and |object|:
 
 1. If |object| is not a [=platform object=], return <code>null</code>.
 
@@ -1830,6 +1827,7 @@ HTMLCollectionRemoteValue = {
 
 NodeRemoteValue = {
   type: "node",
+  sharedId: SharedId,
   ?handle: Handle,
   ?internalId: InternalId,
   ?value: NodeProperties,
@@ -2013,14 +2011,13 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>[=unwrapped=] |value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be the [=shared id for an object=] given |realm|,
-         |ownership type| and |value|.
+      1. Let |shared id| be the [=shared id for an object=] given |realm| and
+         |value|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
-         production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle id| if it's not null, or omitted otherwise, and with
-         the <code>sharedId</code> property set to |shared id| if it's not null, or
-         omitted otherwise.
+         production in the [=local end definition=], with the <code>sharedId</code>
+         property set to |shared id|, and the <code>handle</code> property set to
+         |handle id| if it's not null, or omitted otherwise.
 
       1. [=Set internal ids if needed=] given |serialization internal map|,
          |remote value| and |value|.

--- a/index.bs
+++ b/index.bs
@@ -4205,9 +4205,8 @@ To <dfn>get the top level window</dfn> of the given |realm|:
 
 1. Let |global object| be the [=realm/global object=] of the |realm|.
 
-1. While |global object| is a {{Window}} object and has a [=parent=]:
-
-  1. Set |global object| to |global object|'s [=parent=].
+1. While |global object| is a {{Window}} object and has a non-null [=parent=], set
+   |global object| to |global object|'s [=parent=].
 
 1. If |global object| is not a {{Window}} object, return <code>null</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -1153,24 +1153,25 @@ only <code>sharedId</code>.
 ### Deserialization ### {#data-types-reference-deserialization}
 
 <div algorithm>
-To <dfn>deserialize remote reference</dfn> given |session|, |realm| and |remote reference|:
+To <dfn>deserialize remote reference</dfn> given |remote reference|, |realm| and
+|session|:
 
 1. Assert |remote reference| matches the <code>RemoteReference</code> production.
 
 1. If |remote reference| matches the <code>SharedReference</code> production, return
-   [=deserialize shared reference=] given |session|, |realm| and |remote reference|.
+   [=deserialize shared reference=] given |remote reference|, |realm| and |session|.
 
 1. Assert |remote reference| matches the <code>RemoteObjectReference</code>
    production.
 
-1. Return [=deserialize remote object reference=] given |realm| and
-   |remote reference|.
+1. Return [=deserialize remote object reference=] given |remote reference| and
+   |realm|.
 
 </div>
 
 <div algorithm>
-To <dfn>deserialize remote object reference</dfn> given |realm| and
-|remote object reference|:
+To <dfn>deserialize remote object reference</dfn> given |remote object reference| and
+|realm|:
 
 1. Let |handle id| be the value of the <code>handle</code> field of
    |remote object reference|.
@@ -1185,7 +1186,8 @@ To <dfn>deserialize remote object reference</dfn> given |realm| and
 </div>
 
 <div algorithm>
-To <dfn>deserialize shared reference</dfn> given |session|, |realm| and |shared reference|:
+To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
+|session|:
 
 1. Assert |remote reference| matches the <code>SharedReference</code> production.
 
@@ -1503,8 +1505,8 @@ To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm|
 |session|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] with |session|, |realm| and
-   |local protocol value|.
+   [=deserialize remote reference=] with |local protocol value|, |realm| and
+   |session|.
 
 1. If |local protocol value| matches the [=PrimitiveProtocolValue=] production, return
    [=deserialize primitive protocol value=] with |local protocol value|.

--- a/index.bs
+++ b/index.bs
@@ -1126,8 +1126,8 @@ OwnershipModel = "root" / "none";
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
 representing a reference to a [=platform object=] in the given
-[=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] on
-in the given {{Window}}'s [=platform objects map=].
+[=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] or
+in the top level {{Window}}'s [=platform objects map=].
 
 <pre class="cddl remote-cddl local-cddl">
 RemoteReference = {

--- a/index.bs
+++ b/index.bs
@@ -1085,7 +1085,8 @@ Issue: Define in detail how {{SandboxProxy}} works
 <div algorithm>
 To get <dfn>unwrapped</dfn> |object|, get the result of the following steps:
 
-1. While |object| is {{SandboxProxy}}, set |object| to it's wrapped object.
+1. While |object| is {{SandboxProxy}} or {{SandboxWindowProxy}}, set |object| to it's
+   wrapped object.
 
 1. Return |object|.
 
@@ -1204,9 +1205,21 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 1. If |platform objects map| does not contain key |shared id|, then return
    <code>null</code>.
 
-1. Return |platform objects map|[|shared id|].
+1. Let |platform object| be the |platform objects map|[|shared id|].
+
+1. Assert |platform object| is a [=platform object=].
+
+1. Let |realm global object| be the [=realm/global object=] of the |realm|.
+
+1. If the |realm global object| is {{SandboxWindowProxy}} object, set
+   |platform object| to the {{SandboxProxy}} wrapping |platform object| in the
+   |realm|.
+
+1. Return |platform object|.
 
 </div>
+
+Issue: return existing {{SandboxProxy}} if exists.
 
 
 ## Protocol Value ## {#data-types-protocolValue}

--- a/index.bs
+++ b/index.bs
@@ -1466,12 +1466,12 @@ and |session|:
       let |deserialized key| be |serialized key|.
 
    1. Otherwise let |deserialized key| be result of [=trying=] to
-      [=deserialize local value=] with |serialized key|, |realm| and |session|.
+      given [=deserialize local value=] with |serialized key|, |realm| and |session|.
 
    1. Let |serialized value| be |serialized key-value|[1].
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
-      with |serialized value|, |realm| and |session|.
+      given |serialized value|, |realm| and |session|.
 
    1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
       |deserialized key-value list|.
@@ -1492,7 +1492,7 @@ To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and
 1. For each |serialized value| in the |serialized value list|:
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
-      with |serialized value|, |realm| and |session|.
+      given |serialized value|, |realm| and |session|.
 
    1. Append |deserialized value| to |deserialized values|;
 
@@ -4837,9 +4837,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|,
-   |result ownership|, <code>new map</code> as |serialization internal map|, |realm|
-   and |session|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|,
+   <code>new map</code> as |serialization internal map|, |realm| and |session|.
 
 1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,

--- a/index.bs
+++ b/index.bs
@@ -1114,8 +1114,9 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
-Each {{Window}} has a corresponding <dfn>platform objects map</dfn>. This is a weak
-map from shared ids to their corresponding [=platform object=].
+Each {{Window}} with [=/parent=] <code>null</doce> has a corresponding
+<dfn>platform objects map</dfn>. This is a weak map from shared ids to their
+corresponding [=platform object=].
 
 <pre class="cddl remote-cddl">
 OwnershipModel = "root" / "none";
@@ -1145,7 +1146,7 @@ SharedId = text;
 
 SharedReference = {
    sharedId: SharedId,
-   *text => any,
+   Extensible
 }
 </pre>
 
@@ -1154,6 +1155,8 @@ Issue: handle "stale object reference" case.
 Note: if the provided reference has both <code>handle</code> and
 <code>sharedId</code>, the algorithm will first try to resolve <code>handle</code>,
 then <code>sharedId</code>, and if non of that succeeded, return a error.
+
+### Deserialization ### {#data-types-reference-deserialization}
 
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
@@ -1212,7 +1215,7 @@ To <dfn>find platform object by shared reference</dfn> given |realm| and
    to [=get a known connected element=] with argument |shared id| and
    |browsing context|.
 
-1. Let |window| be the result of [=get the window=] of the |realm|.
+1. Let |window| be the result of [=getting the top level window=] of the |realm|.
 
 1. If |window| is <code>null</code>, return <code>null</code>.
 
@@ -1227,7 +1230,7 @@ To <dfn>find platform object by shared reference</dfn> given |realm| and
 
 1. Let |realm global object| be the [=realm/global object=] of the |realm|.
 
-1. If the |realm global object| is {{SandboxWindowProxy}} object, set
+1. If the |realm global object| is {{SandboxWindowProxy}} object, return set
    |platform object| to the {{SandboxProxy}} wrapping |platform object| in the
    |realm|.
 
@@ -1254,9 +1257,6 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 1. Return |platform object|.
 
 </div>
-
-Issue: return existing {{SandboxProxy}} if exists.
-
 
 ## Protocol Value ## {#data-types-protocolValue}
 
@@ -1698,7 +1698,7 @@ To get the <dfn>shared id for an object</dfn> given a |realm| and |object|:
   1. Return the result of [=trying=] to [=get or create a shadow root reference=]
      with |object| and |browsing context|.
 
-1. Let |window| be the result of [=get the window=] of the |realm|.
+1. Let |window| be the result of [=getting the top level window=] of the |realm|.
 
 1. If |window| is <code>null</code>, return <code>null</code>.
 
@@ -4264,22 +4264,28 @@ Note: there's a 1:1 relationship between the <code>script.RealmInfo</code>
 The <code>script.RealmInfo</code> type represents the properties of a realm.
 
 <div algorithm>
-To <dfn>get the window</dfn> of the given |realm|:
+Steps of <dfn>getting the top level window</dfn> of the given |realm|:
 
 1. Let |global object| be the [=realm/global object=] of the |realm|.
 
 1. Let |global object| be [=unwrapped=] |global object|.
 
-1. If |global object| is a {{Window}} object, return |global object|.
+1. If |global object| is not a {{Window}} object, return <code>null</code>.
 
-1. Return <code>null</code>.
+1. While |global object| has a [=/parent=]:
+
+  1. Set |global object| to |global object|'s [=/parent=].
+
+  1. If |global object| is not a {{Window}} object, return <code>null</code>.
+
+1. Return |global object|.
 
 </div
 
 <div algorithm>
 To <dfn>get the browsing context</dfn> of the given |realm|:
 
-1. Let |window| be the [=get the window=] of the |realm|.
+1. Let |window| be the result of [=getting the top level window=] of the |realm|.
 
 1. Let |global object| be [=unwrapped=] |global object|.
 

--- a/index.bs
+++ b/index.bs
@@ -1195,7 +1195,7 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 1. Let |browsing context| be [=get the browsing context=] with |realm|.
 
 1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
-   [=invalid argument=].
+   [=no such frame=].
 
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.

--- a/index.bs
+++ b/index.bs
@@ -1203,11 +1203,8 @@ To <dfn>deserialize shared reference</dfn> given |session|, |realm| and |shared 
 1. Let |node| be result of [=trying=] to [=get a node=] given [=current session=],
    |browsing context| and |shared id|.
 
-1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
-   [=no such element=].
-
-1. If |node| [=is stale=], return [=error=] with [=error code=]
-   [=stale element reference=].
+1. If |node| is <code>null</code>, return [=error=] with [=error code=]
+   [=no such reference=].
 
 1. Let |realm global object| be the [=realm/global object=] of the |realm|.
 
@@ -1215,6 +1212,9 @@ To <dfn>deserialize shared reference</dfn> given |session|, |realm| and |shared 
    |node| to the {{SandboxProxy}} wrapping |node| in the |realm|.
 
 1. Return [=success=] with data |node|.
+
+TODO: Add check that `|node|`'s `ownerDocument`'s origin is same origin-domain with
+|context|'s associated Document.
 
 </div>
 
@@ -4218,13 +4218,16 @@ To <dfn>get the top level window</dfn> with given |realm|:
 <div algorithm>
 To <dfn>get the browsing context</dfn> with given |realm|:
 
-1. Let |window| be [=get the top level window=] with |realm|.
+1. Let |global object| be the [=realm/global object=] of the |realm|.
 
-1. If |window| is <code>null</code>, return <code>null</code>.
+1. Let |global object| be the [=unwrapped=] |global object|.
 
-1. Let |window| be [=unwrapped=] |window|.
+1. If |global object| is not a {{Window}} object, return <code>null</code>.
 
-1. Return |window|'s [=/browsing context=].
+1. Let |document| be |global object|'s wrapped {{Window}}'s
+   <a>associated <code>Document</code></a>.
+
+1. Return |document|'s [=/browsing context=].
 
 </div
 

--- a/index.bs
+++ b/index.bs
@@ -424,17 +424,17 @@ WebDriver BiDi extends the set of [=error codes=] from [[WEBDRIVER|WebDriver]]
 with the following additional codes:
 
 <dl>
-  <dt><dfn>No such script</dfn>
+  <dt><dfn>no such script</dfn>
   <dd>Tried to remove an unknown [=preload script=].
 </dl>
 
 <dl>
-  <dt><dfn>No such handle</dfn>
+  <dt><dfn>no such handle</dfn>
   <dd>Tried to deserialize an unknown <code>RemoteObjectReference</code>.
 </dl>
 
 <dl>
-  <dt><dfn>No such node</dfn>
+  <dt><dfn>no such node</dfn>
   <dd>Tried to deserialize an unknown <code>SharedReference</code>.
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -1502,7 +1502,7 @@ To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and
 
 <div algorithm>
 
-To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm| and
+To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
 |session|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return

--- a/index.bs
+++ b/index.bs
@@ -435,6 +435,7 @@ ErrorCode = ("invalid argument" /
              "invalid session id" /
              "no such alert" /
              "no such frame" /
+             "no such reference" /
              "no such script" /
              "session not created" /
              "unknown command" /
@@ -1128,10 +1129,10 @@ SharedId = text;
 </pre>
 
 <pre class="cddl remote-cddl">
-RemoteReference = {
+RemoteReference = (
   RemoteObjectReference //
   SharedReference
-}
+)
 
 RemoteObjectReference = {
    handle: Handle,
@@ -1149,29 +1150,24 @@ SharedReference = {
 Issue: handle "stale object reference" case.
 
 Note: if the provided reference has both <code>handle</code> and
-<code>sharedId</code>, the algorithm will first try to resolve <code>handle</code>,
-then <code>sharedId</code>, and if non of that succeeded, return a error.
+<code>sharedId</code>, the algorithm will ignore <code>handle</code> and respect
+only <code>sharedId</code>.
 
 ### Deserialization ### {#data-types-reference-deserialization}
 
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
-1. Let |remote value| be <code>null</code>.
+1. Assert |remote reference| matches the <code>RemoteReference</code> production.
 
-1. If |remote reference| matches the <code>RemoteObjectReference</code>
-   production, set |remote value| to the result of
-   [=deserialize remote object reference=] given |realm| and |remote reference|.
+1. If |remote reference| matches the <code>SharedReference</code> production, return
+   [=deserialize shared reference=] given |realm| and |remote reference|.
 
-1. If |remote value| is <code>null</code> and |remote reference| matches the
-  <code>SharedReference</code> production, set |remote value| to the result of
-  [=trying=] to [=deserialize shared reference=] given |realm| and
-  |remote reference|.
+1. Assert |remote reference| matches the <code>RemoteObjectReference</code>
+   production.
 
-1. If |remote value| is <code>null</code>, return [=error=] with [=error code=]
-   [=invalid argument=].
-
-1. Return [=success=] with data |remote value|.
+1. Return [=deserialize remote object reference=] given |realm| and
+   |remote reference|.
 
 </div>
 
@@ -1184,16 +1180,19 @@ To <dfn>deserialize remote object reference</dfn> given |realm| and
 
 1. Let |handle map| be |realm|'s [=handle object map=]
 
-1. If |handle map| does not contain |handle id|, then return <code>null</code>.
+1. If |handle map| does not contain |handle id|, then return [=error=] with
+   [=error code=] [=no such reference=].
 
-1. Return |handle map|[|handle id|].
+1. Return [=success=] with data |handle map|[|handle id|].
 
 </div>
 
 <div algorithm>
 To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 
-1. Let |browsing context| be [=get the browsing context=] of the |realm|.
+1. Assert |remote reference| matches the <code>SharedReference</code> production.
+
+1. Let |browsing context| be [=get the browsing context=] with |realm|.
 
 1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
    [=invalid argument=].
@@ -1642,7 +1641,7 @@ To get <dfn>shared id for a node</dfn> given |realm| and |node|:
 
 1. If |node| is not a [=node=], return <code>null</code>.
 
-1. Let |browsing context| be [=get the browsing context=] of the |realm|.
+1. Let |browsing context| be [=get the browsing context=] with |realm|.
 
 1. If |browsing context| is <code>null</code>, return <code>null</code>.
 
@@ -4201,7 +4200,7 @@ Note: there's a 1:1 relationship between the <code>script.RealmInfo</code>
 The <code>script.RealmInfo</code> type represents the properties of a realm.
 
 <div algorithm>
-To <dfn>get the top level window</dfn> of the given |realm|:
+To <dfn>get the top level window</dfn> with given |realm|:
 
 1. Let |global object| be the [=realm/global object=] of the |realm|.
 
@@ -4215,9 +4214,9 @@ To <dfn>get the top level window</dfn> of the given |realm|:
 </div
 
 <div algorithm>
-To <dfn>get the browsing context</dfn> of the given |realm|:
+To <dfn>get the browsing context</dfn> with given |realm|:
 
-1. Let |window| be [=get the top level window=] of the |realm|.
+1. Let |window| be [=get the top level window=] with |realm|.
 
 1. If |window| is <code>null</code>, return <code>null</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -1114,7 +1114,7 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
-Each {{Window}} with [=parent=] <code>null</doce> has a corresponding
+Each {{Window}} with [=parent=] <code>null</code> has a corresponding
 <dfn>platform objects map</dfn>. This is a weak map from shared ids to their
 corresponding [=platform object=].
 

--- a/index.bs
+++ b/index.bs
@@ -1176,9 +1176,9 @@ To <dfn>deserialize remote reference</dfn> given |remote reference|, |realm| and
 1. Assert |remote reference| matches the <code>RemoteReference</code> production.
 
 1. If |remote reference| matches the <code>SharedReference</code> production, return
-   [=deserialize shared reference=] given |remote reference|, |realm| and |session|.
+   [=deserialize shared reference=] with |remote reference|, |realm| and |session|.
 
-1. Return [=deserialize remote object reference=] given |remote reference| and
+1. Return [=deserialize remote object reference=] with |remote reference| and
    |realm|.
 
 </div>
@@ -1215,7 +1215,7 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.
 
-1. Let |node| be result of [=trying=] to [=get a node=] given |session|,
+1. Let |node| be result of [=trying=] to [=get a node=] with |session|,
    |browsing context| and |shared id|.
 
 1. If |node| is <code>null</code>, return [=error=] with [=error code=]
@@ -1566,7 +1566,7 @@ To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] given |value|, |realm| and |session|.
+         [=deserialize key-value list=] with |value|, |realm| and |session|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1907,7 +1907,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
-1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership type|
+1. Let |handle id| be the [=handle for an object=] with |realm|, |ownership type|
    and |value|.
 
 1. Set |ownership type| to "<code>none</code>".
@@ -1960,7 +1960,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        <code>handle</code> property set to |handle id| if it's not null, or omitted
        otherwise.
 
-    1. [=Set internal ids if needed=] given |serialization internal map|,
+    1. [=Set internal ids if needed=] with |serialization internal map|,
        |remote value| and |value|.
 
     1. Let |serialized| be null.
@@ -1982,7 +1982,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        <code>handle</code> property set to |handle id| if it's not null, or omitted
        otherwise.
 
-    1. [=Set internal ids if needed=] given |serialization internal map|,
+    1. [=Set internal ids if needed=] with |serialization internal map|,
        |remote value| and |value|.
 
     1. Let |serialized| be null.
@@ -2040,7 +2040,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be [=shared id for a node=] given |value|, |realm| and
+      1. Let |shared id| be [=shared id for a node=] with |value|, |realm| and
          |session|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
@@ -2049,7 +2049,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
          <code>handle</code> property set to |handle id| if it's not null, or omitted
          otherwise.
 
-      1. [=Set internal ids if needed=] given |serialization internal map|,
+      1. [=Set internal ids if needed=] with |serialization internal map|,
          |remote value| and |value|.
 
       1. Let |serialized| be null.
@@ -2148,7 +2148,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        in the [=local end definition=], with the <code>handle</code> property set
        to |handle id| if it's not null, or omitted otherwise.
 
-    1. [=Set internal ids if needed=] given |serialization internal map|,
+    1. [=Set internal ids if needed=] with |serialization internal map|,
        |remote value| and |value|.
 
     1. Let |serialized| be null.
@@ -2190,7 +2190,7 @@ To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known ob
    <code>handle</code> property set to |handle id| if it's not null, or omitted
    otherwise.
 
-1. [=Set internal ids if needed=] given |serialization internal map|,
+1. [=Set internal ids if needed=] with |serialization internal map|,
    |remote value| and |value|.
 
 1. If |known object| is <code>false</code>, and |max depth| is not 0:
@@ -4931,7 +4931,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
-  1. Let |exception details| be the result of [=get exception details=] given
+  1. Let |exception details| be the result of [=get exception details=] with
      |realm|, |evaluation status|, |result ownership| and |session|.
 
   1. Return a new map matching the <code>script.EvaluateResultException</code>

--- a/index.bs
+++ b/index.bs
@@ -1137,20 +1137,25 @@ SharedId = text;
 </pre>
 
 <pre class="cddl remote-cddl">
+<!-- This is specifically ordered in the order in which matches need to be -->
+<!-- evaluated, since the definitions are overlapping -->
 RemoteReference = (
-  RemoteObjectReference //
-  SharedReference
+  SharedReference //
+  RemoteObjectReference
 )
 
-RemoteObjectReference = {
-   handle: Handle,
-   ?sharedId: SharedId
+SharedReference = {
+   sharedId: SharedId
+   <!-- Ensure that if we have a handle, it at least has the correct type -->
+   ?handle: Handle,
    Extensible
 }
 
-SharedReference = {
-   ?handle: Handle,
-   sharedId: SharedId
+RemoteObjectReference = {
+   handle: Handle,
+   <!-- This shouldn't ever match. The problem is that Extensible would
+   otherwise allow this to match a non-text sharedId -->
+   ?sharedId: SharedId
    Extensible
 }
 </pre>
@@ -1171,9 +1176,6 @@ To <dfn>deserialize remote reference</dfn> given |remote reference|, |realm| and
 
 1. If |remote reference| matches the <code>SharedReference</code> production, return
    [=deserialize shared reference=] given |remote reference|, |realm| and |session|.
-
-1. Assert |remote reference| matches the <code>RemoteObjectReference</code>
-   production.
 
 1. Return [=deserialize remote object reference=] given |remote reference| and
    |realm|.

--- a/index.bs
+++ b/index.bs
@@ -1118,7 +1118,7 @@ OwnershipModel = "root" / "none";
 <dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
-representing a reference to a [=node=] in the given [=Realm=].
+representing a reference to a [=node=].
 
 <pre class="cddl remote-cddl local-cddl">
 Handle = text;

--- a/index.bs
+++ b/index.bs
@@ -1125,9 +1125,9 @@ OwnershipModel = "root" / "none";
 <dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
-representing a reference to a [=platform object=] in the given [=browsing context=]'s
-[=list of known elements=], [=list of known shadow roots=] on in the given
-{{Window}}'s [=platform objects map=].
+representing a reference to a [=platform object=] in the given
+[=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] on
+in the given {{Window}}'s [=platform objects map=].
 
 <pre class="cddl remote-cddl local-cddl">
 RemoteReference = {

--- a/index.bs
+++ b/index.bs
@@ -152,6 +152,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: report an error; url: webappapis.html#report-the-error
     text: remove a browsing context; url: browsers.html#bcg-remove
     text: run the animation frame callbacks; url: imagebitmap-and-animations.html#run-the-animation-frame-callbacks
+    text: same origin domain; url: browsers.html#same-origin-domain
     text: session history; url: history.html#session-history
     text: set up a window environment settings object; url: window-object.html#set-up-a-window-environment-settings-object
     text: set up a worker environment settings object; url: workers.html#set-up-a-worker-environment-settings-object
@@ -1223,8 +1224,8 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
-1. If |node|'s [=node document=]'s [=document/origin=] is not [=same origin
-   domain=] with |environment settings|'s [=environment settings/origin=] then
+1. If |node|'s [=node document=]'s [=Document/origin=] is not [=same origin
+   domain=] with |environment settings|'s [=environment settings object/origin=] then
    return null.
 
    Note: This ensures that WebDriver-BiDi can not be used to pass objects

--- a/index.bs
+++ b/index.bs
@@ -1156,12 +1156,12 @@ only <code>sharedId</code>.
 ### Deserialization ### {#data-types-reference-deserialization}
 
 <div algorithm>
-To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
+To <dfn>deserialize remote reference</dfn> given |session|, |realm| and |remote reference|:
 
 1. Assert |remote reference| matches the <code>RemoteReference</code> production.
 
 1. If |remote reference| matches the <code>SharedReference</code> production, return
-   [=deserialize shared reference=] given |realm| and |remote reference|.
+   [=deserialize shared reference=] given |session|, |realm| and |remote reference|.
 
 1. Assert |remote reference| matches the <code>RemoteObjectReference</code>
    production.
@@ -1188,7 +1188,7 @@ To <dfn>deserialize remote object reference</dfn> given |realm| and
 </div>
 
 <div algorithm>
-To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
+To <dfn>deserialize shared reference</dfn> given |session|, |realm| and |shared reference|:
 
 1. Assert |remote reference| matches the <code>SharedReference</code> production.
 
@@ -1450,7 +1450,8 @@ SetLocalValue = {
 
 <div algorithm>
 
-To <dfn>deserialize key-value list</dfn> given |realm| and |serialized key-value list|:
+To <dfn>deserialize key-value list</dfn> given |session|, |realm| and
+|serialized key-value list|:
 
 1. Let |deserialized key-value list| be a new list.
 
@@ -1464,13 +1465,13 @@ To <dfn>deserialize key-value list</dfn> given |realm| and |serialized key-value
    1. If |serialized key| is a <code>string</code>,
       let |deserialized key| be |serialized key|.
 
-   1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize local value=]
-      given |realm| and |serialized key|.
+   1. Otherwise let |deserialized key| be result of [=trying=] to
+      [=deserialize local value=] with |session|, |realm| and |serialized key|.
 
    1. Let |serialized value| be |serialized key-value|[1].
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
-      given |realm| and |serialized value|.
+      with |session|, |realm| and |serialized value|.
 
    1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
       |deserialized key-value list|.
@@ -1483,14 +1484,15 @@ To <dfn>deserialize key-value list</dfn> given |realm| and |serialized key-value
 
 Issue: TODO distinguish between `List` and `Array`.
 
-To <dfn>deserialize value list</dfn> given |realm| and |serialized value list|:
+To <dfn>deserialize value list</dfn> given |session|, |realm| and
+|serialized value list|:
 
 1. Let |deserialized values| be a new list.
 
 1. For each |serialized value| in the |serialized value list|:
 
-   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
-      given |realm| and |serialized value|.
+   1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=]
+      with |session|, |realm| and |serialized value|.
 
    1. Append |deserialized value| to |deserialized values|;
 
@@ -1500,10 +1502,12 @@ To <dfn>deserialize value list</dfn> given |realm| and |serialized value list|:
 
 <div algorithm>
 
-To <dfn>deserialize local value</dfn> given |realm| and |local protocol value|:
+To <dfn>deserialize local value</dfn> with given |session|, |realm| and
+|local protocol value|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] of given |realm| and |local protocol value|.
+   [=deserialize remote reference=] with |session|, |realm| and
+   |local protocol value|.
 
 1. If |local protocol value| matches the [=PrimitiveProtocolValue=] production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
@@ -1522,7 +1526,7 @@ To <dfn>deserialize local value</dfn> given |realm| and |local protocol value|:
     <dt>|type| is the string "<code>array</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
-         given |realm| and |value|.
+         given |session|, |realm| and |value|.
 
       1. Return [=success=] with data [=CreateArrayFromList=](|deserialized value list|).
 
@@ -1540,7 +1544,7 @@ To <dfn>deserialize local value</dfn> given |realm| and |local protocol value|:
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] given |realm| and |value|.
+         [=deserialize key-value list=] with |session|, |realm| and |value|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1549,7 +1553,7 @@ To <dfn>deserialize local value</dfn> given |realm| and |local protocol value|:
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] given |realm| and |value|.
+         [=deserialize key-value list=] with |session|, |realm| and |value|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1570,7 +1574,7 @@ To <dfn>deserialize local value</dfn> given |realm| and |local protocol value|:
     <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
-         given |realm| and |value|.
+         given |session|, |realm| and |value|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -4712,14 +4716,15 @@ Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 <div algorithm>
 
-To <dfn>deserialize arguments</dfn> given |realm| and |serialized arguments list|:
+To <dfn>deserialize arguments</dfn> with given |session|, |realm| and
+|serialized arguments list|:
 
 1. Let |deserialized arguments list| be an empty list.
 
 1. For each |serialized argument| of |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize local value=]
-     given |realm| and |serialized argument|.
+  1. Let |deserialized argument| be the result of [=trying=] to
+     [=deserialize local value=] with |session|, |realm| and |serialized argument|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -4750,7 +4755,7 @@ Note: the |function declaration| is parenthesized and evaluated.
 </div>
 
 
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.
@@ -4766,7 +4771,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |deserialized arguments| be an empty list.
 
 1. If |command arguments| is not null, set |deserialized arguments| to the result of [=trying=] to
-   [=deserialize arguments=] given |realm| and |command arguments|.
+   [=deserialize arguments=] with |session|, |realm| and |command arguments|.
 
 1. Let |this parameter| be the value of the <code>this</code> field
    of |command parameters|.
@@ -4774,7 +4779,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |this object| be null.
 
 1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
-   [=deserialize local value=] given |realm| and |this parameter|.
+   [=deserialize local value=] with |session|, |realm| and |this parameter|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -1658,7 +1658,7 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To get <dfn>shared id for a node</dfn> given |node|, |realm| and |session|:
+To <dfn>get shared id for a node</dfn> given |node|, |realm| and |session|:
 
 1. Let |node| be [=unwrapped=] |node|.
 
@@ -2040,7 +2040,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be [=shared id for a node=] with |value|, |realm| and
+      1. Let |shared id| be [=get shared id for a node=] with |value|, |realm| and
          |session|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>

--- a/index.bs
+++ b/index.bs
@@ -1834,7 +1834,7 @@ HTMLCollectionRemoteValue = {
 
 NodeRemoteValue = {
   type: "node",
-  sharedId: SharedId,
+  ?sharedId: SharedId,
   ?handle: Handle,
   ?internalId: InternalId,
   ?value: NodeProperties,

--- a/index.bs
+++ b/index.bs
@@ -4202,20 +4202,6 @@ Note: there's a 1:1 relationship between the <code>script.RealmInfo</code>
 The <code>script.RealmInfo</code> type represents the properties of a realm.
 
 <div algorithm>
-To <dfn>get the top level window</dfn> with given |realm|:
-
-1. Let |global object| be the [=realm/global object=] of the |realm|.
-
-1. While |global object| is a {{Window}} object and has a non-null [=parent=], set
-   |global object| to |global object|'s [=parent=].
-
-1. If |global object| is not a {{Window}} object, return <code>null</code>.
-
-1. Return |global object|.
-
-</div
-
-<div algorithm>
 To <dfn>get the browsing context</dfn> with given |realm|:
 
 1. Let |global object| be the [=realm/global object=] of the |realm|.

--- a/index.bs
+++ b/index.bs
@@ -1130,10 +1130,12 @@ representing a reference to a [=platform object=] in the given
 [=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] or
 in the top level {{Window}}'s [=platform objects map=].
 
-<pre class="cddl remote-cddl">
+<pre class="cddl remote-cddl local-cddl">
 Handle = text;
 SharedId = text;
+</pre>
 
+<pre class="cddl remote-cddl">
 RemoteReference = {
   RemoteObjectReference //
   SharedReference

--- a/index.bs
+++ b/index.bs
@@ -1114,7 +1114,7 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
-Each {{Window}} with [=/parent=] <code>null</doce> has a corresponding
+Each {{Window}} with [=parent=] <code>null</doce> has a corresponding
 <dfn>platform objects map</dfn>. This is a weak map from shared ids to their
 corresponding [=platform object=].
 
@@ -1688,7 +1688,7 @@ To get the <dfn>shared id for an object</dfn> given a |realm| and |object|:
   1. Return the result of [=trying=] to [=get or create a web element reference=]
      with |object| and |browsing context|.
 
-1. If |object| is a [=/ShadowRoot=]:
+1. If |object| is a [=/shadow root=]:
 
   1. Let |browsing context| be the result of [=get the browsing context=] of the
      |realm|.
@@ -4272,9 +4272,9 @@ Steps of <dfn>getting the top level window</dfn> of the given |realm|:
 
 1. If |global object| is not a {{Window}} object, return <code>null</code>.
 
-1. While |global object| has a [=/parent=]:
+1. While |global object| has a [=parent=]:
 
-  1. Set |global object| to |global object|'s [=/parent=].
+  1. Set |global object| to |global object|'s [=parent=].
 
   1. If |global object| is not a {{Window}} object, return <code>null</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -46,16 +46,10 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
     text: getting a property; url: dfn-get-a-property
-    text: get a known connected element; url: dfn-get-a-known-connected-element
-    text: get a known shadow root; url: dfn-get-a-known-shadow-root
-    text: get or create a shadow root reference; url: dfn-get-or-create-a-shadow-root-reference
-    text: get or create a web element reference; url: dfn-get-or-create-a-web-element-reference
     text: http session; url: dfn-http-session
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: invalid session id; url: dfn-invalid-session-id
-    text: list of known elements; url: dfn-list-of-known-elements
-    text: list of known shadow roots; url: dfn-list-of-known-shadow-roots
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
     text: maximum active sessions; url: dfn-maximum-active-sessions
@@ -70,7 +64,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: session not created; url: dfn-session-not-created
     text: session; url: dfn-sessions
     text: set a property; url: dfn-set-a-property
-    text: shadow root reference; url: dfn-shadow-root-reference
+    text: stale element reference; url: dfn-stale-element-reference
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: trying; url: dfn-try
@@ -1090,7 +1084,7 @@ There is no {{SandboxProxy}} interface object.
 Issue: Define in detail how {{SandboxProxy}} works
 
 <div algorithm>
-To get <dfn>unwrapped</dfn> |object|, get the result of the following steps:
+To get <dfn>unwrapped</dfn> |object|:
 
 1. While |object| is {{SandboxProxy}} or {{SandboxWindowProxy}}, set |object| to it's
    wrapped object.
@@ -1115,10 +1109,6 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
-Each {{Window}} with [=parent=] <code>null</code> has a corresponding
-<dfn>platform objects map</dfn>. This is a weak map from shared ids to their
-corresponding [=platform object=].
-
 <pre class="cddl remote-cddl">
 OwnershipModel = "root" / "none";
 </pre>
@@ -1126,9 +1116,7 @@ OwnershipModel = "root" / "none";
 <dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
-representing a reference to a [=platform object=] in the given
-[=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] or
-in the top level {{Window}}'s [=platform objects map=].
+representing a reference to a [=node=] in the given [=Realm=].
 
 <pre class="cddl remote-cddl local-cddl">
 Handle = text;
@@ -1198,66 +1186,34 @@ To <dfn>deserialize remote object reference</dfn> given |realm| and
 </div>
 
 <div algorithm>
-To <dfn>find platform object by shared reference</dfn> given |realm| and
-|shared reference|:
+To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
 
-1. Let |browsing context| be the result of [=get the browsing context=] of the
-   |realm|.
+1. Let |browsing context| be [=get the browsing context=] of the |realm|.
 
-1. If |browsing context| is <code>null</code>, return <code>null</code>.
+1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
+   [=invalid argument=].
 
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.
 
-1. If |browser context|'s [=list of known elements=] contains an item, which
-   [=web element reference=] equals to |shared id|, return the result of [=trying=]
-   to [=get a known connected element=] with argument |shared id| and
-   |browsing context|.
+1. If |shared id| is <code>null</code>, return [=error=] with [=error code=]
+   [=invalid argument=].
 
-1. If |browser context|'s [=list of known shadow roots=] contains an item, which
-   [=shadow root reference=] equals to |shared id|, return the result of [=trying=]
-   to [=get a known shadow root=] with argument |shared id| and |browsing context|.
+1. Let |node| be result of [=trying=] to [=get a node=] given [=current session=],
+   |browsing context| and |shared id|.
 
-1. Let |window| be the result of [=getting the top level window=] of the |realm|.
+1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
+   [=no such element=].
 
-1. If |window| is <code>null</code>, return <code>null</code>.
-
-1. Let |platform objects map| be |window|'s [=platform objects map=].
-
-1. If |platform objects map| does not contain key |shared id|, then return
-   <code>null</code>.
-
-1. Let |platform object| be the |platform objects map|[|shared id|].
-
-1. Assert |platform object| is a [=platform object=].
-
-1. Let |realm global object| be the [=realm/global object=] of the |realm|.
-
-1. If the |realm global object| is {{SandboxWindowProxy}} object, return set
-   |platform object| to the {{SandboxProxy}} wrapping |platform object| in the
-   |realm|.
-
-1. Return |platform object|.
-
-</div>
-
-<div algorithm>
-To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
-
-1. Let |platform object| be result of [=trying=] to
-   [=find platform object by shared reference=] given |realm| and |shared reference|.
-
-1. If |platform object| is <code>null</code>, return <code>null</code>.
-
-1. Assert |platform object| is a [=platform object=].
+1. If |node| [=is stale=], return [=error=] with [=error code=]
+   [=stale element reference=].
 
 1. Let |realm global object| be the [=realm/global object=] of the |realm|.
 
 1. If the |realm global object| is {{SandboxWindowProxy}} object, set
-   |platform object| to the {{SandboxProxy}} wrapping |platform object| in the
-   |realm|.
+   |node| to the {{SandboxProxy}} wrapping |node| in the |realm|.
 
-1. Return |platform object|.
+1. Return |node|.
 
 </div>
 
@@ -1675,46 +1631,18 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To get the <dfn>shared id for an object</dfn> given a |realm| and |object|:
+To get <dfn>shared id for a node</dfn> given |realm| and |node|:
 
-1. Let |object| be [=unwrapped=] |object|.
+1. Let |node| be [=unwrapped=] |node|.
 
-1. If |object| is not a [=platform object=], return <code>null</code>.
+1. If |node| is not a [=node=], return <code>null</code>.
 
-1. If |object| is an [=/Element=]:
+1. Let |browsing context| be [=get the browsing context=] of the |realm|.
 
-  1. Let |browsing context| be the result of [=get the browsing context=] of the
-     |realm|.
+1. If |browsing context| is <code>null</code>, return <code>null</code>.
 
-  1. If |browsing context| is <code>null</code>, return <code>null</code>.
-
-  1. Return the result of [=trying=] to [=get or create a web element reference=]
-     with |object| and |browsing context|.
-
-1. If |object| is a [=/shadow root=]:
-
-  1. Let |browsing context| be the result of [=get the browsing context=] of the
-     |realm|.
-
-  1. If |browsing context| is <code>null</code>, return <code>null</code>.
-
-  1. Return the result of [=trying=] to [=get or create a shadow root reference=]
-     with |object| and |browsing context|.
-
-1. Let |window| be the result of [=getting the top level window=] of the |realm|.
-
-1. If |window| is <code>null</code>, return <code>null</code>.
-
-1. Let |platform objects map| be |window|'s [=platform objects map=].
-
-1. If |platform objects map| contains value |object|, then return |object|'s key in
-   |platform objects map| as a result.
-
-1. Let |shared id| be a new, unique, string handle for |object|.
-
-1. Set |platform objects map|[|shared id|] to |object|.
-
-1. Return |shared id| as a result.
+1. Return [=get or create a node reference=] with [=current session=],
+   |browsing context| and |node|.
 
 </div>
 
@@ -2085,13 +2013,14 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>[=unwrapped=] |value| is a [=platform object=] that implements [=Node=]
     <dd>
-      1. Let |shared id| be the [=shared id for an object=] given |realm| and
+      1. Let |shared id| be [=shared id for a node=] given |realm| and
          |value|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>sharedId</code>
-         property set to |shared id|, and the <code>handle</code> property set to
-         |handle id| if it's not null, or omitted otherwise.
+         property set to |shared id| if it's not null, or omitted otherwise, and the
+         <code>handle</code> property set to |handle id| if it's not null, or omitted
+         otherwise.
 
       1. [=Set internal ids if needed=] given |serialization internal map|,
          |remote value| and |value|.
@@ -4267,19 +4196,15 @@ Note: there's a 1:1 relationship between the <code>script.RealmInfo</code>
 The <code>script.RealmInfo</code> type represents the properties of a realm.
 
 <div algorithm>
-Steps of <dfn>getting the top level window</dfn> of the given |realm|:
+To <dfn>get the top level window</dfn> of the given |realm|:
 
 1. Let |global object| be the [=realm/global object=] of the |realm|.
 
-1. Let |global object| be [=unwrapped=] |global object|.
-
-1. If |global object| is not a {{Window}} object, return <code>null</code>.
-
-1. While |global object| has a [=parent=]:
+1. While |global object| is a {{Window}} object and has a [=parent=]:
 
   1. Set |global object| to |global object|'s [=parent=].
 
-  1. If |global object| is not a {{Window}} object, return <code>null</code>.
+1. If |global object| is not a {{Window}} object, return <code>null</code>.
 
 1. Return |global object|.
 
@@ -4288,16 +4213,13 @@ Steps of <dfn>getting the top level window</dfn> of the given |realm|:
 <div algorithm>
 To <dfn>get the browsing context</dfn> of the given |realm|:
 
-1. Let |window| be the result of [=getting the top level window=] of the |realm|.
+1. Let |window| be [=get the top level window=] of the |realm|.
 
-1. Let |global object| be [=unwrapped=] |global object|.
+1. If |window| is <code>null</code>, return <code>null</code>.
 
-1. If |window| is code>null</code>, return code>null</code>.
+1. Let |window| be [=unwrapped=] |window|.
 
-1. Let |document| be |window|'s [=relevant global object=]'s
-   <a>associated <code>Document</code></a>.
-
-1. Return |document|'s [=/browsing context=].
+1. Return |window|'s [=/browsing context=].
 
 </div
 

--- a/index.bs
+++ b/index.bs
@@ -1207,7 +1207,9 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 1. Let |browsing context| be [=get the browsing context=] with |realm|.
 
 1. If |browsing context| is <code>null</code>, return [=error=] with [=error code=]
-   [=no such frame=].
+   [=no such node=].
+
+   Note: This happens when the realm isn't a Window global.
 
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.

--- a/index.bs
+++ b/index.bs
@@ -5368,67 +5368,68 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for log.entryAdded">
 
-Define the following [=console steps=] with |method|, |args|, |session| and
+Define the following [=console steps=] with |method|, |args|, and
 <var ignore>options</var>:
 
-1. If |method| is "<code>error</code>" or "<code>assert</code>", let |level| be
-   "<code>error</code>". If |method| is "<code>debug</code>" or "<code>trace</code>"
-   let |level| be "<code>debug</code>". If |method| is "<code>warn</code>", let
-   |level| be "<code>warn</code>". Otherwise let |level| be "<code>info</code>".
+1. For each |session| in [=active BiDI sessions=]:
 
-1. Let |timestamp| be a [=time value=] representing the current date and time in UTC.
+  1. If |method| is "<code>error</code>" or "<code>assert</code>", let |level| be
+     "<code>error</code>". If |method| is "<code>debug</code>" or "<code>trace</code>"
+     let |level| be "<code>debug</code>". If |method| is "<code>warn</code>", let
+     |level| be "<code>warn</code>". Otherwise let |level| be "<code>info</code>".
 
-1. Let |text| be an empty string.
+  1. Let |timestamp| be a [=time value=] representing the current date and time in UTC.
 
-1. If [=Type=](|args|[0]) is String, and |args|[0] contains a
-   [=formatting specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise
-   let |formatted args| be |args|.
+  1. Let |text| be an empty string.
 
-   Note: The formatter operation is underdefined in the console specification,
-   formatting can be inconsistent between different implementations.
+  1. If [=Type=](|args|[0]) is String, and |args|[0] contains a
+     [=formatting specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise
+     let |formatted args| be |args|.
 
-1. For each |arg| in |formatted args|:
+     Note: The formatter operation is underdefined in the console specification,
+     formatting can be inconsistent between different implementations.
 
-  1. If |arg| is not the first entry in |args|, append a U+0020 SPACE to |text|.
+  1. For each |arg| in |formatted args|:
 
-  1. If |arg| is a [=primitive ECMAScript value=], append [=ToString=](|arg|) to
-     |text|. Otherwise append an implementation-defined string to |text|.
+    1. If |arg| is not the first entry in |args|, append a U+0020 SPACE to |text|.
 
-1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
+    1. If |arg| is a [=primitive ECMAScript value=], append [=ToString=](|arg|) to
+       |text|. Otherwise append an implementation-defined string to |text|.
 
-1. Let |serialized args| be a new list.
+  1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
 
-1. For each |arg| of |args|:
-   1. Let |serialized arg| be the result of [=serialize as a remote value=] given
-      |arg| as value, <code>1</code> as max depth, <code>none</code> as
-      ownership type, a new [=Map=] as serialization internal map, |realm| and
-      |session|.
+  1. Let |serialized args| be a new list.
 
-   1. Add |serialized arg| to |serialized args|.
+  1. For each |arg| of |args|:
 
-1. Let |source| be the result of [=get the source=] given [=current Realm Record=].
+     1. Let |serialized arg| be the result of [=serialize as a remote value=] with
+        |arg| as value, <code>1</code> as max depth, <code>none</code> as
+        ownership type, a new [=Map=] as serialization internal map, |realm| and
+        |session|.
 
-1. If |method| is "<code>assert</code>", "<code>error</code>",
-   "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
-   stack trace=]. Otherwise let |stack| be null.
+     1. Add |serialized arg| to |serialized args|.
 
-1. Let |entry| be a map matching the <code>log.ConsoleLogEntry</code> production,
-   with the the <code>level</code> field set to |level|, the <code>text</code>
-   field set to |text|, the <code>timestamp</code> field set to |timestamp|, the
-   <code>stackTrace</code> field set to |stack| if |stack| is not null, or
-   omitted otherwise, the |method| field set to |method|, the <code>source</code>
-   field set to |source| and the <code>args</code> field set to |serialized
-   args|.
+  1. Let |source| be the result of [=get the source=] given [=current Realm Record=].
 
-1. Let |body| be a map matching the <code>log.EntryAdded</code> production, with
-   the <code>params</code> field set to |entry|.
+  1. If |method| is "<code>assert</code>", "<code>error</code>",
+     "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
+     stack trace=]. Otherwise let |stack| be null.
 
-1. Let |settings| be the [=current settings object=]
+  1. Let |entry| be a map matching the <code>log.ConsoleLogEntry</code> production,
+     with the the <code>level</code> field set to |level|, the <code>text</code>
+     field set to |text|, the <code>timestamp</code> field set to |timestamp|, the
+     <code>stackTrace</code> field set to |stack| if |stack| is not null, or
+     omitted otherwise, the |method| field set to |method|, the <code>source</code>
+     field set to |source| and the <code>args</code> field set to |serialized
+     args|.
 
-1. Let |related browsing contexts| be the result of [=get related browsing
-   contexts=] given |settings|.
+  1. Let |body| be a map matching the <code>log.EntryAdded</code> production, with
+     the <code>params</code> field set to |entry|.
 
-1. For each |session| in [=active BiDi sessions=]:
+  1. Let |settings| be the [=current settings object=]
+
+  1. Let |related browsing contexts| be the result of [=get related browsing
+     contexts=] given |settings|.
 
   1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
      |related browsing contexts|, [=emit an event=] with |session| and |body|.
@@ -5550,14 +5551,12 @@ Other specifications can define <dfn>console steps</dfn>. When any method of the
 {{console}} interface is called, with method name
 |method| and argument |args|:
 
-1. For each |session| in [=active BiDI sessions=]:
 
-  1. If that method does not call the [=Printer=] operation, call any [=console
-     steps=] defined in external specification with arguments |method|,
-     |args|, |session| and undefined.
+1. If that method does not call the [=Printer=] operation, call any [=console
+   steps=] defined in external specification with arguments |method|,
+   |args|, and undefined.
 
-     Otherwise, at the point when the [=Printer=] operation is called with
-     arguments |name|, |printerArgs| and |options| (which is undefined if the
-     argument is not provided), call any [=console steps=] defined in
-     external specification with arguments |name|, |printerArgs|, |session| and
-     |options|.
+   Otherwise, at the point when the [=Printer=] operation is called with
+   arguments |name|, |printerArgs| and |options| (which is undefined if the
+   argument is not provided), call any [=console steps=] defined in
+   external specification with arguments |name|, |printerArgs|, and |options|.

--- a/index.bs
+++ b/index.bs
@@ -1190,7 +1190,7 @@ To <dfn>deserialize remote object reference</dfn> given |remote object reference
 To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 |session|:
 
-1. Assert |remote reference| matches the <code>SharedReference</code> production.
+1. Assert |shared reference| matches the <code>SharedReference</code> production.
 
 1. Let |browsing context| be [=get the browsing context=] with |realm|.
 

--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
     text: create a session; url: dfn-create-a-session
-    text: current session; url: dfn-current-session
     text: draw a bounding box from the framebuffer; url: dfn-draw-a-bounding-box-from-the-framebuffer
     text: encode a canvas as Base64; url: dfn-encoding-a-canvas-as-base64
     text: endpoint node; url: dfn-endpoint-node
@@ -1200,7 +1199,7 @@ To <dfn>deserialize shared reference</dfn> given |session|, |realm| and |shared 
 1. Let |shared id| be the value of the <code>sharedId</code> field of
    |shared reference|.
 
-1. Let |node| be result of [=trying=] to [=get a node=] given [=current session=],
+1. Let |node| be result of [=trying=] to [=get a node=] given |session|,
    |browsing context| and |shared id|.
 
 1. If |node| is <code>null</code>, return [=error=] with [=error code=]

--- a/index.bs
+++ b/index.bs
@@ -1659,11 +1659,11 @@ To get <dfn>shared id for a node</dfn> given |node|, |realm| and |session|:
 
 1. Let |node| be [=unwrapped=] |node|.
 
-1. If |node| is not a [=node=], return <code>null</code>.
+1. If |node| does not implement {{Node}}, return null.
 
 1. Let |browsing context| be [=get the browsing context=] with |realm|.
 
-1. If |browsing context| is <code>null</code>, return <code>null</code>.
+1. If |browsing context| is null, return null.
 
 1. Return [=get or create a node reference=] with |session|, |browsing context| and
    |node|.
@@ -2192,7 +2192,7 @@ To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known ob
 
 1. If |known object| is <code>false</code>, and |max depth| is not 0:
 
-  1. Let |serialized| be the result of [=serialize as a list=] given
+  1. Let |serialized| be the result of [=serialize as a list=] with
      [=CreateArrayIterator=](|value|, value), |max depth|, |ownership type|,
      |serialization internal map|, |realm|, and |session|.
 
@@ -4083,7 +4083,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
    TODO: Tighten up the requirements here; people will probably try to parse
    this data with regex or something equally bad.
 
-1. Let |exception| be the result of [=serialize as a remote value=] given
+1. Let |exception| be the result of [=serialize as a remote value=] with
    |record|.\[[Value]], <code>1</code> as max depth, |ownership type|,
    a new [=Map=] as serialization internal map, |realm| and |session|.
 
@@ -4841,7 +4841,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] given
+1. Let |result| be the result of [=serialize as a remote value=] with
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|,
    <code>new map</code> as |serialization internal map|, |realm| and |session|.
 
@@ -4937,7 +4937,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] given
+1. Let |result| be the result of [=serialize as a remote value=] with
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|,
    <code>new map</code> as |serialization internal map|, |realm| and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -52,7 +52,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: invalid session id; url: dfn-invalid-session-id
-    text: is stale; url: dfn-is-stale
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
     text: maximum active sessions; url: dfn-maximum-active-sessions
@@ -67,7 +66,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: session not created; url: dfn-session-not-created
     text: session; url: dfn-sessions
     text: set a property; url: dfn-set-a-property
-    text: stale element reference; url: dfn-stale-element-reference
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: trying; url: dfn-try

--- a/index.bs
+++ b/index.bs
@@ -1129,23 +1129,24 @@ representing a reference to a [=platform object=] in the given
 [=/browsing context=]'s [=list of known elements=], [=list of known shadow roots=] or
 in the top level {{Window}}'s [=platform objects map=].
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl remote-cddl">
+Handle = text;
+SharedId = text;
+
 RemoteReference = {
   RemoteObjectReference //
   SharedReference
 }
 
-Handle = text;
-
 RemoteObjectReference = {
    handle: Handle,
+   ?sharedId: SharedId
    Extensible
 }
 
-SharedId = text;
-
 SharedReference = {
-   sharedId: SharedId,
+   ?handle: Handle,
+   sharedId: SharedId
    Extensible
 }
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -1969,7 +1969,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        the following steps:
 
        1. Let |serialized| be the result of [=serialize as a list=] with
-          |session|, [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
+          [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
           |serialization internal map|, |realm|, and |session|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -2135,7 +2135,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        the following steps:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] with
-          |session|, [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
+          [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
           |ownership type|, |serialization internal map|,
           |realm|, and |session|.
 
@@ -4064,7 +4064,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
    TODO: Tighten up the requirements here; people will probably try to parse
    this data with regex or something equally bad.
 
-1. Let |exception| be the result of [=serialize as a remote value=] with
+1. Let |exception| be the result of [=serialize as a remote value=] given
    |record|.\[[Value]], <code>1</code> as max depth, |ownership type|,
    a new [=Map=] as serialization internal map, |realm| and |session|.
 
@@ -4727,8 +4727,8 @@ and |session|:
 
 1. For each |serialized argument| of |serialized arguments list|:
 
-  1. Let |deserialized argument| be the result of [=trying=] to
-     [=deserialize local value=] with |serialized argument|, |realm| and |session|.
+  1. Let |deserialized argument| be the result of [=trying=] to [=deserialize local value=]
+     given |serialized argument|, |realm| and |session|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -4775,7 +4775,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |deserialized arguments| be an empty list.
 
 1. If |command arguments| is not null, set |deserialized arguments| to the result of [=trying=] to
-   [=deserialize arguments=] with |realm|, |command arguments| and |session|.
+   [=deserialize arguments=] given |realm|, |command arguments| and |session|.
 
 1. Let |this parameter| be the value of the <code>this</code> field
    of |command parameters|.
@@ -4783,7 +4783,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |this object| be null.
 
 1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
-   [=deserialize local value=] with |this parameter|, |realm| and |session|.
+   [=deserialize local value=] given |this parameter|, |realm| and |session|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
@@ -4836,7 +4836,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] with
+1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|,
    |result ownership|, <code>new map</code> as |serialization internal map|, |realm|
    and |session|.
@@ -4933,7 +4933,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
-1. Let |result| be the result of [=serialize as a remote value=] with
+1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|,
    <code>new map</code> as |serialization internal map|, |realm| and |session|.
 
@@ -5404,7 +5404,7 @@ Define the following [=console steps=] with |method|, |args|, |session| and
 1. Let |serialized args| be a new list.
 
 1. For each |arg| of |args|:
-   1. Let |serialized arg| be the result of [=serialize as a remote value=] with
+   1. Let |serialized arg| be the result of [=serialize as a remote value=] given
       |arg| as value, <code>1</code> as max depth, <code>none</code> as
       ownership type, a new [=Map=] as serialization internal map, |realm| and
       |session|.

--- a/index.bs
+++ b/index.bs
@@ -1450,8 +1450,8 @@ SetLocalValue = {
 
 <div algorithm>
 
-To <dfn>deserialize key-value list</dfn> given |session|, |realm| and
-|serialized key-value list|:
+To <dfn>deserialize key-value list</dfn> given |serialized key-value list|, |realm|
+and |session|:
 
 1. Let |deserialized key-value list| be a new list.
 
@@ -1484,8 +1484,8 @@ To <dfn>deserialize key-value list</dfn> given |session|, |realm| and
 
 Issue: TODO distinguish between `List` and `Array`.
 
-To <dfn>deserialize value list</dfn> given |session|, |realm| and
-|serialized value list|:
+To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and
+|session|:
 
 1. Let |deserialized values| be a new list.
 
@@ -1526,7 +1526,7 @@ To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm|
     <dt>|type| is the string "<code>array</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
-         given |session|, |realm| and |value|.
+         given |value|, |realm| and |session|.
 
       1. Return [=success=] with data [=CreateArrayFromList=](|deserialized value list|).
 
@@ -1544,7 +1544,7 @@ To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm|
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with |session|, |realm| and |value|.
+         [=deserialize key-value list=] with |value|, |realm| and |session|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1553,7 +1553,7 @@ To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm|
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with |session|, |realm| and |value|.
+         [=deserialize key-value list=] with |value|, |realm| and |session|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1574,7 +1574,7 @@ To <dfn>deserialize local value</dfn> with given |local protocol value|, |realm|
     <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
-         given |session|, |realm| and |value|.
+         given |value|, |realm| and |session|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 

--- a/index.bs
+++ b/index.bs
@@ -2016,7 +2016,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
         |max depth|, |ownership type|, |known object|, |serialization internal map|,
         and |realm|.
 
-    <dt>[=unwrapped=] |value| is a [=platform object=] that implements [=Node=]
+    <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
       1. Let |shared id| be [=shared id for a node=] given |realm| and
          |value|.

--- a/index.bs
+++ b/index.bs
@@ -46,10 +46,16 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: error code; url: dfn-error-code
     text: error; url: dfn-errors
     text: getting a property; url: dfn-get-a-property
+    text: get a known connected element; url: dfn-get-a-known-connected-element
+    text: get a known shadow root; url: dfn-get-a-known-shadow-root
+    text: get or create a shadow root reference; url: dfn-get-or-create-a-shadow-root-reference
+    text: get or create a web element reference; url: dfn-get-or-create-a-web-element-reference
     text: http session; url: dfn-http-session
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
     text: invalid session id; url: dfn-invalid-session-id
+    text: list of known elements; url: dfn-list-of-known-elements
+    text: list of known shadow roots; url: dfn-list-of-known-shadow-roots
     text: local end; url: dfn-local-ends
     text: matched capability serialization algorithm; url: dfn-matched-capability-serialization-algorithm
     text: maximum active sessions; url: dfn-maximum-active-sessions
@@ -1108,7 +1114,7 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
-Each {{Window}} has a corresponding <dfn>platform objects map</dfn>. This is a strong
+Each {{Window}} has a corresponding <dfn>platform objects map</dfn>. This is a weak
 map from shared ids to their corresponding [=platform object=].
 
 <pre class="cddl remote-cddl">
@@ -1118,15 +1124,9 @@ OwnershipModel = "root" / "none";
 <dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>
-representing a reference to a [=platform object=] in [=platform objects map=] in the
-given {{Window}}.
-
-In [=BiDi session=]:
- * Each realm has an <dfn>object id map</dfn>, a weak map from objects to their
-   corresponding id. The [=object id map=] is unique per realm.
- * Each {{Window}} has a <dfn>shared id map</dfn>, a weak map from
-   [=platform object=] to their corresponding shared id. The [=shared id map=] is
-   shared among all of the realms of the {{Window}}.
+representing a reference to a [=platform object=] in the given [=browsing context=]'s
+[=list of known elements=], [=list of known shadow roots=] on in the given
+{{Window}}'s [=platform objects map=].
 
 <pre class="cddl remote-cddl local-cddl">
 RemoteReference = {
@@ -1191,14 +1191,30 @@ To <dfn>deserialize remote object reference</dfn> given |realm| and
 </div>
 
 <div algorithm>
-To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
+To <dfn>find platform object by shared reference</dfn> given |realm| and
+|shared reference|:
+
+1. Let |browsing context| be the result of [=get the browsing context=] of the
+   |realm|.
+
+1. If |browsing context| is <code>null</code>, return <code>null</code>.
+
+1. Let |shared id| be the value of the <code>sharedId</code> field of
+   |shared reference|.
+
+1. If |browser context|'s [=list of known elements=] contains an |element|, which
+   [=web element reference=] equals to |shared id|, return the result of [=trying=]
+   to [=get a known connected element=] with argument |shared id| and
+   |browsing context|.
+
+1. If |browser context|'s [=list of known shadow roots=] contains an |element|, which
+   [=web element reference=] equals to |shared id|, return the result of [=trying=]
+   to [=get a known connected element=] with argument |shared id| and
+   |browsing context|.
 
 1. Let |window| be the result of [=get the window=] of the |realm|.
 
 1. If |window| is <code>null</code>, return <code>null</code>.
-
-1. Let |shared id| be the value of the <code>sharedId</code> field of
-   |shared reference|.
 
 1. Let |platform objects map| be |window|'s [=platform objects map=].
 
@@ -1206,6 +1222,26 @@ To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
    <code>null</code>.
 
 1. Let |platform object| be the |platform objects map|[|shared id|].
+
+1. Assert |platform object| is a [=platform object=].
+
+1. Let |realm global object| be the [=realm/global object=] of the |realm|.
+
+1. If the |realm global object| is {{SandboxWindowProxy}} object, set
+   |platform object| to the {{SandboxProxy}} wrapping |platform object| in the
+   |realm|.
+
+1. Return |platform object|.
+
+</div>
+
+<div algorithm>
+To <dfn>deserialize shared reference</dfn> given |realm| and |shared reference|:
+
+1. Let |platform object| be result of [=trying=] to
+   [=find platform object by shared reference=] given |realm| and |shared reference|.
+
+1. If |platform object| is <code>null</code>, return <code>null</code>.
 
 1. Assert |platform object| is a [=platform object=].
 
@@ -1638,7 +1674,29 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 <div algorithm>
 To get the <dfn>shared id for an object</dfn> given a |realm| and |object|:
 
+1. Let |object| be [=unwrapped=] |object|.
+
 1. If |object| is not a [=platform object=], return <code>null</code>.
+
+1. If |object| is an [=/Element=]:
+
+  1. Let |browsing context| be the result of [=get the browsing context=] of the
+     |realm|.
+
+  1. If |browsing context| is <code>null</code>, return <code>null</code>.
+
+  1. Return the result of [=trying=] to [=get or create a web element reference=]
+     with |object| and |browsing context|.
+
+1. If |object| is a [=/ShadowRoot=]:
+
+  1. Let |browsing context| be the result of [=get the browsing context=] of the
+     |realm|.
+
+  1. If |browsing context| is <code>null</code>, return <code>null</code>.
+
+  1. Return the result of [=trying=] to [=get or create a shadow root reference=]
+     with |object| and |browsing context|.
 
 1. Let |window| be the result of [=get the window=] of the |realm|.
 
@@ -4215,6 +4273,22 @@ To <dfn>get the window</dfn> of the given |realm|:
 1. If |global object| is a {{Window}} object, return |global object|.
 
 1. Return <code>null</code>.
+
+</div
+
+<div algorithm>
+To <dfn>get the browsing context</dfn> of the given |realm|:
+
+1. Let |window| be the [=get the window=] of the |realm|.
+
+1. Let |global object| be [=unwrapped=] |global object|.
+
+1. If |window| is code>null</code>, return code>null</code>.
+
+1. Let |document| be |window|'s [=relevant global object=]'s
+   <a>associated <code>Document</code></a>.
+
+1. Return |document|'s [=/browsing context=].
 
 </div
 

--- a/index.bs
+++ b/index.bs
@@ -1214,7 +1214,7 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 1. Return [=success=] with data |node|.
 
 TODO: Add check that `|node|`'s `ownerDocument`'s origin is same origin-domain with
-|context|'s associated Document.
+|browsing context|'s associated Document.
 
 </div>
 


### PR DESCRIPTION
* Defined `SharedReference`;
* Described RemoteReference deserialization based on `handle` first and `sharedId` afterwards. 
* Define `Node` serialization.

(edit @whimboo) No longer blocked by https://github.com/w3c/webdriver/pull/1707


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver-bidi/pull/180.html" title="Last updated on Feb 1, 2023, 12:16 PM UTC (62b0fbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/180/dfd69fc...sadym-chromium:62b0fbd.html" title="Last updated on Feb 1, 2023, 12:16 PM UTC (62b0fbd)">Diff</a>