### PR TITLE
Let browsingContext.getTree also include the parent, and don't use context ids internally

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2367,9 +2367,9 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. Let |child infos| be a list.
-
 1. If |max depth| is null, or |max depth| is greater than 0:
+
+  1. Let |child infos| be an empty list.
 
   1. Let |child contexts| be a list containing all [=/browsing contexts=]
      which are [=child browsing contexts=] of |parent|.
@@ -2379,9 +2379,11 @@ To <dfn>get the browsing context info</dfn> given |context|,
   1. For each |context| of |child contexts|:
 
     1. Let |info| be the result of [=get the browsing context info=] given
-       |context|, |child depth|, and <code>false</code>.
+       |context|, |child depth|, and false.
 
     1. Append |info| to |child infos|
+
+1. Otherwise let |child infos| be null.
 
 1. Let |context info| be a [=map=] matching the
    <code>BrowsingContextInfo</code> production with the <code>context</code>
@@ -2642,7 +2644,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. For each |context| of |contexts|:
 
   1. Let |info| be the result of [=get the browsing context info=] given
-     |context|, |max depth|, and <code>true</code>.
+     |context|, |max depth|, and true.
 
   1. Append |info| to |contexts info|
 
@@ -2807,7 +2809,7 @@ To <dfn>Recursively emit context created events</dfn> given |session| and |conte
 To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=] given
-   |context|, 0, and <code>true</code>.
+   |context|, 0, and true.
 
 1. Let |body| be a [=map=] matching the
    <code>BrowsingContextCreatedEvent</code> production, with the
@@ -2869,7 +2871,7 @@ Define the following [=browsing context tree discarded=] steps:
 1. Let |context| be the browsing context being discarded.
 
 1. Let |params| be the result of [=get the browsing context info=], given
-   |context|, 0, and <code>true</code>.
+   |context|, 0, and true.
 
 1. Let |body| be a [=map=] matching the
     <code>BrowsingContextDestroyedEvent</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -2368,7 +2368,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
    Note: This includes the fragment component of the URL.
 
 1. Let |child info| be the result of [=get the descendent browsing contexts=]
-   given |context id|, |depth| + 1, and |max depth|.
+   given |context|, |depth| + 1, and |max depth|.
 
 1. Let |context info| be a [=map=] matching the
    <code>BrowsingContextInfo</code> production with the <code>context</code>
@@ -2381,17 +2381,15 @@ To <dfn>get the browsing context info</dfn> given |context|,
 </div>
 
 <div algorithm>
-To <dfn>get the descendent browsing contexts</dfn> given |parent id|, |depth|
+To <dfn>get the descendent browsing contexts</dfn> given |parent|, |depth|
 and |max depth|:
 
-1. If |max depth| is greater than zero, and |depth| is equal to |max depth|,
+1. Assert: |parent| is not null.
+
+1. If |max depth| is not null, and |depth| is greater than |max depth|,
    return null.
 
-1. Let |parent| be the result of [=trying=] to [=get a browsing context=]
-   given |parent id|.
-
-1. If |parent| is null, let |child contexts| be a list containing all [=top-level
-   browsing contexts=]. Otherwise let |child contexts| be a list containing all
+1. Let |child contexts| be a list containing all
    [=/browsing contexts=] which are [=child browsing contexts=] of |parent|.
 
 1. Let |contexts info| be a list.
@@ -2608,8 +2606,8 @@ The [=remote end steps=] with |command parameters| are:
 #### The browsingContext.getTree Command ####  {#command-browsingContext-getTree}
 
 The <dfn export for=commands>browsingContext.getTree</dfn> command returns a
-tree of all browsing contexts that are descendents of the given context, or all
-top-level contexts when no parent is provided.
+tree of all descendent browsing contexts including the given parent iself,
+or all top-level contexts when no parent is provided.
 
 <dl>
    <dt>Command Type</dt>
@@ -2643,15 +2641,27 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    |command parameters| if present, or null otherwise.
 
 1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
-   parameters| if present, or 0 otherwise.
+   parameters| if present, or null otherwise.
 
 1. Let |depth| be 0.
 
-1. Let |contexts| be the result of [=get the descendent browsing contexts=],
-   given |parent id|, |depth|, and |max depth|.
+1. Let |contexts| be a list.
+
+1. If |parent id| is not null, append the result of [=trying=] to
+   [=get a browsing context=] given |parent id| to |contexts|.
+   Otherwise append all [=top-level browsing contexts=] to |contexts|.
+
+1. Let |contexts info| be a list.
+
+1. For each |context| of |contexts|:
+
+  1. Let |info| be the result of [=get the browsing context info=] given
+     |context|, |depth|, and |max depth|.
+
+  1. Append |info| to |contexts info|
 
 1. Let |body| be a [=map=] matching the <code>BrowsingContextGetTreeResult</code>
-   production, with the <code>contexts</code> field set to |contexts|.
+   production, with the <code>contexts</code> field set to |contexts info|.
 
 1. Return [=success=] with data |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -2631,8 +2631,6 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
    parameters| if present, or null otherwise.
 
-1. Let |depth| be 0.
-
 1. Let |contexts| be a list.
 
 1. If |parent id| is not null, append the result of [=trying=] to

--- a/index.bs
+++ b/index.bs
@@ -2353,7 +2353,7 @@ browsing context.
 
 <div algorithm>
 To <dfn>get the browsing context info</dfn> given |context|,
-|depth| and |max depth|:
+|max depth| and |is root|:
 
 1. Let |context id| be the [=browsing context id=] for |context|.
 
@@ -2367,41 +2367,29 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. Let |child info| be the result of [=get the descendent browsing contexts=]
-   given |context|, |depth| + 1, and |max depth|.
+1. Let |child infos| be a list.
+
+1. If |max depth| is null, or |max depth| is greater than 0:
+
+  1. Let |child contexts| be a list containing all [=/browsing contexts=]
+     which are [=child browsing contexts=] of |parent|.
+
+  1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
+
+  1. For each |context| of |child contexts|:
+
+    1. Let |info| be the result of [=get the browsing context info=] given
+       |context|, |child depth|, and <code>false</code>.
+
+    1. Append |info| to |child infos|
 
 1. Let |context info| be a [=map=] matching the
    <code>BrowsingContextInfo</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
-   if |depth| is 0, or unset otherwise, the <code>url</code> field set to
-   |url|, and the <code>children</code> field set to |child info|.
+   if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
+   field set to |url|, and the <code>children</code> field set to |child infos|.
 
 1. Return |context info|.
-
-</div>
-
-<div algorithm>
-To <dfn>get the descendent browsing contexts</dfn> given |parent|, |depth|
-and |max depth|:
-
-1. Assert: |parent| is not null.
-
-1. If |max depth| is not null, and |depth| is greater than |max depth|,
-   return null.
-
-1. Let |child contexts| be a list containing all
-   [=/browsing contexts=] which are [=child browsing contexts=] of |parent|.
-
-1. Let |contexts info| be a list.
-
-1. For each |context| of |child contexts|:
-
-  1. Let |info| be the result of [=get the browsing context info=] given
-     |context|, |depth|, and |max depth|.
-
-  1. Append |info| to |contexts info|
-
-1. Return |contexts info|
 
 </div>
 
@@ -2656,7 +2644,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. For each |context| of |contexts|:
 
   1. Let |info| be the result of [=get the browsing context info=] given
-     |context|, |depth|, and |max depth|.
+     |context|, |max depth|, and <code>true</code>.
 
   1. Append |info| to |contexts info|
 
@@ -2821,7 +2809,7 @@ To <dfn>Recursively emit context created events</dfn> given |session| and |conte
 To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=] given
-   |context|, 0, and 0.
+   |context|, 0, and <code>true</code>.
 
 1. Let |body| be a [=map=] matching the
    <code>BrowsingContextCreatedEvent</code> production, with the
@@ -2883,7 +2871,7 @@ Define the following [=browsing context tree discarded=] steps:
 1. Let |context| be the browsing context being discarded.
 
 1. Let |params| be the result of [=get the browsing context info=], given
-   |context|, 0, and 0.
+   |context|, 0, and <code>true</code>.
 
 1. Let |body| be a [=map=] matching the
     <code>BrowsingContextDestroyedEvent</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -2367,14 +2367,16 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. If |max depth| is null, or |max depth| is greater than 0:
+1. Let |child infos| be null.
 
-  1. Let |child infos| be an empty list.
+1. If |max depth| is null, or |max depth| is greater than 0:
 
   1. Let |child contexts| be a list containing all [=/browsing contexts=]
      which are [=child browsing contexts=] of |parent|.
 
   1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
+
+  1. Set |child infos| to an empty list
 
   1. For each |context| of |child contexts|:
 
@@ -2382,8 +2384,6 @@ To <dfn>get the browsing context info</dfn> given |context|,
        |context|, |child depth|, and false.
 
     1. Append |info| to |child infos|
-
-1. Otherwise let |child infos| be null.
 
 1. Let |context info| be a [=map=] matching the
    <code>BrowsingContextInfo</code> production with the <code>context</code>
@@ -2633,13 +2633,13 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
    parameters| if present, or null otherwise.
 
-1. Let |contexts| be a list.
+1. Let |contexts| be an empty list.
 
 1. If |parent id| is not null, append the result of [=trying=] to
    [=get a browsing context=] given |parent id| to |contexts|.
    Otherwise append all [=top-level browsing contexts=] to |contexts|.
 
-1. Let |contexts info| be a list.
+1. Let |contexts info| be an empty list.
 
 1. For each |context| of |contexts|:
 

--- a/index.bs
+++ b/index.bs
@@ -2821,7 +2821,7 @@ To <dfn>Recursively emit context created events</dfn> given |session| and |conte
 To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=] given
-   |context|, 0, and 1.
+   |context|, 0, and 0.
 
 1. Let |body| be a [=map=] matching the
    <code>BrowsingContextCreatedEvent</code> production, with the


### PR DESCRIPTION
Fixes issue #178.

Appropriate tests for this change are part of https://bugzilla.mozilla.org/show_bug.cgi?id=1694391 and will land soon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/181.html" title="Last updated on Mar 17, 2022, 10:02 AM UTC (7c317f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/181/8b12b43...whimboo:7c317f5.html" title="Last updated on Mar 17, 2022, 10:02 AM UTC (7c317f5)">Diff</a>