### PR TITLE
Make `objectId` realm-specific

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1019,13 +1019,11 @@ Issue: Define how this works.
 
 ## Reference ## {#data-types-reference}
 
-<dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
-[=object id map=].
-
-A [=BiDi session=] has an <dfn>object id map</dfn>. This is a weak map
+Each EMCAScript [=Realm=] has a corresponding <dfn>object id map</dfn>. This is a strong map
 from objects to their corresponding id.
 
-Issue: Should this be explicitly per realm?
+<dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
+[=object id map=] in the given [=Realm=].
 
 ```
 ObjectId = text;
@@ -1039,11 +1037,11 @@ RemoteReference = {
 Issue: handle "stale object reference" case.
 
 <div algorithm>
-To <dfn>deserialize remote reference</dfn> given a |remote reference|:
+To <dfn>deserialize remote reference</dfn> given a |remote reference| in |realm|:
 
 1. Let |object id| be the value of the <code>objectId</code> field of |remote reference|.
 
-1. For each |object| → |id value| of [=object id map=]:
+1. For each |object| → |id value| of the given |realm|'s [=object id map=]:
 
   1. If |id value| is equal to |object id|, return [=success=] with data
      |object|
@@ -1284,7 +1282,7 @@ SetLocalValue = {
 
 <div algorithm>
 
-To <dfn>deserialize key-value list</dfn> given a |serialized key-value list|:
+To <dfn>deserialize key-value list</dfn> given a |serialized key-value list| in |realm|:
 
 1. Let |deserialized key-value list| be a new list.
 
@@ -1299,12 +1297,12 @@ To <dfn>deserialize key-value list</dfn> given a |serialized key-value list|:
       let |deserialized key| be |serialized key|.
 
    1. Otherwise let |deserialized key| be result of [=trying=] to [=deserialize local value=]
-      with |serialized key|.
+      with |serialized key| in |realm|.
 
    1. Let |serialized value| be |serialized key-value|[1].
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
-      |serialized value|.
+      |serialized value| in |realm|.
 
    1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
       |deserialized key-value list|.
@@ -1317,14 +1315,14 @@ To <dfn>deserialize key-value list</dfn> given a |serialized key-value list|:
 
 Issue: TODO distinguish between `List` and `Array`.
 
-To <dfn>deserialize value list</dfn> given a |serialized value list|:
+To <dfn>deserialize value list</dfn> given a |serialized value list| in |realm|:
 
 1. Let |deserialized values| be a new list.
 
 1. For each |serialized value| in the |serialized value list|:
 
    1. Let |deserialized value| be result of [=trying=] to [=deserialize local value=] with
-      |serialized value|.
+      |serialized value| in |realm|.
 
    1. Append |deserialized value| to |deserialized values|;
 
@@ -1334,10 +1332,10 @@ To <dfn>deserialize value list</dfn> given a |serialized value list|:
 
 <div algorithm>
 
-To <dfn>deserialize local value</dfn> given a |local protocol value|:
+To <dfn>deserialize local value</dfn> given a |local protocol value| in |realm|:
 
 1. If |local protocol value| matches the [=RemoteReference=] production, return
-   [=deserialize remote reference=] of |local protocol value|.
+   [=deserialize remote reference=] of |local protocol value| in |realm|.
 
 1. If |local protocol value| matches the [=PrimitiveProtocolValue=] production, return
    [=deserialize primitive protocol value=] with |local protocol value|.
@@ -1356,7 +1354,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>array</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=] with
-         given |value|.
+         given |value| in |realm|.
 
       1. Return [=success=] with data [=CreateArrayFromList=](|deserialized value list|).
 
@@ -1370,7 +1368,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>map</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with |value|.
+         [=deserialize key-value list=] with |value| in |realm|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1379,7 +1377,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>object</code>"
     <dd>
       1. Let |deserialized key-value list| be a result of [=trying=] to
-         [=deserialize key-value list=] with |value|.
+         [=deserialize key-value list=] with |value| in |realm|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1400,7 +1398,7 @@ To <dfn>deserialize local value</dfn> given a |local protocol value|:
     <dt>|type| is the string "<code>set</code>"
     <dd>
       1. Let |deserialized value list| be a result of [=trying=] to [=deserialize value list=]
-         with |value|.
+         with |value| in |realm|.
 
       1. Let |iterable| be [=CreateArrayFromList=](|deserialized key-value list|)
 
@@ -1439,19 +1437,18 @@ object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
 <div algorithm>
-To get the <dfn>object id for an object</dfn> given a |session| and |object|:
+To get the <dfn>object id for an object</dfn> given an |object| in a given |realm|:
 
-1. If |session|'s [=object id map=] does not contain |object|, run the
+1. If the given |realm|'s [=object id map=] does not contain |object|, run the
    following steps:
 
   1. Let |object id| be a new, unique, string identifier for |object|. If |object| is an
      [=/element=] this must be the [=web element reference=] for |object|; if it's a {{WindowProxy}}
      object, this must be the [=browsing context id=] for |object|.
 
-  1. Set the value of |object| in |session|'s [=object id map=] to |object id|.
+  1. Set the value of |object| in the given |realm|'s [=object id map=] to |object id|.
 
-1. Return the result of getting the value for |object| in |session|'s [=object
-   id map=].
+1. Return the result of getting the value for |object| in |realm|'s [=object id map=].
 
 </div>
 
@@ -1613,7 +1610,7 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-|node details|, and a |set of known objects|:
+|node details|, a |set of known objects| in a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1627,7 +1624,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>[=IsArray=](|value|)
     <dd>
@@ -1639,12 +1636,12 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateArrayIterator=](|value|, value), |max depth|, |node details| and
-              |set of known objects|.
+              |set of known objects| in |realm|.
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code> production
        in the [=local end definition=], with the <code>objectId</code> property set
-       to the [=object id for an object=] |value|, and the <code>value</code>
-       field set to |serialized| if it's not null, or ommitted otherwise.
+       to the [=object id for an object=] |value| in |realm|, and the <code>value</code>
+       field set to |serialized| if it's not null, or omitted otherwise.
 
     <dt>[=IsRegExp=](|value|)
     <dd>
@@ -1658,8 +1655,8 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] |object| and the
-           <code>value</code> property set to |value|.
+           property set to the [=object id for an object=] |object| in |realm| and
+           the <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>
@@ -1667,8 +1664,8 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
       1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
-         property set to the [=object id for an object=] |object| and the value
-         set to |serialized|.
+         property set to the [=object id for an object=] |object| in |realm| and the
+         value set to |serialized|.
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
     <dd>
@@ -1680,13 +1677,13 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
            1. Let |serialized| be the result of [=serialize as a mapping=] given
               [=CreateMapIterator=](|value|, key+value), |max depth|, |node details| and
-              |set of known objects|.
+              |set of known objects| in |realm|.
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
        <code>objectId</code> property set to the [=object id for an object=]
-       |value|, and the <code>value</code> field set to |serialized| if it's
-       not null, or ommitted otherwise.
+       |value| in |realm|, and the <code>value</code> field set to |serialized| if
+       it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[SetData]] [=internal slot=]
     <dd>
@@ -1698,43 +1695,43 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateSetIterator=](|value|, value), |max depth|, |node details| and
-              |set of known objects|.
+              |set of known objects| in |realm|.
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
         <code>objectId</code> property set to the [=object id for an object=]
-        |value|, and the <code>value</code> field set to |serialized| if it's
-        not null, or ommitted otherwise.
+        |value| in |realm|, and the <code>value</code> field set to |serialized| if
+        it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakSetRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ErrorRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>[=IsPromise=](|value|)
     <dd>Let |remote value| be a map matching the <code>PromiseRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>TypedArrayRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -1766,7 +1763,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
                with |child|, |child depth|, |node details| and
-               |set of known objects|.
+               |set of known objects| in |realm|.
 
             1. Append |serialized| to |children|.
 
@@ -1796,7 +1793,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
-                  false and |set of known objects|.
+                  false and |set of known objects| in |realm|.
 
                 Note: this means the <code>objectId</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1806,23 +1803,23 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
-         property set to the [=object id for an object=] |value|, and <code>value</code>
+         property set to the [=object id for an object=] |value| in |realm|, and <code>value</code>
          set to |serialized|, if |serialized| is not null.
 
     <dt>|value| is a [=platform object=] that implements {{WindowProxy}}
     <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] |value|.
+           property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a map matching the <code>ObjectValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] |value|.
+           property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>[=IsCallable=](|value|)
     <dd>Let |remote value| be a map matching the <code>FunctionValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] |value|.
+        property set to the [=object id for an object=] |value| in |realm|.
 
     <dt>Otherwise:
     <dd>
@@ -1836,11 +1833,11 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|, |node
-          details| and |set of known objects|
+          details| and |set of known objects| in |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>objectId</code> property set
-       to the [=object id for an object=] |value|, and the <code>value</code> field
+       to the [=object id for an object=] |value| in |realm|, and the <code>value</code> field
        set to |serialized|.
   </dl>
 
@@ -1864,7 +1861,7 @@ remove optional flag from the field.
 
 <div algorithm>
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
-|node details| and |set of known objects|:
+|node details| and |set of known objects| in |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1874,8 +1871,8 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
        otherwise.
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
-       with arguments |child value|, |child depth|, |node details| and |set of
-       known objects|.
+       with arguments |child value|, |child depth|, |node details| and
+       |set of known objects| in |realm|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -1886,7 +1883,7 @@ Issue: this assumes for-in works on iterators
 
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
-|node details| and |set of known objects|:
+|node details| and |set of known objects| in |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -1909,8 +1906,8 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
      |set of known objects|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with arguments |value|, |child depth|, |node details| and |set of known
-     objects|.
+     with arguments |value|, |child depth|, |node details| and
+     |set of known objects| in |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
@@ -3354,7 +3351,7 @@ The <code>ExceptionDetails</code> type represents a JavaScript exception.
 
 <div algorithm>
 
-To <dfn>get exception details</dfn> given a [=completion record=] |record|:
+To <dfn>get exception details</dfn> given a [=completion record=] |record| in |realm|:
 
 1. Assert: |record|.\[[Type]] is <code>throw</code>.
 
@@ -3365,7 +3362,8 @@ To <dfn>get exception details</dfn> given a [=completion record=] |record|:
    this data with regex or something equally bad.
 
 1. Let |exception| be the result of [=serialize as a remote value=] given
-   |record|.\[[Value]].
+   |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as |node details|,
+   a <code>new set</code> as |set of known objects| in |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -3787,14 +3785,14 @@ Issue: TODO: Add timeout argument as described in the script.evaluate.
 
 <div algorithm>
 
-To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
+To <dfn>deserialize arguments</dfn> given |serialized arguments list| in |realm|:
 
 1. Let |deserialized arguments list| be an empty list.
 
 1. For each |serialized argument| of |serialized arguments list|:
 
   1. Let |deserialized argument| be the result of [=trying=] to [=deserialize local value=]
-     with |serialized argument|.
+     given |serialized argument| in |realm|.
 
   1. Append |deserialized argument| to the |deserialized arguments list|.
 
@@ -3804,7 +3802,7 @@ To <dfn>deserialize arguments</dfn> given |serialized arguments list|:
 
 <div algorithm>
 To <dfn>evaluate function body</dfn> with a given |function declaration|,
-|environment settings|, |base URL|, and |options|:
+|environment settings|, |base URL|, and |options| in |realm|:
 
 Note: the |function declaration| is parenthesized and evaluated.
 
@@ -3841,7 +3839,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |deserialized arguments| be an empty list.
 
 1. If |command arguments| is not null, set |deserialized arguments| to the result of [=trying=] to
-   [=deserialize arguments=] with |command arguments|.
+   [=deserialize arguments=] with |command arguments| in |realm|.
 
 1. Let |this parameter| be the value of the <code>this</code> field
    of |command parameters|.
@@ -3849,13 +3847,13 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |this object| be null.
 
 1. If |this parameter| is not null, set |this object| to the result of [=trying=] to
-   [=deserialize local value=] with |this parameter|.
+   [=deserialize local value=] given |this parameter| in |realm|.
 
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
 1. Let |function body evaluation status| be the result of [=evaluate function body=]
-   (|function declaration|, |environment settings|, |base URL|, and |options|).
+   (|function declaration|, |environment settings|, |base URL|, and |options| in |realm|).
 
 1. If |function body evaluation status|.\[[Type]] is <code>throw</code>, return [=error=] with
    [=error code=] [=invalid argument=].
@@ -3882,7 +3880,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |evaluation status|.
+     |evaluation status| in |realm|.
 
   1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>exceptionDetails</code> field set to
@@ -3891,7 +3889,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]].
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
+   |node details|, <code>new set</code> as |set of known objects| in |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -3973,7 +3972,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given |evaluation
-     status|
+     status| in |realm|.
 
   1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>realm</code> field set to |realm id|, and the
@@ -3982,7 +3981,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]].
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
+   |node details|, <code>new set</code> as |set of known objects| in |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and


### PR DESCRIPTION
Step 1 towards addressing #90 and implementing the [proposal](https://github.com/w3c/webdriver-bidi/issues/90#issuecomment-1111052638).

* Make `ObjectId` realm-specific.