### PR TITLE
Rename `parent` parameter to browsingContext.getTree to `root`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2743,7 +2743,7 @@ or all top-level contexts when no parent is provided.
 
       BrowsingContextGetTreeParameters = {
         ?maxDepth: uint,
-        ?parent: BrowsingContext,
+        ?root: BrowsingContext,
       }
       </pre>
    </dd>
@@ -2760,7 +2760,7 @@ or all top-level contexts when no parent is provided.
 <div algorithm="remote end steps for browsingContext.getTree">
 The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 
-1. Let |parent id| be the value of the <code>parent</code> field of
+1. Let |root id| be the value of the <code>root</code> field of
    |command parameters| if present, or null otherwise.
 
 1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
@@ -2768,8 +2768,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
 1. Let |contexts| be an empty list.
 
-1. If |parent id| is not null, append the result of [=trying=] to
-   [=get a browsing context=] given |parent id| to |contexts|.
+1. If |root id| is not null, append the result of [=trying=] to
+   [=get a browsing context=] given |root id| to |contexts|.
    Otherwise append all [=top-level browsing contexts=] to |contexts|.
 
 1. Let |contexts info| be an empty list.


### PR DESCRIPTION
Since #181 browsingContext.getTree returns the information for the
context passed in as `parent`. This makes the parameter name confusing
because it's not obvious that e.g. `browsingContext.getTree({parent:
<id>, maxDepth: 0})` will return the information for "parent".

Renaming this parameter `root` clarifies than, when passed, it will be
the root of the returned tree.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/190.html" title="Last updated on Apr 6, 2022, 7:53 PM UTC (435ef98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/190/4e8e5d7...435ef98.html" title="Last updated on Apr 6, 2022, 7:53 PM UTC (435ef98)">Diff</a>