### PR TITLE
Fix the log.entryAdded event heading

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4352,7 +4352,7 @@ provide additional fields specific to the entry type.
 
 ### Events ### {#module-log-events}
 
-#### entryAdded #### {#event-log-entryAdded}
+#### The log.entryAdded Event #### {#event-log-entryAdded}
 
 <dl>
    <dt>Event Type</dt>


### PR DESCRIPTION
This is consistent with previous event heading


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/198.html" title="Last updated on May 2, 2022, 8:56 AM UTC (2a1b891)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/198/f286d8e...2a1b891.html" title="Last updated on May 2, 2022, 8:56 AM UTC (2a1b891)">Diff</a>