### PR TITLE
Don't try to define SandboxWindowProxy in terms of WebIDL.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1009,13 +1009,9 @@ Issue: Define in detail how {{SandboxProxy}} works
 
 ## SandboxWindowProxy ## {#sandbox-sandboxwindowproxy}
 
-<xmp class=idl>
-[Exposed=]
-interface SandboxWindowProxy : WindowProxy {};
-</xmp>
-
-A {{SandboxWindowProxy}} is a {{Window}} object wrapped by a {{SandboxProxy}}
-object. This provides sandboxed access to that data in a {{Window}} global.
+A <dfn interface>SandboxWindowProxy</dfn> is an exotic object that represents a
+{{Window}} object wrapped by a {{SandboxProxy}} object. This provides sandboxed
+access to that data in a {{Window}} global.
 
 Issue: Define how this works.
 


### PR DESCRIPTION
This kind of exotic interface that isn't directly exposed to content
isn't really supported by WebIDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/185.html" title="Last updated on Mar 17, 2022, 11:03 AM UTC (be60e92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/185/9856946...be60e92.html" title="Last updated on Mar 17, 2022, 11:03 AM UTC (be60e92)">Diff</a>