### PR TITLE
Unifying regex with the other values.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1264,14 +1264,14 @@ ObjectLocalValue = {
   value: MappingLocalValue,
 }
 
-RegExpLocalValuePresentation = {
+RegExpValue = {
   pattern: text,
   ?flags: text,
 }
 
 RegExpLocalValue = {
   type: "regexp",
-  value: RegExpLocalValuePresentation,
+  value: RegExpValue,
 }
 
 SetLocalValue = {

--- a/index.bs
+++ b/index.bs
@@ -1264,15 +1264,19 @@ ObjectLocalValue = {
   value: MappingLocalValue,
 }
 
+RegExpLocalValuePresentation = {
+  pattern: text,
+  ?flags: text,
+}
+
 RegExpLocalValue = {
   type: "regexp",
-  pattern: text,
-  ?flags: text
+  value: RegExpLocalValuePresentation,
 }
 
 SetLocalValue = {
   type: "set",
-  value: ListLocalValue
+  value: ListLocalValue,
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -1652,12 +1652,14 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
         1. Let |flags| be [=ToString=]([=Get=](|value|, "flags")).
 
-        1. Let |serialized| be the string-concatenation of "/", |pattern|, "/", and |flags|.
+        1. Let |value| be a map matching the <code>RegExpValue</code> production in the
+           [=local end definition=], with the <code>pattern</code> property set to the
+           |pattern| and the the <code>flags</code> property set to the |flags|.
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
            property set to the [=object id for an object=] |object| and the value
-           set to |serialized|
+           set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>

--- a/index.bs
+++ b/index.bs
@@ -1658,8 +1658,8 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] |object| and the value
-           set to |value|.
+           property set to the [=object id for an object=] |object| and the
+           <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>


### PR DESCRIPTION
Regex is the only data type having value details (`pattern` and `flags`) on the highest level along with `type` and (maybe) `objectId`. It would be easier to process the unified top-level fields, like `type`, `?value`, `?objectId`.

This PR suggests to unify Regex with other types, and move `pattern` and `flags` inside `value` property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver-bidi/pull/189.html" title="Last updated on Apr 6, 2022, 4:08 PM UTC (5baa9d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/189/ed5198c...sadym-chromium:5baa9d5.html" title="Last updated on Apr 6, 2022, 4:08 PM UTC (5baa9d5)">Diff</a>