### PR TITLE
Switch to Rust CDDL implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,8 @@ jobs:
           toolchain: stable
       - name: Validate CDDL files
         run: ./scripts/test.sh --install
+      - name: Archive CDDL files
+        uses: actions/upload-artifact@v3
+        with:
+          name: cddl
+          path: "*.cddl"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - name: Install Dependencies
-        run: npm install cddl parse5
-      - name: Extract CDDL content from spec into files
-        run: ./scripts/cddl/generate.js
-      - name: Print remote.cddl
-        run: cat remote.cddl
-      - name: Print local.cddl
-        run: cat local.cddl
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Validate CDDL files
-        run: |
-          npx cddl validate local.cddl
-          npx cddl validate remote.cddl
+        run: ./scripts/test.sh --install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -ex
+
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+ROOT=$(dirname $SCRIPT_DIR)
+
+if [ "$1" = "--install" ]; then
+    cargo install cddl
+    npm install parse5
+fi
+$ROOT/scripts/cddl/generate.js
+
+cddl compile-cddl --cddl local.cddl
+cddl compile-cddl --cddl remote.cddl

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,7 @@ if [ "$1" = "--install" ]; then
     cargo install cddl
     npm install parse5
 fi
+# Extract CDDL content from spec into files
 $ROOT/scripts/cddl/generate.js
 
 cddl compile-cddl --cddl local.cddl


### PR DESCRIPTION
This has a few advantages:
* It prints a more useful error message when it fails, so it's easier
to identify the point of failure
* It supports validation, so we can write tests against the CDDL
defined in the spec.
* It seems to be more actively maintained