### PR TITLE
Change Issue about the formatter operation into a Note (log.entryAdded)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4388,8 +4388,8 @@ ignore>options</var>:
    specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise let
    |formatted args| be |args|.
 
-   Issue: This is underdefined in the console spec, so it's unclar if we can get
-   interoperable behaviour here.
+   Note: The formatter operation is underdefined in the console specification,
+   formatting can be inconsistent between different implementations.
 
 1. For each |arg| in |formatted args|:
 


### PR DESCRIPTION
Fixes #139

Inconsistencies caused by stringifying non-primitives are already mentioned in the specification. 
The only thing left here to close the issue is to update the current issue into a note, since there is no action on our side besides notifying users that the formatted `text` might differ across implementations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/200.html" title="Last updated on May 4, 2022, 1:02 PM UTC (3590979)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/200/3dbd65e...juliandescottes:3590979.html" title="Last updated on May 4, 2022, 1:02 PM UTC (3590979)">Diff</a>