### PR TITLE
Strong unique `Handle` in serialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -337,8 +337,8 @@ An implementation may define <dfn>extension modules</dfn>. These must have a
 [=module name=] that contains a single colon "<code>:</code>" character. The
 part before the colon is the prefix; this is typically the same for all
 extension modules specific to a given implementation and should be unique for a
-given implementation. Such modules extend the [=local end definition=] and
-[=remote end definition=] providing additional groups as choices for the defined
+given implementation. Such modules extend the [=local end definition=] and [=remote
+end definition=] providing additional groups as choices for the defined
 [=commands=] and [=events=].
 
 ## Commands ## {#commands}
@@ -351,17 +351,16 @@ long-running. As a consequence, commands can finish out-of-order.
 
 Each [=command=] is defined by:
 
-- A <dfn export for=command>command type</dfn> which is defined by a
-  [=remote end definition=] fragment containing a group. Each such group has two
-  fields:
+- A <dfn export for=command>command type</dfn> which is defined by a [=remote
+   end definition=] fragment containing a group. Each such group has two fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[method name]</code>. This is the <dfn export for=command>command
       name</dfn>.
     - <code>params</code> which defines a mapping containing data that to be passed into
       the command. The populated value of this map is the
       <dfn export for=command>command parameters</dfn>.
-- A <dfn export for=command>result type</dfn>, which is defined by a
-  [=local end definition=] fragment.
+- A <dfn export for=command>result type</dfn>, which is defined by a [=local
+  end definition=] fragment.
 - A set of [=remote end steps=] which define the actions to take for a command
   given a [=BiDi session=] and [=command parameters=] and return an
   instance of the command [=return type=].
@@ -376,21 +375,21 @@ command. From the point of view of the [=remote end=] this identifier is opaque
 and cannot be used internally to identify the command.
 
 Note: This is because the command id is entirely controlled by the [=local end=]
-and isn't necessarily unique over the course of a session. For example a
-[=local end=] which ignores all responses could use the same command id for each
-command.
+and isn't necessarily unique over the course of a session. For example a [=local
+end=] which ignores all responses could use the same command id for each command.
 
 The <dfn export for=command>set of all command names</dfn> is a set containing
-all the defined [=command names=], including any belonging to [=extension modules=].
+all the defined [=command names=], including any belonging to [=extension
+modules=].
 
 ## Events ## {#events}
 
-An <dfn export>event</dfn> is a notification, sent by the [=remote end=] to the
-[=local end=], signaling that something of interest has occurred on the
-[=remote end=].
+An <dfn export>event</dfn> is a notification, sent by the [=remote
+end=] to the [=local end=], signaling that something of interest has
+occurred on the [=remote end=].
 
- - An <dfn export for=event>event type</dfn> is defined by a [=local end definition=]
-   fragment containing a group. Each such group has two fields:
+ - An <dfn export for=event>event type</dfn> is defined by a [=local
+   end definition=] fragment containing a group. Each such group has two fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[event name]</code>. This is the <dfn export for=event>event
       name</dfn>.
@@ -509,10 +508,11 @@ Message transport is provided using the WebSocket protocol.
 Note: In the terms of the WebSocket protocol, the [=local end=] is the
 client and the [=remote end=] is the server / remote host.
 
-Note: The encoding of [=commands=] and [=events=] as messages is similar to JSON-RPC,
-but this specification does not normatively reference it. [[JSON-RPC]] The normative
-requirements on [=remote ends=] are instead given as a precise processing model,
-while no normative requirements are given for [=local ends=].
+Note: The encoding of [=commands=] and [=events=] as messages is
+similar to JSON-RPC, but this specification does not normatively
+reference it. [[JSON-RPC]] The normative requirements on [=remote
+ends=] are instead given as a precise processing model, while no
+normative requirements are given for [=local ends=].
 
 A <dfn>WebSocket listener</dfn> is a network endpoint that is able
 to accept incoming [[!RFC6455|WebSocket]] connections.
@@ -543,19 +543,22 @@ initially empty.
 A [=BiDi session=] |session| is <dfn>associated with connection</dfn>
 |connection| if |session|'s [=session WebSocket connections=] contains |connection|.
 
-Note: Each [=WebSocket connection=] is associated with at most one [=BiDi session=].
+Note: Each [=WebSocket connection=] is associated with at most one [=BiDi
+session=].
 
 <div>
 
-When a client [=establishes a WebSocket connection=] |connection| by connecting to
-one of the set of [=active listeners=] |listener|, the implementation must proceed
-according to the WebSocket [=server-side requirements=], with the following steps run
-when deciding whether to accept the incoming connection:
+When a client [=establishes a WebSocket connection=] |connection| by
+connecting to one of the set of [=active listeners=] |listener|, the
+implementation must proceed according to the WebSocket [=server-side
+requirements=], with the following steps run when deciding whether to
+accept the incoming connection:
 
-1. Let |resource name| be the resource name from
-   [=reading the client's opening handshake=]. If |resource name| is not in
-   |listener|'s [=list of WebSocket resources=], then stop running these steps and
-   act as if the requested service is not available.
+1. Let |resource name| be the resource name from [=reading the
+   client's opening handshake=]. If |resource name| is not in
+   |listener|'s [=list of WebSocket resources=], then stop
+   running these steps and act as if the requested service is not
+   available.
 
 1. If |resource name| is the byte string "<code>/session</code>",
    and the implementation [=supports BiDi-only sessions=]:
@@ -564,8 +567,8 @@ when deciding whether to accept the incoming connection:
        connection should be accepted, and if it is not stop running these
        steps and act as if the requested service is not available.
 
-    1. Add the connection to the set of
-       [=WebSocket connections not associated with a session=].
+    1. Add the connection to the set of [=WebSocket connections not associated
+       with a session=].
 
     1. Return.
 
@@ -583,21 +586,23 @@ when deciding whether to accept the incoming connection:
    connection should be accepted, and if it is not stop running these
    steps and act as if the requested service is not available.
 
-1. Otherwise append |connection| to |session|'s [=session WebSocket connections=],
-   and proceed with the WebSocket [=server-side requirements=] when a server chooses
-   to accept an incoming connection.
+1. Otherwise append |connection| to |session|'s [=session WebSocket
+   connections=], and proceed with the WebSocket [=server-side requirements=]
+   when a server chooses to accept an incoming connection.
 
 Issue: Do we support > 1 connection for a single session?
 
 </div>
 
-When [=a WebSocket message has been received=] for a [=WebSocket connection=]
-|connection| with type |type| and data |data|, a [=remote end=] must
-[=handle an incoming message=] given |connection|, |type| and |data|.
+When [=a WebSocket message has been received=] for a [=WebSocket
+connection=] |connection| with type |type| and data |data|, a [=remote
+end=] must [=handle an incoming message=] given |connection|, |type|
+and |data|.
 
-When [=the WebSocket closing handshake is started=] or when
-[=the WebSocket connection is closed=] for a [=WebSocket connection=] |connection|, a
-[=remote end=] must [=handle a connection closing=] given |connection|.
+When [=the WebSocket closing handshake is started=] or when [=the
+WebSocket connection is closed=] for a [=WebSocket connection=]
+|connection|, a [=remote end=] must [=handle a connection closing=]
+given |connection|.
 
 Note: Both conditions are needed because it is possible for a
 WebSocket connection to be closed without a closing handshake.
@@ -621,8 +626,8 @@ To <dfn lt="construct a WebSocket URL|constructing a WebSocket
 URL">construct a WebSocket URL</dfn> given a [=WebSocket listener=]
 |listener| and [=/session=] |session|:
 
-1. Let |resource name| be the result of [=constructing a WebSocket resource name=]
-   given |session|.
+1. Let |resource name| be the result of [=constructing a WebSocket
+   resource name=] given |session|.
 
 1. Return a [=WebSocket URI=] constructed with host set to
    |listener|'s [=listener/host=], port set to |listener|'s
@@ -661,13 +666,14 @@ To <dfn>start listening for a WebSocket connection</dfn> given a
    [=listener/host=], [=listener/port=], [=listener/secure flag=],
    and an empty [=list of WebSocket resources=].
 
-1. Let |resource name| be the result of [=constructing a WebSocket resource name=]
-   given |session|.
+1. Let |resource name| be the result of [=constructing a WebSocket
+   resource name=] given |session|.
 
 1. Append |resource name| to the [=list of WebSocket resources=] for
    |listener|.
 
-1. [=set/Append=] |listener| to the [=remote end=]'s [=active listeners=].
+1. [=set/Append=] |listener| to the [=remote end=]'s [=active
+    listeners=].
 
 1. Return |listener|.
 
@@ -685,12 +691,14 @@ typically be "<code>localhost</code>".
 To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 |connection|, type |type| and data |data|:
 
-1. If |type| is not [=%x1 denotes a text frame|text=], [=respond with an error=]
-   given |connection|, null, and [=invalid argument=], and finally return.
+1. If |type| is not [=%x1 denotes a text frame|text=], [=respond with an
+   error=] given |connection|, null, and [=invalid argument=], and finally
+   return.
 
 1. [=Assert=]: |data| is a [=scalar value string=], because the
     WebSocket [=handling errors in UTF-8-encoded data=] would already
-    have [=fail the WebSocket connection|failed the WebSocket connection=] otherwise.
+    have [=fail the WebSocket connection|failed the WebSocket
+    connection=] otherwise.
 
    Issue: Nothing seems to define what [=status codes|status code=]
    is used for UTF-8 errors.
@@ -700,10 +708,10 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
    [=WebSocket connections not associated with a session=], let |session| be
    null. Otherwise, return.
 
-1. Let |parsed| be the result of
-   [=parse JSON into Infra values|parsing JSON into Infra values=] given |data|. If
-   this throws an exception, then [=respond with an error=] given |connection|, null,
-   and [=invalid argument=], and finally return.
+1. Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
+   into Infra values=] given |data|. If this throws an exception, then [=respond
+   with an error=] given |connection|, null, and [=invalid argument=], and
+   finally return.
 
 1. Match |parsed| against the [=remote end definition=]. If this results in a
    match:
@@ -720,8 +728,8 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     1. Let |command| be the command with [=command name=] |method|.
 
     1. If |session| is null and |command| is not a [=static command=], then
-       [=respond with an error=] given |connection|, |command id|, and
-       [=invalid session id=], and return.
+       [=respond with an error=] given |connection|, |command id|, and [=invalid
+       session id=], and return.
 
     1. Run the following steps in parallel:
 
@@ -749,8 +757,8 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
         field set to |command id| and the <code>value</code> field set to
         |value|.
 
-     1. Let |serialized| be the result of [=serialize an infra value to JSON bytes=]
-        given |response|.
+     1. Let |serialized| be the result of [=serialize an infra value to JSON
+        bytes=] given |response|.
 
      1. [=Send a WebSocket message=] comprised of |serialized| over
         |connection|.
@@ -765,10 +773,11 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
    1. Let |error code| be [=invalid argument=].
 
    1. If |parsed| is a map and |parsed|["<code>method</code>"] exists and is a
-      string, but |parsed|["<code>method</code>"] is not in the
-      [=set of all command names=], set |error code| to [=unknown command=].
+      string, but |parsed|["<code>method</code>"] is not in the [=set of all
+      command names=], set |error code| to [=unknown command=].
 
-   1. [=Respond with an error=] given |connection|, |command id|, and |error code|.
+   1. [=Respond with an error=] given |connection|, |command id|, and
+      |error code|.
 
 </div>
 
@@ -801,8 +810,8 @@ To <dfn>get related browsing contexts</dfn> given an [=script/settings object=]
 
 1. If |connection| is null, return.
 
-1. Let |serialized| be the result of [=serialize an infra value to JSON bytes=] given
-   |body|.
+1. Let |serialized| be the result of [=serialize an infra value to JSON
+   bytes=] given |body|.
 
 1. [=Send a WebSocket message=] comprised of |serialized| over |connection|.
 
@@ -842,7 +851,8 @@ To <dfn>handle a connection closing</dfn> given a [=WebSocket connection=]
   1. Let |session| be the [=BiDi session=] [=associated with connection=]
      |connection|.
 
-  1. Remove |connection| from |session|'s [=session WebSocket connections=].
+  1. Remove |connection| from |session|'s [=session WebSocket
+     connections=].
 
 1. Otherwise, if the set of [=WebSocket connections not associated with a session=]
    contains |connection|, remove |connection| from that set.
@@ -897,11 +907,11 @@ with parameters |session|, |capabilities|, and |flags| is:
 
 1. [=Assert=]: |webSocketUrl| is true.
 
-1. Let |listener| be the result of [=start listening for a WebSocket connection=]
-   given |session|.
+1. Let |listener| be the result of [=start listening for a WebSocket
+   connection=] given |session|.
 
-1. Set |webSocketUrl| to the result of [=constructing a WebSocket URL=] given
-   |listener| and |session|.
+1. Set |webSocketUrl| to the result of [=constructing a WebSocket
+   URL=] given |listener| and |session|.
 
 1. [=Set a property=] on |capabilities| named
    "<code>webSocketUrl</code>" to |webSocketUrl|.
@@ -956,13 +966,13 @@ provides access to platform objects in an existing {{Window}} realm via
 <div algorithm>
 To <dfn>get or create a sandbox realm</dfn> given |name| and |browsing context|:
 
-1. If [=context sandbox map=] does not contain |browsing context|, set
-   [=context sandbox map=][|source browsing context|] to a new map.
+1. If [=context sandbox map=] does not contain |browsing context|, set [=context
+   sandbox map=][|source browsing context|] to a new map.
 
 1. Let |sandboxes| be [=context sandbox map=][|source browsing context|].
 
-1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to
-   [=create a sandbox realm=] with |source browsing context|.
+1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to [=create
+   a sandbox realm=] with |source browsing context|.
 
 1. Return |sandboxes|[|name|].
 
@@ -2029,17 +2039,16 @@ events are disabled, the return value is always empty.
 
          1. If |global event set| doesn't contain |event name|:
 
-           1. Let |already enabled contexts| be the
-              [=event enabled browsing contexts=] given |session| and |event name|
+           1. Let |already enabled contexts| be the [=event enabled browsing
+              contexts=] given |session| and |event name|
 
            1. Add |event name| to |global event set|.
 
            1. For each |context| of |already enabled contexts|, remove |event name|
               from |event map|[|context|].
 
-           1. Let |newly enabled contexts| be a list of all
-              [=top-level browsing contexts=] that are not contained in
-              |already enabled contexts|,
+           1. Let |newly enabled contexts| be a list of all [=top-level browsing
+              contexts=] that are not contained in |already enabled contexts|,
 
            1. Set |enabled events|[|event name|] to |newly enabled contexts|.
 
@@ -2085,8 +2094,8 @@ events are disabled, the return value is always empty.
       1. If |enabled| is false:
 
         1. If |target| contains |event name|, remove |event name| from
-           |target|. Otherwise return [=error=] with [=error code=]
-           [=invalid argument=].
+           |target|. Otherwise return [=error=] with [=error code=] [=invalid
+           argument=].
 
 1. Set the [=global event set=] for |session| to |global event set|.
 
@@ -2309,9 +2318,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. For each |event name| → |contexts| in |enabled events|:
 
-  1. If the [=event=] with [=event name=] |event name| defines
-     [=remote end subscribe steps=], set |subscribe step events|[|event name|] to
-     |contexts|.
+  1. If the [=event=] with [=event name=] |event name| defines [=remote end
+     subscribe steps=], set |subscribe step events|[|event name|] to |contexts|.
 
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
    than algorithm given two entries with keys |event name one| and |event name two|:
@@ -2747,10 +2755,10 @@ The [=remote end steps=] with |command parameters| are:
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->
-  1. Create a new [=top-level browsing context=] by running the
-     [=window open steps=] with <var ignore>url</var> set to
-     "<code>about:blank</code>", <var ignore>target</var> set to the empty string,
-     and <var ignore>features</var> set to "<code>noopener</code>". This must be
+  1. Create a new [=top-level browsing context=] by running the [=window open
+     steps=] with <var ignore>url</var> set to "<code>about:blank</code>",
+     <var ignore>target</var> set to the empty string, and
+     <var ignore>features</var> set to "<code>noopener</code>". This must be
      done without invoking the [=/focusing steps=] for the created browsing
      context. If |type| is "<code>tab</code>", and the implementation supports
      multiple browsing contexts in the same OS window, the new browsing context
@@ -2895,8 +2903,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |url record| be the result of applying the [=URL parser=] to |url|,
    with [=base URL=] |base|.
 
-1. If |url record| is failure, return [=error=] with [=error code=]
-   [=invalid argument=].
+1. If |url record| is failure, return [=error=] with [=error code=] [=invalid
+   argument=].
 
 1. Let |request| be a new [=/request=] whose URL is |url record|.
 
@@ -3059,9 +3067,8 @@ Define the following [=browsing context tree discarded=] steps:
     <code>BrowsingContextDestroyedEvent</code> production, with the
     <code>params</code> field set to |params|.
 
-1. Let |related browsing contexts| be a set containing the
-   [=parent browsing context=] of |context|, if that is not null, or an empty set
-   otherwise.
+1. Let |related browsing contexts| be a set containing the [=parent browsing
+   context=] of |context|, if that is not null, or an empty set otherwise.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related browsing
@@ -3675,9 +3682,9 @@ To <dfn>construct a stack trace</dfn>, with a list of stack frames |stack|:
    1. Let |frame info| be a new map matching the <code>StackFrame</code>
       production, with the <code>url</code> field set to |url|, the
       <code>functionName</code> field set to |frame|'s [=stackframe/function=],
-      the <code>lineNumber</code> field set to |frame|'s
-      [=stackframe/line number=] and the <code>columnNumber</code> field set to
-      |frame|'s [=stackframe/column number=].
+      the <code>lineNumber</code> field set to |frame|'s [=stackframe/line
+      number=] and the <code>columnNumber</code> field set to |frame|'s
+      [=stackframe/column number=].
 
 1. Append |frame info| to |call frames|.
 
@@ -3689,13 +3696,13 @@ To <dfn>construct a stack trace</dfn>, with a list of stack frames |stack|:
 </div>
 
 The <dfn>current stack trace</dfn> is the result of [=construct a stack trace=]
-given a [=list of stack frames=] representing the callstack of the
-[=running execution context=].
+given a [=list of stack frames=] representing the callstack of the [=running
+execution context=].
 
 <div algorithm>
 
-The <dfn>stack trace for an exception</dfn> with an exception, or a
-[=Completion Record=] of type <code>throw</code>, |exception|, is given by:
+The <dfn>stack trace for an exception</dfn> with an exception, or a [=Completion
+Record=] of type <code>throw</code>, |exception|, is given by:
 
 1. If |exception| is a value that has been thrown as an exception, let |record|
    be the [=Completion Record=] created to throw |exception|. Otherwise let
@@ -4205,20 +4212,21 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for script.realmCreated">
 
-When any of the [=set up a window environment settings object=],
-[=set up a worker environment settings object=] or
-[=set up a worklet environment settings object=] algorithms are invoked, immediately
-prior to returning the settings object:
+When any of the [=set up a window environment settings object=], [=set up a
+worker environment settings object=] or [=set up a worklet environment settings
+object=] algorithms are invoked, immediately prior to returning the settings
+object:
 
-1. Let |environment settings| be the newly created [=environment settings object=].
+1. Let |environment settings| be the newly created [=environment settings
+   object=].
 
 1. Let |realm info| be be the result of [=get the realm info=] given
    |environment settings|.
 
 1. If |realm info| is null, return.
 
-1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
-   given |environment settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing
+   contexts=] given |environment settings|.
 
 1. Let |body| be a map matching the <code>RealmCreatedEvent</code>
    production, with the <code>params</code> field set to |realm info|.
@@ -4329,14 +4337,14 @@ Define the following [=unloading document cleanup steps=] with |document|:
   1. [=Emit an event=] with |session| and |body|.
 
 Whenever a [=worker event loop=] |event loop| is destroyed, either because the
-worker comes to the end of its lifecycle, or prematurely via the
-[=terminate a worker=] algorithm:
+worker comes to the end of its lifecycle, or prematurely via the [=terminate a
+worker=] algorithm:
 
 1. Let |environment settings| be the [=environment settings object=] for which
    |event loop| is the [=responsible event loop=].
 
-1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
-   given |environment settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing
+   contexts=] given |environment settings|.
 
 1. Let |realm| be |environment settings|'s [=environment settings object's Realm=].
 
@@ -4509,14 +4517,14 @@ ignore>options</var>:
 
 1. Let |serialized args| be a new list.
 
-1. For each |arg| of |args|, append the result of [=serialize as a remote value=]
-   given |arg|, null, true, and an empty [=set=] to |serialized args|.
+1. For each |arg| of |args|, append the result of [=serialize as a remote
+   value=] given |arg|, null, true, and an empty [=set=] to |serialized args|.
 
 1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
 
 1. If |method| is "<code>assert</code>", "<code>error</code>",
-   "<code>trace</code>", or "<code>warn</code>", let |stack| be the
-   [=current stack trace=]. Otherwise let |stack| be null.
+   "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
+   stack trace=]. Otherwise let |stack| be null.
 
 1. Let |entry| be a map matching the <code>ConsoleLogEntry</code> production,
    with the the <code>level</code> field set to |level|, the <code>text</code>
@@ -4530,8 +4538,8 @@ ignore>options</var>:
 
 1. Let |settings| be the [=current settings object=]
 
-1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
-   given |settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing
+   contexts=] given |settings|.
 
 1. For each |session| in [=active BiDi sessions=]:
 
@@ -4556,8 +4564,8 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
    with <code>level</code> set to "<code>error</code>", <code>text</code> set to
    |message|, and the <code>timestamp</code> field set to |timestamp|.
 
-1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
-   given |settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing
+   contexts=] given |settings|.
 
 1. For each |session| in [=active BiDi sessions=]:
 
@@ -4586,8 +4594,8 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 10, given
   1. Let |maybe context| be the result of [=getting a browsing context=] given
      |context id|.
 
-  1. If |maybe context| is an [=error=], remove |context id| from
-     [=log event buffer=] and continue.
+  1. If |maybe context| is an [=error=], remove |context id| from [=log event
+     buffer=] and continue.
 
   1. Let |context| be |maybe context|'s data
 
@@ -4623,8 +4631,8 @@ To discard a browsing context |browsingContext|, run these steps:
 1. If this is not a recursive invocation of this algorithm, call any <dfn export>browsing context
    tree discarded</dfn> steps defined in other applicable specifications with |browsingContext|.
 
-1. Discard all {{Document}} objects for all the entries in |browsingContext|'s
-   [=session history=].
+1. Discard all {{Document}} objects for all the entries in |browsingContext|'s [=session
+   history=].
 
 1. If |browsingContext| is a [=top-level browsing context=], then [=remove a browsing context=]
    |browsingContext|.
@@ -4652,8 +4660,9 @@ Other specifications can define <dfn>console steps</dfn>. When any method of the
 {{console}} interface is called, with method name
 |method| and argument |args|:
 
-1. If that method does not call the [=Printer=] operation, call any [=console steps=]
-   defined in external specification with arguments |method|, |args| and undefined.
+1. If that method does not call the [=Printer=] operation, call any [=console
+   steps=] defined in external specification with arguments |method|, |args|
+   and, undefined.
 
    Otherwise, at the point when the [=Printer=] operation is called with
    arguments |name|, |printerArgs| and |options| (which is undefined if the

--- a/index.bs
+++ b/index.bs
@@ -1908,8 +1908,8 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with arguments |child key|, |child depth|, |node details| and
-     |set of known objects|.
+     with arguments |child key|, |child depth|, |node details|,
+     |set of known objects| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
      with arguments |value|, |child depth|, |node details|, |child ownership|,

--- a/index.bs
+++ b/index.bs
@@ -217,8 +217,8 @@ The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
 convenience of implementors two seperate CDDL definitions are defined; the
 <dfn>remote end definition</dfn> which defines the format of messages produced
 on the [=local end=] and consumed on the [=remote end=], and the <dfn>local end
-definition</dfn> which defines the format of messages produced on the [=remote
-end=] and consumed on the [=local end=]
+definition</dfn> which defines the format of messages produced on the [=remote end=]
+and consumed on the [=local end=]
 
 ## Definition ## {#protocol-definition}
 
@@ -337,8 +337,8 @@ An implementation may define <dfn>extension modules</dfn>. These must have a
 [=module name=] that contains a single colon "<code>:</code>" character. The
 part before the colon is the prefix; this is typically the same for all
 extension modules specific to a given implementation and should be unique for a
-given implementation. Such modules extend the [=local end definition=] and [=remote
-end definition=] providing additional groups as choices for the defined
+given implementation. Such modules extend the [=local end definition=] and
+[=remote end definition=] providing additional groups as choices for the defined
 [=commands=] and [=events=].
 
 ## Commands ## {#commands}
@@ -351,16 +351,17 @@ long-running. As a consequence, commands can finish out-of-order.
 
 Each [=command=] is defined by:
 
-- A <dfn export for=command>command type</dfn> which is defined by a [=remote
-   end definition=] fragment containing a group. Each such group has two fields:
+- A <dfn export for=command>command type</dfn> which is defined by a
+  [=remote end definition=] fragment containing a group. Each such group has two
+  fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[method name]</code>. This is the <dfn export for=command>command
       name</dfn>.
     - <code>params</code> which defines a mapping containing data that to be passed into
       the command. The populated value of this map is the
       <dfn export for=command>command parameters</dfn>.
-- A <dfn export for=command>result type</dfn>, which is defined by a [=local
-  end definition=] fragment.
+- A <dfn export for=command>result type</dfn>, which is defined by a
+  [=local end definition=] fragment.
 - A set of [=remote end steps=] which define the actions to take for a command
   given a [=BiDi session=] and [=command parameters=] and return an
   instance of the command [=return type=].
@@ -375,21 +376,21 @@ command. From the point of view of the [=remote end=] this identifier is opaque
 and cannot be used internally to identify the command.
 
 Note: This is because the command id is entirely controlled by the [=local end=]
-and isn't necessarily unique over the course of a session. For example a [=local
-end=] which ignores all responses could use the same command id for each command.
+and isn't necessarily unique over the course of a session. For example a
+[=local end=] which ignores all responses could use the same command id for each
+command.
 
 The <dfn export for=command>set of all command names</dfn> is a set containing
-all the defined [=command names=], including any belonging to [=extension
-modules=].
+all the defined [=command names=], including any belonging to [=extension modules=].
 
 ## Events ## {#events}
 
-An <dfn export>event</dfn> is a notification, sent by the [=remote
-end=] to the [=local end=], signaling that something of interest has
-occurred on the [=remote end=].
+An <dfn export>event</dfn> is a notification, sent by the [=remote end=] to the
+[=local end=], signaling that something of interest has occurred on the
+[=remote end=].
 
- - An <dfn export for=event>event type</dfn> is defined by a [=local
-   end definition=] fragment containing a group. Each such group has two fields:
+ - An <dfn export for=event>event type</dfn> is defined by a [=local end definition=]
+   fragment containing a group. Each such group has two fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[event name]</code>. This is the <dfn export for=event>event
       name</dfn>.
@@ -508,11 +509,10 @@ Message transport is provided using the WebSocket protocol.
 Note: In the terms of the WebSocket protocol, the [=local end=] is the
 client and the [=remote end=] is the server / remote host.
 
-Note: The encoding of [=commands=] and [=events=] as messages is
-similar to JSON-RPC, but this specification does not normatively
-reference it. [[JSON-RPC]] The normative requirements on [=remote
-ends=] are instead given as a precise processing model, while no
-normative requirements are given for [=local ends=].
+Note: The encoding of [=commands=] and [=events=] as messages is similar to JSON-RPC,
+but this specification does not normatively reference it. [[JSON-RPC]] The normative
+requirements on [=remote ends=] are instead given as a precise processing model,
+while no normative requirements are given for [=local ends=].
 
 A <dfn>WebSocket listener</dfn> is a network endpoint that is able
 to accept incoming [[!RFC6455|WebSocket]] connections.
@@ -543,22 +543,19 @@ initially empty.
 A [=BiDi session=] |session| is <dfn>associated with connection</dfn>
 |connection| if |session|'s [=session WebSocket connections=] contains |connection|.
 
-Note: Each [=WebSocket connection=] is associated with at most one [=BiDi
-session=].
+Note: Each [=WebSocket connection=] is associated with at most one [=BiDi session=].
 
 <div>
 
-When a client [=establishes a WebSocket connection=] |connection| by
-connecting to one of the set of [=active listeners=] |listener|, the
-implementation must proceed according to the WebSocket [=server-side
-requirements=], with the following steps run when deciding whether to
-accept the incoming connection:
+When a client [=establishes a WebSocket connection=] |connection| by connecting to
+one of the set of [=active listeners=] |listener|, the implementation must proceed
+according to the WebSocket [=server-side requirements=], with the following steps run
+when deciding whether to accept the incoming connection:
 
-1. Let |resource name| be the resource name from [=reading the
-   client's opening handshake=]. If |resource name| is not in
-   |listener|'s [=list of WebSocket resources=], then stop
-   running these steps and act as if the requested service is not
-   available.
+1. Let |resource name| be the resource name from
+   [=reading the client's opening handshake=]. If |resource name| is not in
+   |listener|'s [=list of WebSocket resources=], then stop running these steps and
+   act as if the requested service is not available.
 
 1. If |resource name| is the byte string "<code>/session</code>",
    and the implementation [=supports BiDi-only sessions=]:
@@ -567,8 +564,8 @@ accept the incoming connection:
        connection should be accepted, and if it is not stop running these
        steps and act as if the requested service is not available.
 
-    1. Add the connection to the set of [=WebSocket connections not associated
-       with a session=].
+    1. Add the connection to the set of
+       [=WebSocket connections not associated with a session=].
 
     1. Return.
 
@@ -586,23 +583,21 @@ accept the incoming connection:
    connection should be accepted, and if it is not stop running these
    steps and act as if the requested service is not available.
 
-1. Otherwise append |connection| to |session|'s [=session WebSocket
-   connections=], and proceed with the WebSocket [=server-side requirements=]
-   when a server chooses to accept an incoming connection.
+1. Otherwise append |connection| to |session|'s [=session WebSocket connections=],
+   and proceed with the WebSocket [=server-side requirements=] when a server chooses
+   to accept an incoming connection.
 
 Issue: Do we support > 1 connection for a single session?
 
 </div>
 
-When [=a WebSocket message has been received=] for a [=WebSocket
-connection=] |connection| with type |type| and data |data|, a [=remote
-end=] must [=handle an incoming message=] given |connection|, |type|
-and |data|.
+When [=a WebSocket message has been received=] for a [=WebSocket connection=]
+|connection| with type |type| and data |data|, a [=remote end=] must
+[=handle an incoming message=] given |connection|, |type| and |data|.
 
-When [=the WebSocket closing handshake is started=] or when [=the
-WebSocket connection is closed=] for a [=WebSocket connection=]
-|connection|, a [=remote end=] must [=handle a connection closing=]
-given |connection|.
+When [=the WebSocket closing handshake is started=] or when
+[=the WebSocket connection is closed=] for a [=WebSocket connection=] |connection|, a
+[=remote end=] must [=handle a connection closing=] given |connection|.
 
 Note: Both conditions are needed because it is possible for a
 WebSocket connection to be closed without a closing handshake.
@@ -626,8 +621,8 @@ To <dfn lt="construct a WebSocket URL|constructing a WebSocket
 URL">construct a WebSocket URL</dfn> given a [=WebSocket listener=]
 |listener| and [=/session=] |session|:
 
-1. Let |resource name| be the result of [=constructing a WebSocket
-   resource name=] given |session|.
+1. Let |resource name| be the result of [=constructing a WebSocket resource name=]
+   given |session|.
 
 1. Return a [=WebSocket URI=] constructed with host set to
    |listener|'s [=listener/host=], port set to |listener|'s
@@ -666,14 +661,13 @@ To <dfn>start listening for a WebSocket connection</dfn> given a
    [=listener/host=], [=listener/port=], [=listener/secure flag=],
    and an empty [=list of WebSocket resources=].
 
-1. Let |resource name| be the result of [=constructing a WebSocket
-   resource name=] given |session|.
+1. Let |resource name| be the result of [=constructing a WebSocket resource name=]
+   given |session|.
 
 1. Append |resource name| to the [=list of WebSocket resources=] for
    |listener|.
 
-1. [=set/Append=] |listener| to the [=remote end=]'s [=active
-    listeners=].
+1. [=set/Append=] |listener| to the [=remote end=]'s [=active listeners=].
 
 1. Return |listener|.
 
@@ -691,14 +685,12 @@ typically be "<code>localhost</code>".
 To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 |connection|, type |type| and data |data|:
 
-1. If |type| is not [=%x1 denotes a text frame|text=], [=respond with an
-   error=] given |connection|, null, and [=invalid argument=], and finally
-   return.
+1. If |type| is not [=%x1 denotes a text frame|text=], [=respond with an error=]
+   given |connection|, null, and [=invalid argument=], and finally return.
 
 1. [=Assert=]: |data| is a [=scalar value string=], because the
     WebSocket [=handling errors in UTF-8-encoded data=] would already
-    have [=fail the WebSocket connection|failed the WebSocket
-    connection=] otherwise.
+    have [=fail the WebSocket connection|failed the WebSocket connection=] otherwise.
 
    Issue: Nothing seems to define what [=status codes|status code=]
    is used for UTF-8 errors.
@@ -708,10 +700,10 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
    [=WebSocket connections not associated with a session=], let |session| be
    null. Otherwise, return.
 
-1. Let |parsed| be the result of [=parse JSON into Infra values|parsing JSON
-   into Infra values=] given |data|. If this throws an exception, then [=respond
-   with an error=] given |connection|, null, and [=invalid argument=], and
-   finally return.
+1. Let |parsed| be the result of
+   [=parse JSON into Infra values|parsing JSON into Infra values=] given |data|. If
+   this throws an exception, then [=respond with an error=] given |connection|, null,
+   and [=invalid argument=], and finally return.
 
 1. Match |parsed| against the [=remote end definition=]. If this results in a
    match:
@@ -728,8 +720,8 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
     1. Let |command| be the command with [=command name=] |method|.
 
     1. If |session| is null and |command| is not a [=static command=], then
-       [=respond with an error=] given |connection|, |command id|, and [=invalid
-       session id=], and return.
+       [=respond with an error=] given |connection|, |command id|, and
+       [=invalid session id=], and return.
 
     1. Run the following steps in parallel:
 
@@ -757,8 +749,8 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
         field set to |command id| and the <code>value</code> field set to
         |value|.
 
-     1. Let |serialized| be the result of [=serialize an infra value to JSON
-        bytes=] given |response|.
+     1. Let |serialized| be the result of [=serialize an infra value to JSON bytes=]
+        given |response|.
 
      1. [=Send a WebSocket message=] comprised of |serialized| over
         |connection|.
@@ -773,11 +765,10 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
    1. Let |error code| be [=invalid argument=].
 
    1. If |parsed| is a map and |parsed|["<code>method</code>"] exists and is a
-      string, but |parsed|["<code>method</code>"] is not in the [=set of all
-      command names=], set |error code| to [=unknown command=].
+      string, but |parsed|["<code>method</code>"] is not in the
+      [=set of all command names=], set |error code| to [=unknown command=].
 
-   1. [=Respond with an error=] given |connection|, |command id|, and
-      |error code|.
+   1. [=Respond with an error=] given |connection|, |command id|, and |error code|.
 
 </div>
 
@@ -810,8 +801,8 @@ To <dfn>get related browsing contexts</dfn> given an [=script/settings object=]
 
 1. If |connection| is null, return.
 
-1. Let |serialized| be the result of [=serialize an infra value to JSON
-   bytes=] given |body|.
+1. Let |serialized| be the result of [=serialize an infra value to JSON bytes=] given
+   |body|.
 
 1. [=Send a WebSocket message=] comprised of |serialized| over |connection|.
 
@@ -851,8 +842,7 @@ To <dfn>handle a connection closing</dfn> given a [=WebSocket connection=]
   1. Let |session| be the [=BiDi session=] [=associated with connection=]
      |connection|.
 
-  1. Remove |connection| from |session|'s [=session WebSocket
-     connections=].
+  1. Remove |connection| from |session|'s [=session WebSocket connections=].
 
 1. Otherwise, if the set of [=WebSocket connections not associated with a session=]
    contains |connection|, remove |connection| from that set.
@@ -907,11 +897,11 @@ with parameters |session|, |capabilities|, and |flags| is:
 
 1. [=Assert=]: |webSocketUrl| is true.
 
-1. Let |listener| be the result of [=start listening for a WebSocket
-   connection=] given |session|.
+1. Let |listener| be the result of [=start listening for a WebSocket connection=]
+   given |session|.
 
-1. Set |webSocketUrl| to the result of [=constructing a WebSocket
-   URL=] given |listener| and |session|.
+1. Set |webSocketUrl| to the result of [=constructing a WebSocket URL=] given
+   |listener| and |session|.
 
 1. [=Set a property=] on |capabilities| named
    "<code>webSocketUrl</code>" to |webSocketUrl|.
@@ -966,13 +956,13 @@ provides access to platform objects in an existing {{Window}} realm via
 <div algorithm>
 To <dfn>get or create a sandbox realm</dfn> given |name| and |browsing context|:
 
-1. If [=context sandbox map=] does not contain |browsing context|, set [=context
-   sandbox map=][|source browsing context|] to a new map.
+1. If [=context sandbox map=] does not contain |browsing context|, set
+   [=context sandbox map=][|source browsing context|] to a new map.
 
 1. Let |sandboxes| be [=context sandbox map=][|source browsing context|].
 
-1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to [=create
-   a sandbox realm=] with |source browsing context|.
+1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to
+   [=create a sandbox realm=] with |source browsing context|.
 
 1. Return |sandboxes|[|name|].
 
@@ -1901,8 +1891,8 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
      otherwise.
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
-     otherwise let |serialized key| be the result of [=serialize as a remote
-     value=] with arguments |child key|, |child depth|, |node details| and
+     otherwise let |serialized key| be the result of [=serialize as a remote value=]
+     with arguments |child key|, |child depth|, |node details| and
      |set of known objects|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
@@ -1977,16 +1967,17 @@ events are disabled, the return value is always empty.
 
          1. If |global event set| doesn't contain |event name|:
 
-           1. Let |already enabled contexts| be the [=event enabled browsing
-              contexts=] given |session| and |event name|
+           1. Let |already enabled contexts| be the
+              [=event enabled browsing contexts=] given |session| and |event name|
 
            1. Add |event name| to |global event set|.
 
            1. For each |context| of |already enabled contexts|, remove |event
               name| from |event map|[|context|].
 
-           1. Let |newly enabled contexts| be a list of all [=top-level browsing
-              contexts=] that are not contained in |already enabled contexts|,
+           1. Let |newly enabled contexts| be a list of all
+              [=top-level browsing contexts=] that are not contained in
+              |already enabled contexts|,
 
            1. Set |enabled events|[|event name|] to |newly enabled contexts|.
 
@@ -2032,8 +2023,8 @@ events are disabled, the return value is always empty.
       1. If |enabled| is false:
 
         1. If |target| contains |event name|, remove |event name| from
-           |target|. Otherwise return [=error=] with [=error code=] [=invalid
-           argument=].
+           |target|. Otherwise return [=error=] with [=error code=]
+           [=invalid argument=].
 
 1. Set the [=global event set=] for |session| to |global event set|.
 
@@ -2256,8 +2247,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. For each |event name| → |contexts| in |enabled events|:
 
-  1. If the [=event=] with [=event name=] |event name| defines [=remote end
-     subscribe steps=], set |subscribe step events|[|event name|] to |contexts|.
+  1. If the [=event=] with [=event name=] |event name| defines
+     [=remote end subscribe steps=], set |subscribe step events|[|event name|] to
+     |contexts|.
 
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
    than algorithm given two entries with keys |event name one| and |event
@@ -2694,10 +2686,10 @@ The [=remote end steps=] with |command parameters| are:
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->
-  1. Create a new [=top-level browsing context=] by running the [=window open
-     steps=] with <var ignore>url</var> set to "<code>about:blank</code>",
-     <var ignore>target</var> set to the empty string, and
-     <var ignore>features</var> set to "<code>noopener</code>". This must be
+  1. Create a new [=top-level browsing context=] by running the
+     [=window open steps=] with <var ignore>url</var> set to
+     "<code>about:blank</code>", <var ignore>target</var> set to the empty string,
+     and <var ignore>features</var> set to "<code>noopener</code>". This must be
      done without invoking the [=/focusing steps=] for the created browsing
      context. If |type| is "<code>tab</code>", and the implementation supports
      multiple browsing contexts in the same OS window, the new browsing context
@@ -2843,8 +2835,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |url record| be the result of applying the [=URL parser=] to |url|,
    with [=base URL=] |base|.
 
-1. If |url record| is failure, return [=error=] with [=error code=] [=invalid
-   argument=].
+1. If |url record| is failure, return [=error=] with [=error code=]
+   [=invalid argument=].
 
 1. Let |request| be a new [=/request=] whose URL is |url record|.
 
@@ -3007,8 +2999,9 @@ Define the following [=browsing context tree discarded=] steps:
     <code>BrowsingContextDestroyedEvent</code> production, with the
     <code>params</code> field set to |params|.
 
-1. Let |related browsing contexts| be a set containing the [=parent browsing
-   context=] of |context|, if that is not null, or an empty set otherwise.
+1. Let |related browsing contexts| be a set containing the
+   [=parent browsing context=] of |context|, if that is not null, or an empty set
+   otherwise.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related browsing
@@ -3620,9 +3613,9 @@ To <dfn>construct a stack trace</dfn>, with a list of stack frames |stack|:
    1. Let |frame info| be a new map matching the <code>StackFrame</code>
       production, with the <code>url</code> field set to |url|, the
       <code>functionName</code> field set to |frame|'s [=stackframe/function=],
-      the <code>lineNumber</code> field set to |frame|'s [=stackframe/line
-      number=] and the <code>columnNumber</code> field set to |frame|'s
-      [=stackframe/column number=].
+      the <code>lineNumber</code> field set to |frame|'s
+      [=stackframe/line number=] and the <code>columnNumber</code> field set to
+      |frame|'s [=stackframe/column number=].
 
 1. Append |frame info| to |call frames|.
 
@@ -3634,13 +3627,13 @@ To <dfn>construct a stack trace</dfn>, with a list of stack frames |stack|:
 </div>
 
 The <dfn>current stack trace</dfn> is the result of [=construct a stack trace=]
-given a [=list of stack frames=] representing the callstack of the [=running
-execution context=].
+given a [=list of stack frames=] representing the callstack of the
+[=running execution context=].
 
 <div algorithm>
 
-The <dfn>stack trace for an exception</dfn> with an exception, or a [=Completion
-Record=] of type <code>throw</code>, |exception|, is given by:
+The <dfn>stack trace for an exception</dfn> with an exception, or a
+[=Completion Record=] of type <code>throw</code>, |exception|, is given by:
 
 1. If |exception| is a value that has been thrown as an exception, let |record|
    be the [=Completion Record=] created to throw |exception|. Otherwise let
@@ -4094,21 +4087,20 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for script.realmCreated">
 
-When any of the [=set up a window environment settings object=], [=set up a
-worker environment settings object=] or [=set up a worklet environment settings
-object=] algorithms are invoked, immediately prior to returning the settings
-object:
+When any of the [=set up a window environment settings object=],
+[=set up a worker environment settings object=] or
+[=set up a worklet environment settings object=] algorithms are invoked, immediately
+prior to returning the settings object:
 
-1. Let |environment settings| be the newly created [=environment settings
-   object=].
+1. Let |environment settings| be the newly created [=environment settings object=].
 
 1. Let |realm info| be be the result of [=get the realm info=] given
    |environment settings|.
 
 1. If |realm info| is null, return.
 
-1. Let |related browsing contexts| be the result of [=get related browsing
-   contexts=] given |environment settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
+   given |environment settings|.
 
 1. Let |body| be a map matching the <code>RealmCreatedEvent</code>
    production, with the <code>params</code> field set to |realm info|.
@@ -4220,14 +4212,14 @@ Define the following [=unloading document cleanup steps=] with |document|:
   1. [=Emit an event=] with |session| and |body|.
 
 Whenever a [=worker event loop=] |event loop| is destroyed, either because the
-worker comes to the end of its lifecycle, or prematurely via the [=terminate a
-worker=] algorithm:
+worker comes to the end of its lifecycle, or prematurely via the
+[=terminate a worker=] algorithm:
 
 1. Let |environment settings| be the [=environment settings object=] for which
    |event loop| is the [=responsible event loop=].
 
-1. Let |related browsing contexts| be the result of [=get related browsing
-   contexts=] given |environment settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
+   given |environment settings|.
 
 1. Let |realm| be |environment settings|'s [=environment settings object's Realm=].
 
@@ -4384,9 +4376,9 @@ ignore>options</var>:
 
 1. Let |text| be an empty string.
 
-1. If [=Type=](||args|[0]) is String, and |args|[0] contains a [=formatting
-   specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise let
-   |formatted args| be |args|.
+1. If [=Type=](||args|[0]) is String, and |args|[0] contains a
+   [=formatting specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise
+   let |formatted args| be |args|.
 
    Issue: This is underdefined in the console spec, so it's unclar if we can get
    interoperable behaviour here.
@@ -4400,14 +4392,14 @@ ignore>options</var>:
 
 1. Let |serialized args| be a new list.
 
-1. For each |arg| of |args|, append the result of [=serialize as a remote
-   value=] given |arg|, null, true, and an empty [=set=] to |serialized args|.
+1. For each |arg| of |args|, append the result of [=serialize as a remote value=]
+   given |arg|, null, true, and an empty [=set=] to |serialized args|.
 
 1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
 
 1. If |method| is "<code>assert</code>", "<code>error</code>",
-   "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
-   stack trace=]. Otherwise let |stack| be null.
+   "<code>trace</code>", or "<code>warn</code>", let |stack| be the
+   [=current stack trace=]. Otherwise let |stack| be null.
 
 1. Let |entry| be a map matching the <code>ConsoleLogEntry</code> production,
    with the the <code>level</code> field set to |level|, the <code>text</code>
@@ -4422,8 +4414,8 @@ ignore>options</var>:
 
 1. Let |settings| be the [=current settings object=]
 
-1. Let |related browsing contexts| be the result of [=get related browsing
-   contexts=] given |settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
+   given |settings|.
 
 1. For each |session| in [=active BiDi sessions=]:
 
@@ -4448,8 +4440,8 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
    with <code>level</code> set to "<code>error</code>", <code>text</code> set to
    |message|, and the <code>timestamp</code> field set to |timestamp|.
 
-1. Let |related browsing contexts| be the result of [=get related browsing
-   contexts=] given |settings|.
+1. Let |related browsing contexts| be the result of [=get related browsing contexts=]
+   given |settings|.
 
 1. For each |session| in [=active BiDi sessions=]:
 
@@ -4478,8 +4470,8 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 10, given
   1. Let |maybe context| be the result of [=getting a browsing context=] given
      |context id|.
 
-  1. If |maybe context| is an [=error=], remove |context id| from [=log event
-     buffer=] and continue.
+  1. If |maybe context| is an [=error=], remove |context id| from
+     [=log event buffer=] and continue.
 
   1. Let |context| be |maybe context|'s data
 
@@ -4515,8 +4507,8 @@ To discard a browsing context |browsingContext|, run these steps:
 1. If this is not a recursive invocation of this algorithm, call any <dfn export>browsing context
    tree discarded</dfn> steps defined in other applicable specifications with |browsingContext|.
 
-1. Discard all {{Document}} objects for all the entries in |browsingContext|'s [=session
-   history=].
+1. Discard all {{Document}} objects for all the entries in |browsingContext|'s
+   [=session history=].
 
 1. If |browsingContext| is a [=top-level browsing context=], then [=remove a browsing context=]
    |browsingContext|.
@@ -4544,9 +4536,8 @@ Other specifications can define <dfn>console steps</dfn>. When any method of the
 {{console}} interface is called, with method name
 |method| and argument |args|:
 
-1. If that method does not call the [=Printer=] operation, call any [=console
-   steps=] defined in external specification with arguments |method|, |args|
-   and, undefined.
+1. If that method does not call the [=Printer=] operation, call any [=console steps=]
+   defined in external specification with arguments |method|, |args| and undefined.
 
    Otherwise, at the point when the [=Printer=] operation is called with
    arguments |name|, |printerArgs| and |options| (which is undefined if the

--- a/index.bs
+++ b/index.bs
@@ -1424,7 +1424,7 @@ handles. The object will not be disposed until all the handles are disowned.
 For some non-primitive types, the <code>value</code> property contains a
 representation of the data in the ECMAScript object; for container types this can
 contain further <code>RemoteValue</code> instances. The <code>value</code> property
-can be null or emitted if there is a duplicate object i.e. the object has already
+can be null or omitted if there is a duplicate object i.e. the object has already
 been serialized in the current <code>RemoteValue</code>, perhaps as part of a cycle,
 or otherwise when the maximum serialization depth is reached.
 In case of duplicated objects in the same <code>RemoteValue</code>, the value is

--- a/index.bs
+++ b/index.bs
@@ -1458,16 +1458,15 @@ To <dfn>set internal ids if needed</dfn> given |object remote value map|,
     1. Let |previously serialized remote value| be the value of |object| in
        |object remote value map|.
 
-    1. If |previously serialized remote value| has a field <code>internalId</code>,
-       let |internal id| be a value of a field <code>internalId</code> in
+    1. If |previously serialized remote value| does not have a field
+       <code>internalId</code>, set the <code>internalId</code> field of
+       |previously serialized remote value| to a new, unique, string identifier for
+       |object|.
+
+    1. Let |internal id| be a value of a field <code>internalId</code> in
        |previously serialized remote value|.
 
-    1. Otherwise let |internal id| be a new, unique, string identifier for |object|.
-
     1. Set the <code>internalId</code> field of |remote value| to |internal id|.
-
-    1. Set the <code>internalId</code> field of |previously serialized remote value|
-       to |internal id|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1462,6 +1462,7 @@ To <dfn>handle internal ids</dfn> given |object remote value map|, |remote value
 
     1. Set the <code>internalId</code> field of |previously serialized remote value|
        to |internal id|.
+
 </div>
 
 [=remote end definition=] and [=local end definition=]
@@ -1886,7 +1887,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
   </dl>
 
 1. [=Handle internal ids=] given |object remote value map|, |remote value| and
-|value|.
+   |value|.
 
 1. Return |remote value|
 
@@ -3800,6 +3801,43 @@ ownership should be treated.
 
 
 ### Commands ### {#module-script-commands}
+
+#### The script.disown Command ####  {#command-script-disown}
+
+The <dfn export for=commands>script.disown</dfn> command disowns the given handles.
+This does not guarantee the handled object will be disposed, as there can be other
+handles or strong ECMAScript references.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      ScriptDisownCommand = {
+        method: "script.disown",
+        params: DisownParameters
+      }
+
+      GetRealmsParameters = {
+        handles: [Handle]
+        target: Target;
+      }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for script.disown">
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
+   given the value of the <code>target</code> field of |command parameters|.
+
+1. Let |handles| the value of the <code>handles</code> field of |command parameters|.
+
+1. For each |handle| of |handles|:
+   1. If |realm|'s [=handle map=] contains |handle|, remove |handle| from the
+      |realm|'s [=handle map=].
+
+</div>
 
 #### The script.callFunction Command ####  {#command-script-callFunction}
 

--- a/index.bs
+++ b/index.bs
@@ -1009,8 +1009,8 @@ Issue: Define how this works.
 
 ## Reference ## {#data-types-reference}
 
-Each EMCAScript [=Realm=] has a corresponding <dfn>handle map</dfn>. This is a strong map
-from handle ids to their corresponding objects.
+Each EMCAScript [=Realm=] has a corresponding <dfn>handle map</dfn>. This is a strong
+map from handle ids to their corresponding objects.
 
 <dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
 [=handle map=] in the given [=Realm=].
@@ -1407,15 +1407,21 @@ object, specified as <code>RemoteValue</code>. The value's type is specified in
 the <code>type</code> property. In the case of JSON-representable primitive
 values, this contains the value in the <code>value</code> property; in the case
 of non-JSON-representable primitives, the <code>value</code> property contains a
-string representation of the value. For non-primitive objects, the
-<code>handle</code> property contains a string id that provides a unique
-handle to the object, valid for realm's lifetime. For some
-non-primitive types, the <code>value</code> property contains a representation
-of the data in the ECMAScript object; for container types this can contain
-further <code>RemoteValue</code> instances. The <code>value</code> property can
-be null if there is a duplicate object i.e. the object has already been
-serialized in the current <code>RemoteValue</code>, perhaps as part of a
-cycle, or otherwise when the maximum serialization depth is reached.
+string representation of the value.
+For non-primitive objects, the <code>handle</code> property contains a string id that
+provides a unique handle to the object, valid for realm's lifetime, unless the handle
+is disowned by the <code>script.disown</code> command. The handles are unique,
+meaning serialization of the same ECMAScript object twice will have 2 different
+handles. The object will not be disposed until all the handles are disowned.
+For some non-primitive types, the <code>value</code> property contains a
+representation of the data in the ECMAScript object; for container types this can
+contain further <code>RemoteValue</code> instances. The <code>value</code> property
+can be null if there is a duplicate object i.e. the object has already been
+serialized in the current <code>RemoteValue</code>, perhaps as part of a cycle, or
+otherwise when the maximum serialization depth is reached.
+In case of duplicated objects in the same <code>RemoteValue</code>, the value is
+provided only for one of the remote values, while the unique-per-ECMAScript-object
+<code>internalId</code> is provided for all the duplicated objects.
 
 [=Nodes=] are also represented by <code>RemoteValue</code> instances. These have
 a partial serialization of the node in the value property.

--- a/index.bs
+++ b/index.bs
@@ -1010,7 +1010,7 @@ Issue: Define how this works.
 ## Reference ## {#data-types-reference}
 
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle map</dfn>. This is a strong map
-from objects to their corresponding handle id.
+from handle ids to their corresponding objects.
 
 <dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
 [=handle map=] in the given [=Realm=].
@@ -1031,7 +1031,7 @@ To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
 1. Let |handle| be the value of the <code>handle</code> field of |remote reference|.
 
-1. For each |object| → |handle value| of the given |realm|'s [=handle map=]:
+1. For each |handle value| → |object| of the given |realm|'s [=handle map=]:
 
   1. If |handle value| is equal to |handle|, return [=success=] with data
      |object|
@@ -1432,16 +1432,11 @@ and |object|:
 
 1. If |ownership| is equal <code>none</code>, return <code>null</code>.
 
-1. If the given |realm|'s [=handle map=] does not contain |object|, run the
-   following steps:
+1. Let |handle| be a new, unique, string handle for |object|.
 
-  1. Let |handle| be a new, unique, string identifier for |object|. If |object| is an
-     [=/element=] this must be the [=web element reference=] for |object|; if it's a {{WindowProxy}}
-     object, this must be the [=browsing context id=] for |object|.
+1. Set the value of |handle| in |realm|'s [=handle map=] to |object|.
 
-  1. Set the value of |object| in |realm|'s [=handle map=] to |handle|.
-
-1. Return the result of getting the value for |object| in |realm|'s [=handle map=].
+1. Return |handle| as a result.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -217,8 +217,8 @@ The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
 convenience of implementors two seperate CDDL definitions are defined; the
 <dfn>remote end definition</dfn> which defines the format of messages produced
 on the [=local end=] and consumed on the [=remote end=], and the <dfn>local end
-definition</dfn> which defines the format of messages produced on the [=remote end=]
-and consumed on the [=local end=]
+definition</dfn> which defines the format of messages produced on the [=remote
+end=] and consumed on the [=local end=]
 
 ## Definition ## {#protocol-definition}
 
@@ -1510,6 +1510,7 @@ MappingRemoteValue = [*[(RemoteValue / text), RemoteValue]];
 SymbolRemoteValue = {
   type: "symbol",
   ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 ArrayRemoteValue = {

--- a/index.bs
+++ b/index.bs
@@ -1479,7 +1479,7 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
        <code>internalId</code>, run the following steps:
 
       1. Let |internal id| be a unique across the <code>internalId</code> fields of
-         the values of |serialization internal map| number.
+         the values of |serialization internal map| integer.
 
        1. Set the <code>internalId</code> field of
           |previously serialized remote value| to |internal id|.
@@ -1514,7 +1514,7 @@ RemoteValue = {
   WindowProxyRemoteValue //
 }
 
-InternalId = Number;
+InternalId = integer;
 
 ListRemoteValue = [*RemoteValue];
 

--- a/index.bs
+++ b/index.bs
@@ -1009,11 +1009,11 @@ Issue: Define how this works.
 
 ## Reference ## {#data-types-reference}
 
-Each EMCAScript [=Realm=] has a corresponding <dfn>handle map</dfn>. This is a strong
-map from handle ids to their corresponding objects.
+Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
+strong map from handle ids to their corresponding objects.
 
-<dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
-[=handle map=] in the given [=Realm=].
+<dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript
+object in [=handle object map=] in the given [=Realm=].
 
 ```
 Handle = text;
@@ -1031,12 +1031,10 @@ To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
 1. Let |handle| be the value of the <code>handle</code> field of |remote reference|.
 
-1. For each |handle value| → |object| of the given |realm|'s [=handle map=]:
+1. If the given |realm|'s [=handle object map=] does not contain |handle value|,
+   return [=error=] with [=error code=] [=invalid argument=].
 
-  1. If |handle value| is equal to |handle|, return [=success=] with data
-     |object|
-
-1. Return [=error=] with [=error code=] [=invalid argument=].
+1. Return the |handle| value of the given |realm|'s [=handle object map=].
 
 </div>
 
@@ -1440,7 +1438,7 @@ and |object|:
 
 1. Let |handle| be a new, unique, string handle for |object|.
 
-1. Set the value of |handle| in |realm|'s [=handle map=] to |object|.
+1. Set the value of |handle| in |realm|'s [=handle object map=] to |object|.
 
 1. Return |handle| as a result.
 
@@ -3837,8 +3835,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |handles| the value of the <code>handles</code> field of |command parameters|.
 
 1. For each |handle| of |handles|:
-   1. If |realm|'s [=handle map=] contains |handle|, remove |handle| from the
-      |realm|'s [=handle map=].
+   1. If |realm|'s [=handle object map=] contains |handle|, remove |handle| from the
+      |realm|'s [=handle object map=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1440,6 +1440,30 @@ and |object|:
 
 </div>
 
+<div algorithm>
+To <dfn>handle internal ids</dfn> given |object remote value map|, |remote value| and
+|object|:
+
+1. If the |object remote value map| does not contain |object|, set the value of
+   |object| in |object remote value map| to |remote value|.
+
+1. Otherwise, run the following steps:
+
+    1. Let |previously serialized remote value| be the value of |object| in
+       |object remote value map|.
+
+    1. If |previously serialized remote value| has a field <code>internalId</code>,
+       let |internal id| be a value of a field <code>internalId</code> in
+       |previously serialized remote value|.
+
+    1. Otherwise let |internal id| be a new, unique, string identifier for |object|.
+
+    1. Set the <code>internalId</code> field of |remote value| to |internal id|.
+
+    1. Set the <code>internalId</code> field of |previously serialized remote value|
+       to |internal id|.
+</div>
+
 [=remote end definition=] and [=local end definition=]
 ```
 RemoteValue = {
@@ -1465,102 +1489,121 @@ RemoteValue = {
   WindowProxyRemoteValue //
 }
 
+InternalId = String;
+
 ListRemoteValue = [*RemoteValue];
 
 MappingRemoteValue = [*[(RemoteValue / text), RemoteValue]];
 
 SymbolRemoteValue = {
-   type: "symbol",
-   ?handle: Handle,
+  type: "symbol",
+  ?handle: Handle,
 }
 
 ArrayRemoteValue = {
   type: "array",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
   ?value: ListRemoteValue,
 }
 
 ObjectRemoteValue = {
   type: "object",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
   ?value: MappingRemoteValue,
 }
 
 FunctionRemoteValue = {
-   type: "function",
-   ?handle: Handle,
+  type: "function",
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 RegExpRemoteValue = {
-   RegExpLocalValue,
-   ?handle: Handle,
+  RegExpLocalValue,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 DateRemoteValue = {
   DateLocalValue,
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 MapRemoteValue = {
   type: "map",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
   value: MappingRemoteValue,
 }
 
 SetRemoteValue = {
   type: "set",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
   value: ListRemoteValue
 }
 
 WeakMapRemoteValue = {
   type: "weakmap",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 WeakSetRemoteValue = {
   type: "weakset",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 IteratorRemoteValue = {
   type: "iterator",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 GeneratorRemoteValue = {
   type: "generator",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 ErrorRemoteValue = {
   type: "error",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 ProxyRemoteValue = {
   type: "proxy",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 PromiseRemoteValue = {
   type: "promise",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 TypedArrayRemoteValue = {
   type: "typedarray",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 ArrayBufferRemoteValue = {
   type: "arraybuffer",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 
 NodeRemoteValue = {
   type: "node",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
   ?value: NodeProperties,
 }
 
@@ -1577,7 +1620,8 @@ NodeProperties = {
 
 WindowProxyRemoteValue = {
   type: "window",
-   ?handle: Handle,
+  ?handle: Handle,
+  ?internalId: InternalId,
 }
 ```
 
@@ -1591,9 +1635,6 @@ Issue: Describe `GeneratorRemoteValue` serialization.
 
 Issue: Describe `ProxyRemoteValue` serialization.
 
-Issue: Handle internal cycles by providing `internalId`s.
-See https://github.com/w3c/webdriver-bidi/issues/90
-
 Issue: handle String / Number / etc. wrapper objects specially?
 
 #### Serialization #### {#data-types-protocolValue-RemoteValue-serialization}
@@ -1601,7 +1642,8 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-a |node details|, an |ownership|, a |set of known objects| and a |realm|:
+a |node details|, an |ownership|, a |set of known objects|, an
+|internal object remote value map| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1632,7 +1674,7 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
-              |child ownership|, |set of known objects| and |realm|.
+              |set of known objects|, |internal object remote value map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
        production in the [=local end definition=], with the <code>handle</code>
@@ -1674,7 +1716,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
            1. Let |serialized| be the result of [=serialize as a mapping=] given
               [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
-              |child ownership|, |set of known objects| and |realm|.
+              |child ownership|, |set of known objects|,
+              |internal object remote value map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
@@ -1692,7 +1735,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
-              |child ownership|, |set of known objects| and |realm|.
+              |child ownership|, |set of known objects|,
+              |internal object remote value map| and |realm|.
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
@@ -1760,7 +1804,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
                with |child|, |child depth|, |node details|, |child ownership|,
-               |set of known objects| and |realm|.
+               |set of known objects|, |internal object remote value map| and
+               |realm|.
 
             1. Append |serialized| to |children|.
 
@@ -1790,7 +1835,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
-                  false, |child ownership|, |set of known objects| and |realm|.
+                  false, |child ownership|, |set of known objects|,
+                  |internal object remote value map| and |realm|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1830,14 +1876,17 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |node details|, |child ownership|, |set of known objects| and
-          |realm|.
+          |node details|, |child ownership|, |set of known objects|,
+          |internal object remote value map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>handle</code> property set
        to |handle| if it's not null, or omitted otherwise, and the
        <code>value</code> field set to |serialized|.
   </dl>
+
+1. [=Handle internal ids=] given |object remote value map|, |remote value| and
+|value|.
 
 1. Return |remote value|
 
@@ -1859,7 +1908,8 @@ remove optional flag from the field.
 
 <div algorithm>
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
-|node details|, |child ownership|, |set of known objects| and |realm|:
+|node details|, |child ownership|, |set of known objects|,
+|internal object remote value map| and |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1870,7 +1920,8 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
        with arguments |child value|, |child depth|, |node details|,
-       |child ownership|, |set of known objects| and |realm|.
+       |child ownership|, |set of known objects|, |internal object remote value map|
+       and |realm|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -1881,7 +1932,8 @@ Issue: this assumes for-in works on iterators
 
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
-|node details|, |child ownership|, |set of known objects| and |realm|:
+|node details|, |child ownership|, |set of known objects|,
+|internal object remote value map| and |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -1901,11 +1953,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
      with arguments |child key|, |child depth|, |node details|,
-     |set of known objects| and |realm|.
+     |set of known objects|, |internal object remote value map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
      with arguments |value|, |child depth|, |node details|, |child ownership|,
-     |set of known objects| and |realm|.
+     |set of known objects|, |internal object remote value map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
@@ -3363,7 +3415,8 @@ To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] 
 1. Let |exception| be the result of [=serialize as a remote value=] given
    |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
    |node details|, <code>root</code> as |ownership|, <code>new set</code>
-   as |set of known objects| and |realm|.
+   as |set of known objects|, <code>new map</code> as
+   |internal object remote value map| and |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -3903,7 +3956,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code>
    as |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects| and |realm|.
+   |set of known objects|, <code>new map</code> as |internal object remote value map|
+   and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -3999,7 +4053,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
    |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects| and |realm|.
+   |set of known objects|, <code>new map</code> as |internal object remote value map|
+    and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and

--- a/index.bs
+++ b/index.bs
@@ -3439,7 +3439,8 @@ The <code>ExceptionDetails</code> type represents a JavaScript exception.
 
 <div algorithm>
 
-To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] |record|:
+To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
+|record| and an |ownership type|:
 
 1. Assert: |record|.\[[Type]] is <code>throw</code>.
 
@@ -3450,9 +3451,8 @@ To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] 
    this data with regex or something equally bad.
 
 1. Let |exception| be the result of [=serialize as a remote value=] given
-   |record|.\[[Value]], <code>1</code> as |max depth|, <code>root</code> as
-   |ownership type|, <code>new map</code> as |serialization internal map| and
-   |realm|.
+   |record|.\[[Value]], <code>1</code> as |max depth|, |ownership type|,
+   <code>new map</code> as |serialization internal map| and |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -4024,7 +4024,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |realm| and |evaluation status|.
+     |realm|, |evaluation status| and |result ownership| as |ownership type|.
 
   1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>exceptionDetails</code> field set to
@@ -4121,7 +4121,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |evaluation status|.\[[Type]] is <code>throw</code>:
 
   1. Let |exception details| be the result of [=get exception details=] given
-     |realm| and |evaluation status|.
+     |realm|, |evaluation status| and |result ownership| as |ownership type|.
 
   1. Return a new map matching the <code>ScriptResultException</code>
      production, with the <code>realm</code> field set to |realm id|, and the

--- a/index.bs
+++ b/index.bs
@@ -4548,12 +4548,17 @@ ignore>options</var>:
   1. If |arg| is a [=primitive ECMAScript value=], append [=ToString=](|arg|) to
      |text|. Otherwise append an implementation-defined string to |text|.
 
+1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
+
 1. Let |serialized args| be a new list.
 
-1. For each |arg| of |args|, append the result of [=serialize as a remote
-   value=] given |arg|, null, true, and an empty [=set=] to |serialized args|.
+1. For each |arg| of |args|:
+   1. Let |serialized arg| be the result of [=serialize as a remote value=] given
+      |arg| as |value|, <code>1</code> as |max depth|, <code>none</code> as
+      |ownership type|, <code>new map</code> as |serialization internal map| and
+      |realm|.
 
-1. Let |realm| be the [=realm id=] of the [=current Realm Record=].
+   1. Add |serialized arg| to |serialized args|.
 
 1. If |method| is "<code>assert</code>", "<code>error</code>",
    "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current

--- a/index.bs
+++ b/index.bs
@@ -1447,8 +1447,8 @@ and |object|:
 </div>
 
 <div algorithm>
-To <dfn>handle internal ids</dfn> given |object remote value map|, |remote value| and
-|object|:
+To <dfn>set internal ids if needed</dfn> given |object remote value map|,
+|remote value| and |object|:
 
 1. If the |object remote value map| does not contain |object|, set the value of
    |object| in |object remote value map| to |remote value|.
@@ -1892,7 +1892,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
        <code>value</code> field set to |serialized|.
   </dl>
 
-1. [=Handle internal ids=] given |object remote value map|, |remote value| and
+1. [=Set internal ids if needed=] given |object remote value map|, |remote value| and
    |value|.
 
 1. Return |remote value|

--- a/index.bs
+++ b/index.bs
@@ -1041,10 +1041,12 @@ To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
 1. Let |handle id| be the value of the <code>handle</code> field of |remote reference|.
 
-1. If the given |realm|'s [=handle object map=] does not contain |handle value|,
-   return [=error=] with [=error code=] [=invalid argument=].
+1. Let |handle map| be |realm|'s [=handle object map=]
 
-1. Return the |handle id| value of the given |realm|'s [=handle object map=].
+1. If |handle map| does not contain |handle value|, then return [=error=] with
+   [=error code=] [=invalid argument=].
+
+1. Return |handle map|[|handle id|].
 
 </div>
 
@@ -1416,11 +1418,11 @@ the <code>type</code> property. In the case of JSON-representable primitive
 values, this contains the value in the <code>value</code> property; in the case
 of non-JSON-representable primitives, the <code>value</code> property contains a
 string representation of the value.
-For non-primitive objects, the <code>handle</code> property contains a string id that
-provides a unique handle to the object, valid for realm's lifetime, unless the handle
-is disowned by the <code>script.disown</code> command. The handles are unique,
-meaning serialization of the same ECMAScript object twice will have 2 different
-handles. The object will not be disposed until all the handles are disowned.
+For non-primitive objects, the <code>handle</code> property, when present, contains a
+unique string handle to the object. The handle is unique for each serialization. The
+remote end will keep objects with a corresponding handle alive until such a time that
+<code>script.disown</code> is called with that handle, or the realm itself is to be
+discarded (e.g. due to navigation).
 For some non-primitive types, the <code>value</code> property contains a
 representation of the data in the ECMAScript object; for container types this can
 contain further <code>RemoteValue</code> instances. The <code>value</code> property
@@ -1429,7 +1431,8 @@ been serialized in the current <code>RemoteValue</code>, perhaps as part of a cy
 or otherwise when the maximum serialization depth is reached.
 In case of duplicated objects in the same <code>RemoteValue</code>, the value is
 provided only for one of the remote values, while the unique-per-ECMAScript-object
-<code>internalId</code> is provided for all the duplicated objects.
+<code>internalId</code> is provided for all the duplicated objects for a given
+serialization.
 
 [=Nodes=] are also represented by <code>RemoteValue</code> instances. These have
 a partial serialization of the node in the value property.
@@ -1448,23 +1451,25 @@ and |object|:
 
 1. Let |handle id| be a new, unique, string handle for |object|.
 
-1. Set the value of |handle id| in |realm|'s [=handle object map=] to |object|.
+1. Let |handle map| be |realm|'s [=handle object map=]
+
+1. Set |handle map|[|handle id|] to |object|.
 
 1. Return |handle id| as a result.
 
 </div>
 
 <div algorithm>
-To <dfn>set internal ids if needed</dfn> given |object remote value map|,
+To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
 |remote value| and |object|:
 
-1. If the |object remote value map| does not contain |object|, set the value of
-   |object| in |object remote value map| to |remote value|.
+1. If the |serialization internal map| does not contain |object|, set
+   |serialization internal map|[|object|] to |remote value|.
 
 1. Otherwise, run the following steps:
 
-    1. Let |previously serialized remote value| be the value of |object| in
-       |object remote value map|.
+    1. Let |previously serialized remote value| be
+       |serialization internal map|[|object|].
 
     1. If |previously serialized remote value| does not have a field
        <code>internalId</code>, set the <code>internalId</code> field of
@@ -1655,8 +1660,8 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-a |node details|, an |ownership|, a |set of known objects|, an
-|internal object remote value map| and a |realm|:
+a |node details|, an |ownership|, a |set of known objects|, a
+|serialization internal map| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1687,7 +1692,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
-              |set of known objects|, |internal object remote value map| and |realm|.
+              |set of known objects|, |serialization internal map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
        production in the [=local end definition=], with the <code>handle</code>
@@ -1729,8 +1734,8 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
            1. Let |serialized| be the result of [=serialize as a mapping=] given
               [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
-              |child ownership|, |set of known objects|,
-              |internal object remote value map| and |realm|.
+              |child ownership|, |set of known objects|, |serialization internal map|
+              and |realm|.
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
@@ -1748,8 +1753,8 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
-              |child ownership|, |set of known objects|,
-              |internal object remote value map| and |realm|.
+              |child ownership|, |set of known objects|, |serialization internal map|
+              and |realm|.
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
@@ -1817,8 +1822,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
                with |child|, |child depth|, |node details|, |child ownership|,
-               |set of known objects|, |internal object remote value map| and
-               |realm|.
+               |set of known objects|, |serialization internal map| and |realm|.
 
             1. Append |serialized| to |children|.
 
@@ -1849,7 +1853,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
                   false, |child ownership|, |set of known objects|,
-                  |internal object remote value map| and |realm|.
+                  |serialization internal map| and |realm|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1890,7 +1894,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
           |node details|, |child ownership|, |set of known objects|,
-          |internal object remote value map| and |realm|.
+          |serialization internal map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>handle</code> property set
@@ -1898,7 +1902,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
        <code>value</code> field set to |serialized|.
   </dl>
 
-1. [=Set internal ids if needed=] given |object remote value map|, |remote value| and
+1. [=Set internal ids if needed=] given |serialization internal map|, |remote value| and
    |value|.
 
 1. Return |remote value|
@@ -1922,7 +1926,7 @@ remove optional flag from the field.
 <div algorithm>
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 |node details|, |child ownership|, |set of known objects|,
-|internal object remote value map| and |realm|:
+|serialization internal map| and |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1933,7 +1937,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
        with arguments |child value|, |child depth|, |node details|,
-       |child ownership|, |set of known objects|, |internal object remote value map|
+       |child ownership|, |set of known objects|, |serialization internal map|
        and |realm|.
 
     1. Append |serialized child| to |serialized|.
@@ -1946,7 +1950,7 @@ Issue: this assumes for-in works on iterators
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 |node details|, |child ownership|, |set of known objects|,
-|internal object remote value map| and |realm|:
+|serialization internal map| and |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -1966,11 +1970,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
      with arguments |child key|, |child depth|, |node details|,
-     |set of known objects|, |internal object remote value map| and |realm|.
+     |set of known objects|, |serialization internal map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
      with arguments |value|, |child depth|, |node details|, |child ownership|,
-     |set of known objects|, |internal object remote value map| and |realm|.
+     |set of known objects|, |serialization internal map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
@@ -3428,7 +3432,7 @@ To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] 
    |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
    |node details|, <code>root</code> as |ownership|, <code>new set</code>
    as |set of known objects|, <code>new map</code> as
-   |internal object remote value map| and |realm|.
+   |serialization internal map| and |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -3816,8 +3820,8 @@ ownership should be treated.
 #### The script.disown Command ####  {#command-script-disown}
 
 The <dfn export for=commands>script.disown</dfn> command disowns the given handles.
-This does not guarantee the handled object will be disposed, as there can be other
-handles or strong ECMAScript references.
+This does not guarantee the handled object will be garbage collected, as there can be
+other handles or strong ECMAScript references.
 
 <dl>
    <dt>Command Type</dt>
@@ -3845,8 +3849,10 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |handles| the value of the <code>handles</code> field of |command parameters|.
 
 1. For each |handle id| of |handles|:
-   1. If |realm|'s [=handle object map=] contains |handle id|, remove |handle id|
-      from the |realm|'s [=handle object map=].
+
+   1. Let |handle map| be |realm|'s [=handle object map=]
+
+   1. If |handle map| contains |handle id|, remove |handle id| from the |handle map|.
 
 </div>
 
@@ -4005,7 +4011,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code>
    as |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects|, <code>new map</code> as |internal object remote value map|
+   |set of known objects|, <code>new map</code> as |serialization internal map|
    and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
@@ -4102,7 +4108,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
    |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects|, <code>new map</code> as |internal object remote value map|
+   |set of known objects|, <code>new map</code> as |serialization internal map|
     and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>

--- a/index.bs
+++ b/index.bs
@@ -1022,6 +1022,10 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong map from handle ids to their corresponding objects.
 
+```
+OwnershipModel = "root" / "none";
+```
+
 <dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript
 object in [=handle object map=] in the given [=Realm=].
 
@@ -1444,10 +1448,10 @@ object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
 <div algorithm>
-To get the <dfn>handle for an object</dfn> given |realm|, |ownership|
-and |object|:
+To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
+|object|:
 
-1. If |ownership| is equal <code>none</code>, return <code>null</code>.
+1. If |ownership type| is equal "<code>none</code>", return <code>null</code>.
 
 1. Let |handle id| be a new, unique, string handle for |object|.
 
@@ -1660,7 +1664,7 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
+an |ownership type|, a |serialization internal map| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1670,13 +1674,13 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
-1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership|
+1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership type|
    and |value|.
 
 1. Let |known object| be <code>true</code>, if |value| is in the
    |serialization internal map|, otherwise <code>false</code>.
 
-1. Let |child ownership| be <code>none</code>.
+1. Let |child ownership| be "<code>none</code>".
 
   <dl>
     <dt>[=Type=](|value|) is Symbol
@@ -1700,7 +1704,7 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
        greater than 0, run the following steps:
 
            1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
+              [=CreateArrayIterator=](|value|, value), |max depth|,
               |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -1747,7 +1751,7 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
          greater than 0, run the following steps:
 
            1. Let |serialized| be the result of [=serialize as a mapping=] given
-              [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
+              [=CreateMapIterator=](|value|, key+value), |max depth|,
               |child ownership|, |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -1768,8 +1772,8 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
       1. If |known object| is <code>false</code>, and |max depth| is not null and
          greater than 0, run the following steps:
            1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
-              |child ownership|, |serialization internal map| and |realm|.
+              [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,
+              |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
@@ -1815,8 +1819,7 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
 
       1. Let |serialized| be null.
 
-      1. If |known object| is <code>false</code>, and |node details| is true, run the
-         following steps:
+      1. If |known object| is <code>false</code>, run the following steps:
 
           1. Let |serialized| be a map.
 
@@ -1841,7 +1844,7 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
             1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
-               with |child|, |child depth|, |node details|, |child ownership|,
+               with |child|, |child depth|, |child ownership|,
                |serialization internal map| and |realm|.
 
             1. Append |serialized| to |children|.
@@ -1916,7 +1919,7 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |node details|, |child ownership|, |serialization internal map| and
+          |child ownership|, |serialization internal map| and
           |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -1928,8 +1931,6 @@ a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
 
 Issue: Does it make sense to use the same depth parameter for nodes and objects
 in general?
-
-Issue: consider deprecate |node details| in favour of |max depth|.
 
 Issue: |children| and child nodes are different things. Either <code>childNodeCount</code> should
 reference to <code>childNodes</code>, or it should be renamed to <code>childrenCount</code>.
@@ -1943,8 +1944,8 @@ remove optional flag from the field.
 </div>
 
 <div algorithm>
-To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
-|node details|, |child ownership|, |serialization internal map| and |realm|:
+To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |child ownership|,
+|serialization internal map| and |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1954,8 +1955,8 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
        otherwise.
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
-       with arguments |child value|, |child depth|, |node details|,
-       |child ownership|, |serialization internal map| and |realm|.
+       with arguments |child value|, |child depth|, |child ownership|,
+       |serialization internal map| and |realm|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -1965,7 +1966,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 Issue: this assumes for-in works on iterators
 
 <div algorithm>
-To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|, |node details|,
+To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 |child ownership|, |serialization internal map| and |realm|:
 
 1. Let |serialized| be a new list.
@@ -1985,11 +1986,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|, |node detail
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with arguments |child key|, |child depth|, |node details|,
-     |serialization internal map| and |realm|.
+     with arguments |child key|, |child depth|, |serialization internal map| and
+     |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with arguments |value|, |child depth|, |node details|, |child ownership|,
+     with arguments |value|, |child depth|, |child ownership|,
      |serialization internal map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
@@ -3445,9 +3446,9 @@ To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] 
    this data with regex or something equally bad.
 
 1. Let |exception| be the result of [=serialize as a remote value=] given
-   |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>root</code> as |ownership|, <code>new map</code> as
-   |serialization internal map| and |realm|.
+   |record|.\[[Value]], <code>1</code> as |max depth|, <code>root</code> as
+   |ownership type|, <code>new map</code> as |serialization internal map| and
+   |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -3878,8 +3879,8 @@ function with given arguments in a given realm.
 
 <code>RealmInfo</code> can be either a realm or a browsing context.
 
-Note: In case of an arrow function in <code>functionDeclaration</code>, the <code>this</code>
-argument doesn't affect function's <code>this</code> binding.
+Note: In case of an arrow function in <code>functionDeclaration</code>, the
+<code>this</code> argument doesn't affect function's <code>this</code> binding.
 
 <dl>
    <dt>Command Type</dt>
@@ -3896,6 +3897,7 @@ argument doesn't affect function's <code>this</code> binding.
         ?this: ArgumentValue;
         ?awaitPromise: bool;
         target: Target;
+        ?ownership: OwnershipModel;
       }
 
       ArgumentValue = (
@@ -3914,9 +3916,6 @@ argument doesn't affect function's <code>this</code> binding.
 </dl>
 
 Issue: TODO: Add timeout argument as described in the script.evaluate.
-
-Issue: TODO: Add ownership model parameter.
-See https://github.com/w3c/webdriver-bidi/issues/90
 
 <div algorithm>
 
@@ -3987,6 +3986,12 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
+1. Let |await promise| be the value of the <code>awaitPromise</code> field of
+   |command parameters|, if present, or <code>true</code> otherwise.
+
+1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
+   |command parameters|, if present, or <code>none</code> otherwise.
+
 1. Let |function body evaluation status| be the result of [=evaluate function body=]
    (|function declaration|, |environment settings|, |base URL|, |options| and |realm|).
 
@@ -4004,8 +4009,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Set |evaluation status| to
    [=Call=](|function object|, |this object|, |deserialized arguments|).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is true,
-   and [=IsPromise=](|evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is
+   <code>true</code>, and [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to
       <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
@@ -4024,9 +4029,9 @@ The [=remote end steps=] with |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code>
-   as |node details|, <code>root</code> as |ownership|, <code>new map</code> as
-   |serialization internal map| and |realm|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|
+   as |ownership type|, <code>new map</code> as |serialization internal map| and
+   |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -4053,9 +4058,10 @@ case the resolved value of the promise is returned.
       }
 
       ScriptEvaluateParameters = {
-        expression: text,
-        target: Target,
-        ?awaitPromise: bool,
+        expression: text;
+        target: Target;
+        ?awaitPromise: bool;
+        ?resultOwnership: OwnershipModel;
       }
       </pre>
    </dd>
@@ -4066,9 +4072,6 @@ case the resolved value of the promise is returned.
    </pre>
    </dd>
 </dl>
-
-Issue: TODO: Add ownership model parameter.
-See https://github.com/w3c/webdriver-bidi/issues/90
 
 TODO: Add timeout argument. It's not totally clear how this ought to work; in
 Chrome it seems like the timeout doesn't apply to the promise resolve step, but
@@ -4089,6 +4092,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |await promise| be the value of the <code>awaitPromise</code> field of
    |command parameters|, if present, or <code>true</code> otherwise.
+
+1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
+   |command parameters|, if present, or <code>none</code> otherwise.
 
 1. Let |options| be the [=default classic script fetch options=].
 
@@ -4120,9 +4126,9 @@ The [=remote end steps=] with |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>root</code> as |ownership|, <code>new map</code> as
-   |serialization internal map| and |realm|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result ownership|
+   as |ownership type|, <code>new map</code> as |serialization internal map| and
+   |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and

--- a/index.bs
+++ b/index.bs
@@ -440,8 +440,8 @@ The <dfn>set of sessions for which an event is enabled</dfn> given |event name| 
 
 1. For each |session| in [=active BiDI sessions=]:
 
-  1. If [=event is enabled=] with |session|, |event name| and |browsing
-     contexts|, append |session| to |sessions|.
+  1. If [=event is enabled=] with |session|, |event name| and |browsing contexts|,
+     append |session| to |sessions|.
 
 1. Return |sessions|
 
@@ -457,16 +457,16 @@ Note: |browsing contexts| is a set because a [=shared worker=] can be associated
 
 1. Let |top-level browsing contexts| be an empty set.
 
-1. For each |browsing context| of |browsing contexts|, append |browsing
-   context|'s [=top-level browsing context=] to |top-level browsing contexts|.
+1. For each |browsing context| of |browsing contexts|, append |browsing context|'s
+   [=top-level browsing context=] to |top-level browsing contexts|.
 
 1. Let |event map| be the [=browsing context event map=] for |session|.
 
 1. For each |browsing context| of |top-level browsing contexts|:
 
-  1. If |event map| [=contains=] |browsing context|, let |browsing context
-     events| be |event map|[|browsing context|].  Otherwise let |browsing
-     context events| be null.
+  1. If |event map| [=contains=] |browsing context|, let |browsing context events| be
+     |event map|[|browsing context|].  Otherwise let |browsing context events| be
+     null.
 
   1. If |browsing context events| is not null, and |browsing context events|
      [=contains=] |event name|, return true.
@@ -1822,8 +1822,8 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
        1. Append |value| to the |set of known objects|
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
-          [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|, |node
-          details|, |set of known objects| and |realm|.
+          [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
+          |node details|, |set of known objects| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>objectId</code> property set
@@ -1972,8 +1972,8 @@ events are disabled, the return value is always empty.
 
            1. Add |event name| to |global event set|.
 
-           1. For each |context| of |already enabled contexts|, remove |event
-              name| from |event map|[|context|].
+           1. For each |context| of |already enabled contexts|, remove |event name|
+              from |event map|[|context|].
 
            1. Let |newly enabled contexts| be a list of all
               [=top-level browsing contexts=] that are not contained in
@@ -1985,9 +1985,9 @@ events are disabled, the return value is always empty.
 
       1. For each |event name| in |event names|:
 
-        1. If |global event set| [=contains=] |event name|, remove |event
-           name| from |global event set|. Otherwise return [=error=] with
-           [=error code=] [=invalid argument=].
+        1. If |global event set| [=contains=] |event name|, remove |event name| from
+           |global event set|. Otherwise return [=error=] with [=error code=]
+           [=invalid argument=].
 
 1. Otherwise, if |browsing contexts| is not null:
 
@@ -2000,8 +2000,8 @@ events are disabled, the return value is always empty.
 
     1. Let |top-level context| be the [=top-level browsing context=] for |context|.
 
-    1. If |event map| does not contain |top-level context|, set |event
-       map|[|top-level context|] to a new set.
+    1. If |event map| does not contain |top-level context|, set
+       |event map|[|top-level context|] to a new set.
 
     1. Set |targets|[|top-level context|] to |event map|[|top-level context|].
 
@@ -2015,8 +2015,8 @@ events are disabled, the return value is always empty.
 
         1. Add |event name| to |target|.
 
-        1. If |enabled events| does not contain |event name|, set |enabled
-           events|[|event name|] to a new set.
+        1. If |enabled events| does not contain |event name|, set
+           |enabled events|[|event name|] to a new set.
 
         1. Append |context| to |enabled events|[|event name|].
 
@@ -2252,15 +2252,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
      |contexts|.
 
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
-   than algorithm given two entries with keys |event name one| and |event
-   name two|:
+   than algorithm given two entries with keys |event name one| and |event name two|:
 
     1. Let |event one| be the [=event=] with name |event name one|
 
     1. Let |event two| be the [=event=] with name |event name two|
 
-    1. Return true if |event one|'s [=subscribe priority=] is less than |event
-       two|'s susbscribe priority, or false otherwise.
+    1. Return true if |event one|'s [=subscribe priority=] is less than |event two|'s
+       susbscribe priority, or false otherwise.
 
 1. If |list of contexts| is null, let |include global| be true, otherwise let
    |include global| be false.
@@ -2752,8 +2751,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |root id| be the value of the <code>root</code> field of
    |command parameters| if present, or null otherwise.
 
-1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
-   parameters| if present, or null otherwise.
+1. Let |max depth| be the value of the <code>maxDepth</code> field of
+   |command parameters| if present, or null otherwise.
 
 1. Let |contexts| be an empty list.
 
@@ -2822,11 +2821,10 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
 1. Assert: |context| is not null.
 
-1. Let |wait condition| be the value of the <code>wait</code> field of |command
-   parameters| if present, or "<code>none</code>" otherwise.
+1. Let |wait condition| be the value of the <code>wait</code> field of
+   |command parameters| if present, or "<code>none</code>" otherwise.
 
-1. Let |url| be the value of the <code>url</code> field of |command
-   parameters|.
+1. Let |url| be the value of the <code>url</code> field of |command parameters|.
 
 1. Let |document| be |context|'s [=active document=].
 
@@ -2879,11 +2877,11 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. Let |ignore cache| be the the value of the <code>ignoreCache</code> field of |command
-   parameters| if present, or false otherwise.
+1. Let |ignore cache| be the the value of the <code>ignoreCache</code> field of
+   |command parameters| if present, or false otherwise.
 
-1. Let |wait condition| be the value of the <code>wait</code> field of |command
-   parameters| if present, or "<code>none</code>" otherwise.
+1. Let |wait condition| be the value of the <code>wait</code> field of
+   |command parameters| if present, or "<code>none</code>" otherwise.
 
 1. Let |document| be |context|'s [=active document=].
 
@@ -2891,9 +2889,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |request| be a new [=/request=] whose URL is |url|.
 
-1. Return the result of [=await a navigation=] with |context|, |request|, |wait
-   condition|, history handling "<code>reload</code>", and ignore
-   cache |ignore cache|.
+1. Return the result of [=await a navigation=] with |context|, |request|,
+   |wait condition|, history handling "<code>reload</code>", and ignore cache
+   |ignore cache|.
 
 </div>
 
@@ -3392,8 +3390,8 @@ To <dfn>get a realm</dfn> given |realm id|:
 
 1. If |realm id| is null, return [=success=] with data null.
 
-1. If there is no [=realm=] with [=realm id|id=] |realm id| return
-   [=error=] with [=error code=] [=no such frame=]
+1. If there is no [=realm=] with [=realm id|id=] |realm id| return [=error=] with
+   [=error code=] [=no such frame=]
 
 1. Let |realm| be the [=realm=] with [=realm id|id=] |realm id|.
 
@@ -3938,8 +3936,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
-1. Let |source| be the value of the <code>expression</code> field of |command
-   parameters|.
+1. Let |source| be the value of the <code>expression</code> field of
+   |command parameters|.
 
 1. Let |await promise| be the value of the <code>awaitPromise</code> field of
    |command parameters|, if present, or <code>true</code> otherwise.
@@ -4049,9 +4047,9 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
   1. Let |realm info| be the result of [=get the realm info=] given |settings|
 
-  1. If |command parameters| contains <code>type</code> and |realm
-     info|["<code>type</code>"] is not equal to |command
-     parameters|["<code>type</code>"] then [=continue=].
+  1. If |command parameters| contains <code>type</code> and
+     |realm info|["<code>type</code>"] is not equal to
+     |command parameters|["<code>type</code>"] then [=continue=].
 
   1. If |realm info| is not null, append |realm info| to |realms|.
 
@@ -4173,8 +4171,7 @@ Define the following [=unloading document cleanup steps=] with |document|:
 
 1. Let |related browsing contexts| be an empty set.
 
-1. Append |document|'s [=Document/browsing context=] to |related browsing
-   contexts|.
+1. Append |document|'s [=Document/browsing context=] to |related browsing contexts|.
 
 1. For each |worklet global scope| in |document|'s [=worklet global scopes=]:
 
@@ -4263,8 +4260,8 @@ To <dfn>buffer a log event</dfn> given |session|, |contexts| and |event|:
 
   1. For each |other id| in |context ids|:
 
-   1. If |other id| is not equal to |context id|, append |other id| to |other
-      contexts|.
+   1. If |other id| is not equal to |context id|, append |other id| to
+      |other contexts|.
 
   1. If |buffer| does not contain |context id|, let |buffer|[|context id|] be a
      new list.
@@ -4376,7 +4373,7 @@ ignore>options</var>:
 
 1. Let |text| be an empty string.
 
-1. If [=Type=](||args|[0]) is String, and |args|[0] contains a
+1. If [=Type=](|args|[0]) is String, and |args|[0] contains a
    [=formatting specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise
    let |formatted args| be |args|.
 
@@ -4406,8 +4403,7 @@ ignore>options</var>:
    field set to |text|, the <code>timestamp</code> field set to |timestamp|, the
    <code>stackTrace</code> field set to |stack| if |stack| is not null, or
    omitted otherwise, the |method| field set to |method|, the <code>realm</code>
-   field set to |realm| and the <code>args</code> field set to |serialized
-   args|.
+   field set to |realm| and the <code>args</code> field set to |serialized args|.
 
 1. Let |body| be a map matching the <code>LogEntryAddedEvent</code> production, with
    the <code>params</code> field set to |entry|.
@@ -4422,8 +4418,8 @@ ignore>options</var>:
   1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
      |related browsing contexts|, [=emit an event=] with |session| and |body|.
 
-     Otherwise, [=buffer a log event=] with |session|, |related browsing
-     contexts|, and |body|.
+     Otherwise, [=buffer a log event=] with |session|, |related browsing contexts|,
+     and |body|.
 
 Define the following [=error reporting steps=] with arguments |script|, <var
 ignore>line number</var>, <var ignore>column number</var>, |message| and
@@ -4448,8 +4444,8 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
   1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
      |related browsing contexts|, [=emit an event=] with |session| and |body|.
 
-     Otherwise, [=buffer a log event=] with |session|, |related browsing
-     contexts|, and |body|.
+     Otherwise, [=buffer a log event=] with |session|, |related browsing contexts|,
+     and |body|.
 
 Issue: Lots more things require logging. CDP has LogEntryAdded types xml,
 javascript, network, storage, appcache, rendering, security, deprecation,

--- a/index.bs
+++ b/index.bs
@@ -3747,7 +3747,8 @@ Issue: This has the wrong error code
 #### The script.Ownership type #### {#type-script-Ownership}
 
 <pre class="cddl local-cddl remote-cddl">
-SerializationOwnershipModel = "root" // "none"
+SerializationOwnershipModel = "root" / "none"
+</pre>
 
 The <code>SerializationOwnershipModel</code> specifies how the serialized value
 ownership should be treated.

--- a/index.bs
+++ b/index.bs
@@ -1476,9 +1476,13 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
        |serialization internal map|[|object|].
 
     1. If |previously serialized remote value| does not have a field
-       <code>internalId</code>, set the <code>internalId</code> field of
-       |previously serialized remote value| to a new, unique, string identifier for
-       |object|.
+       <code>internalId</code>, run the following steps:
+
+      1. Let |internal id| be the string representation of a [[!RFC4122|UUID]] based
+         on truly random, or pseudo-random numbers.
+
+       1. Set the <code>internalId</code> field of
+          |previously serialized remote value| to |internal id|.
 
     1. Set the <code>internalId</code> field of |remote value| to a field
        <code>internalId</code> in |previously serialized remote value|.

--- a/index.bs
+++ b/index.bs
@@ -1514,7 +1514,7 @@ RemoteValue = {
   WindowProxyRemoteValue //
 }
 
-InternalId = integer;
+InternalId = uint;
 
 ListRemoteValue = [*RemoteValue];
 

--- a/index.bs
+++ b/index.bs
@@ -1478,8 +1478,8 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
     1. If |previously serialized remote value| does not have a field
        <code>internalId</code>, run the following steps:
 
-      1. Let |internal id| be the string representation of a [[!RFC4122|UUID]] based
-         on truly random, or pseudo-random numbers.
+      1. Let |internal id| be a unique across the <code>internalId</code> fields of
+         the values of |serialization internal map| number.
 
        1. Set the <code>internalId</code> field of
           |previously serialized remote value| to |internal id|.
@@ -1514,7 +1514,7 @@ RemoteValue = {
   WindowProxyRemoteValue //
 }
 
-InternalId = String;
+InternalId = Number;
 
 ListRemoteValue = [*RemoteValue];
 

--- a/index.bs
+++ b/index.bs
@@ -1463,10 +1463,8 @@ To <dfn>set internal ids if needed</dfn> given |object remote value map|,
        |previously serialized remote value| to a new, unique, string identifier for
        |object|.
 
-    1. Let |internal id| be a value of a field <code>internalId</code> in
-       |previously serialized remote value|.
-
-    1. Set the <code>internalId</code> field of |remote value| to |internal id|.
+    1. Set the <code>internalId</code> field of |remote value| to a field
+       <code>internalId</code> in |previously serialized remote value|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -439,8 +439,8 @@ The <dfn>set of sessions for which an event is enabled</dfn> given |event name| 
 
 1. For each |session| in [=active BiDI sessions=]:
 
-  1. If [=event is enabled=] with |session|, |event name| and |browsing contexts|,
-     append |session| to |sessions|.
+  1. If [=event is enabled=] with |session|, |event name| and |browsing
+     contexts|, append |session| to |sessions|.
 
 1. Return |sessions|
 
@@ -456,16 +456,16 @@ Note: |browsing contexts| is a set because a [=shared worker=] can be associated
 
 1. Let |top-level browsing contexts| be an empty set.
 
-1. For each |browsing context| of |browsing contexts|, append |browsing context|'s
-   [=top-level browsing context=] to |top-level browsing contexts|.
+1. For each |browsing context| of |browsing contexts|, append |browsing
+   context|'s [=top-level browsing context=] to |top-level browsing contexts|.
 
 1. Let |event map| be the [=browsing context event map=] for |session|.
 
 1. For each |browsing context| of |top-level browsing contexts|:
 
-  1. If |event map| [=contains=] |browsing context|, let |browsing context events| be
-     |event map|[|browsing context|].  Otherwise let |browsing context events| be
-     null.
+  1. If |event map| [=contains=] |browsing context|, let |browsing context
+     events| be |event map|[|browsing context|].  Otherwise let |browsing
+     context events| be null.
 
   1. If |browsing context events| is not null, and |browsing context events|
      [=contains=] |event name|, return true.
@@ -2044,8 +2044,8 @@ events are disabled, the return value is always empty.
 
            1. Add |event name| to |global event set|.
 
-           1. For each |context| of |already enabled contexts|, remove |event name|
-              from |event map|[|context|].
+           1. For each |context| of |already enabled contexts|, remove |event
+              name| from |event map|[|context|].
 
            1. Let |newly enabled contexts| be a list of all [=top-level browsing
               contexts=] that are not contained in |already enabled contexts|,
@@ -2056,9 +2056,9 @@ events are disabled, the return value is always empty.
 
       1. For each |event name| in |event names|:
 
-        1. If |global event set| [=contains=] |event name|, remove |event name| from
-           |global event set|. Otherwise return [=error=] with [=error code=]
-           [=invalid argument=].
+        1. If |global event set| [=contains=] |event name|, remove |event
+           name| from |global event set|. Otherwise return [=error=] with
+           [=error code=] [=invalid argument=].
 
 1. Otherwise, if |browsing contexts| is not null:
 
@@ -2071,8 +2071,8 @@ events are disabled, the return value is always empty.
 
     1. Let |top-level context| be the [=top-level browsing context=] for |context|.
 
-    1. If |event map| does not contain |top-level context|, set
-       |event map|[|top-level context|] to a new set.
+    1. If |event map| does not contain |top-level context|, set |event
+       map|[|top-level context|] to a new set.
 
     1. Set |targets|[|top-level context|] to |event map|[|top-level context|].
 
@@ -2086,8 +2086,8 @@ events are disabled, the return value is always empty.
 
         1. Add |event name| to |target|.
 
-        1. If |enabled events| does not contain |event name|, set
-           |enabled events|[|event name|] to a new set.
+        1. If |enabled events| does not contain |event name|, set |enabled
+           events|[|event name|] to a new set.
 
         1. Append |context| to |enabled events|[|event name|].
 
@@ -2322,14 +2322,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
      subscribe steps=], set |subscribe step events|[|event name|] to |contexts|.
 
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
-   than algorithm given two entries with keys |event name one| and |event name two|:
+   than algorithm given two entries with keys |event name one| and |event
+   name two|:
 
     1. Let |event one| be the [=event=] with name |event name one|
 
     1. Let |event two| be the [=event=] with name |event name two|
 
-    1. Return true if |event one|'s [=subscribe priority=] is less than |event two|'s
-       susbscribe priority, or false otherwise.
+    1. Return true if |event one|'s [=subscribe priority=] is less than |event
+       two|'s susbscribe priority, or false otherwise.
 
 1. If |list of contexts| is null, let |include global| be true, otherwise let
    |include global| be false.
@@ -2821,8 +2822,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |root id| be the value of the <code>root</code> field of
    |command parameters| if present, or null otherwise.
 
-1. Let |max depth| be the value of the <code>maxDepth</code> field of
-   |command parameters| if present, or null otherwise.
+1. Let |max depth| be the value of the <code>maxDepth</code> field of |command
+   parameters| if present, or null otherwise.
 
 1. Let |contexts| be an empty list.
 
@@ -2891,10 +2892,11 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
 1. Assert: |context| is not null.
 
-1. Let |wait condition| be the value of the <code>wait</code> field of
-   |command parameters| if present, or "<code>none</code>" otherwise.
+1. Let |wait condition| be the value of the <code>wait</code> field of |command
+   parameters| if present, or "<code>none</code>" otherwise.
 
-1. Let |url| be the value of the <code>url</code> field of |command parameters|.
+1. Let |url| be the value of the <code>url</code> field of |command
+   parameters|.
 
 1. Let |document| be |context|'s [=active document=].
 
@@ -2947,11 +2949,11 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. Let |ignore cache| be the the value of the <code>ignoreCache</code> field of
-   |command parameters| if present, or false otherwise.
+1. Let |ignore cache| be the the value of the <code>ignoreCache</code> field of |command
+   parameters| if present, or false otherwise.
 
-1. Let |wait condition| be the value of the <code>wait</code> field of
-   |command parameters| if present, or "<code>none</code>" otherwise.
+1. Let |wait condition| be the value of the <code>wait</code> field of |command
+   parameters| if present, or "<code>none</code>" otherwise.
 
 1. Let |document| be |context|'s [=active document=].
 
@@ -2959,9 +2961,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |request| be a new [=/request=] whose URL is |url|.
 
-1. Return the result of [=await a navigation=] with |context|, |request|,
-   |wait condition|, history handling "<code>reload</code>", and ignore cache
-   |ignore cache|.
+1. Return the result of [=await a navigation=] with |context|, |request|, |wait
+   condition|, history handling "<code>reload</code>", and ignore
+   cache |ignore cache|.
 
 </div>
 
@@ -3461,8 +3463,8 @@ To <dfn>get a realm</dfn> given |realm id|:
 
 1. If |realm id| is null, return [=success=] with data null.
 
-1. If there is no [=realm=] with [=realm id|id=] |realm id| return [=error=] with
-   [=error code=] [=no such frame=]
+1. If there is no [=realm=] with [=realm id|id=] |realm id| return
+   [=error=] with [=error code=] [=no such frame=]
 
 1. Let |realm| be the [=realm=] with [=realm id|id=] |realm id|.
 
@@ -4061,8 +4063,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
-1. Let |source| be the value of the <code>expression</code> field of
-   |command parameters|.
+1. Let |source| be the value of the <code>expression</code> field of |command
+   parameters|.
 
 1. Let |await promise| be the value of the <code>awaitPromise</code> field of
    |command parameters|, if present, or <code>true</code> otherwise.
@@ -4174,9 +4176,9 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
   1. Let |realm info| be the result of [=get the realm info=] given |settings|
 
-  1. If |command parameters| contains <code>type</code> and
-     |realm info|["<code>type</code>"] is not equal to
-     |command parameters|["<code>type</code>"] then [=continue=].
+  1. If |command parameters| contains <code>type</code> and |realm
+     info|["<code>type</code>"] is not equal to |command
+     parameters|["<code>type</code>"] then [=continue=].
 
   1. If |realm info| is not null, append |realm info| to |realms|.
 
@@ -4299,7 +4301,8 @@ Define the following [=unloading document cleanup steps=] with |document|:
 
 1. Let |related browsing contexts| be an empty set.
 
-1. Append |document|'s [=Document/browsing context=] to |related browsing contexts|.
+1. Append |document|'s [=Document/browsing context=] to |related browsing
+   contexts|.
 
 1. For each |worklet global scope| in |document|'s [=worklet global scopes=]:
 
@@ -4388,8 +4391,8 @@ To <dfn>buffer a log event</dfn> given |session|, |contexts| and |event|:
 
   1. For each |other id| in |context ids|:
 
-   1. If |other id| is not equal to |context id|, append |other id| to
-      |other contexts|.
+   1. If |other id| is not equal to |context id|, append |other id| to |other
+      contexts|.
 
   1. If |buffer| does not contain |context id|, let |buffer|[|context id|] be a
      new list.
@@ -4501,7 +4504,7 @@ ignore>options</var>:
 
 1. Let |text| be an empty string.
 
-1. If [=Type=](|args|[0]) is String, and |args|[0] contains a
+1. If [=Type=](||args|[0]) is String, and |args|[0] contains a
    [=formatting specifier=], let |formatted args| be [=Formatter=](|args|). Otherwise
    let |formatted args| be |args|.
 
@@ -4531,7 +4534,8 @@ ignore>options</var>:
    field set to |text|, the <code>timestamp</code> field set to |timestamp|, the
    <code>stackTrace</code> field set to |stack| if |stack| is not null, or
    omitted otherwise, the |method| field set to |method|, the <code>realm</code>
-   field set to |realm| and the <code>args</code> field set to |serialized args|.
+   field set to |realm| and the <code>args</code> field set to |serialized
+   args|.
 
 1. Let |body| be a map matching the <code>LogEntryAddedEvent</code> production, with
    the <code>params</code> field set to |entry|.
@@ -4546,8 +4550,8 @@ ignore>options</var>:
   1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
      |related browsing contexts|, [=emit an event=] with |session| and |body|.
 
-     Otherwise, [=buffer a log event=] with |session|, |related browsing contexts|,
-     and |body|.
+     Otherwise, [=buffer a log event=] with |session|, |related browsing
+     contexts|, and |body|.
 
 Define the following [=error reporting steps=] with arguments |script|, <var
 ignore>line number</var>, <var ignore>column number</var>, |message| and
@@ -4572,8 +4576,8 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
   1. If [=event is enabled=] with |session|, "<code>log.entryAdded</code>" and
      |related browsing contexts|, [=emit an event=] with |session| and |body|.
 
-     Otherwise, [=buffer a log event=] with |session|, |related browsing contexts|,
-     and |body|.
+     Otherwise, [=buffer a log event=] with |session|, |related browsing
+     contexts|, and |body|.
 
 Issue: Lots more things require logging. CDP has LogEntryAdded types xml,
 javascript, network, storage, appcache, rendering, security, deprecation,

--- a/index.bs
+++ b/index.bs
@@ -1427,7 +1427,10 @@ object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
 <div algorithm>
-To get the <dfn>object id for an object</dfn> given |realm| and |object|:
+To get the <dfn>object id for an object</dfn> given |realm|, |ownership|
+and |object|:
+
+1. If |ownership| is equal <code>none</code>, return <code>null</code>.
 
 1. If the given |realm|'s [=object id map=] does not contain |object|, run the
    following steps:
@@ -1473,96 +1476,96 @@ MappingRemoteValue = [*[(RemoteValue / text), RemoteValue]];
 
 SymbolRemoteValue = {
    type: "symbol",
-   objectId: ObjectId,
+   ?objectId: ObjectId,
 }
 
 ArrayRemoteValue = {
   type: "array",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
   ?value: ListRemoteValue,
 }
 
 ObjectRemoteValue = {
   type: "object",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
   ?value: MappingRemoteValue,
 }
 
 FunctionRemoteValue = {
    type: "function",
-   objectId: ObjectId,
+   ?objectId: ObjectId,
 }
 
 RegExpRemoteValue = {
    RegExpLocalValue,
-   objectId: ObjectId,
+   ?objectId: ObjectId,
 }
 
 DateRemoteValue = {
   DateLocalValue,
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 MapRemoteValue = {
   type: "map",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
   value: MappingRemoteValue,
 }
 
 SetRemoteValue = {
   type: "set",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
   value: ListRemoteValue
 }
 
 WeakMapRemoteValue = {
   type: "weakmap",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 WeakSetRemoteValue = {
   type: "weakset",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 IteratorRemoteValue = {
   type: "iterator",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 GeneratorRemoteValue = {
   type: "generator",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 ErrorRemoteValue = {
   type: "error",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 ProxyRemoteValue = {
   type: "proxy",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 PromiseRemoteValue = {
   type: "promise",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 TypedArrayRemoteValue = {
   type: "typedarray",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 ArrayBufferRemoteValue = {
   type: "arraybuffer",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 
 NodeRemoteValue = {
   type: "node",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
   ?value: NodeProperties,
 }
 
@@ -1579,7 +1582,7 @@ NodeProperties = {
 
 WindowProxyRemoteValue = {
   type: "window",
-  objectId: ObjectId,
+  ?objectId: ObjectId,
 }
 ```
 
@@ -1593,6 +1596,9 @@ Issue: Describe `GeneratorRemoteValue` serialization.
 
 Issue: Describe `ProxyRemoteValue` serialization.
 
+Issue: Handle internal cycles by providing `internalId`s.
+See https://github.com/w3c/webdriver-bidi/issues/90
+
 Issue: handle String / Number / etc. wrapper objects specially?
 
 #### Serialization #### {#data-types-protocolValue-RemoteValue-serialization}
@@ -1600,7 +1606,7 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-|node details|, a |set of known objects| and a |realm|:
+a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1610,11 +1616,19 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
+1. Let |objectId| be the [=object id for an object=] given |realm|, |ownership|
+   and |value|.
+
+1. Let |child ownership| be <code>none</code>.
+
+1. If |ownership| is equal to <code>all</code>, set |child ownership| to
+   <code>all</code>.
+
   <dl>
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
     <dd>
@@ -1625,13 +1639,14 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
            1. Append |value| to the |set of known objects|
 
            1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateArrayIterator=](|value|, value), |max depth|, |node details| and
-              |set of known objects| and |realm|.
+              [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
+              |child ownership|, |set of known objects| and |realm|.
 
-    1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code> production
-       in the [=local end definition=], with the <code>objectId</code> property set
-       to the [=object id for an object=] given |realm| and |value|, and the <code>value</code>
-       field set to |serialized| if it's not null, or omitted otherwise.
+    1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
+       production in the [=local end definition=], with the <code>objectId</code>
+       property set to |objectId| if it's not null, or omitted otherwise, and the
+       <code>value</code> field set to |serialized| if it's not null, or omitted
+       otherwise.
 
     <dt>[=IsRegExp=](|value|)
     <dd>
@@ -1645,7 +1660,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] given |realm| and |object|, and
+           property set to |objectId| if it's not null, or omitted otherwise, and
            the <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
@@ -1654,7 +1669,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
       1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
-         property set to the [=object id for an object=] given |realm| and |object|, and the
+         property set to |objectId| if it's not null, or omitted otherwise, and the
          value set to |serialized|.
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
@@ -1667,13 +1682,13 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
            1. Let |serialized| be the result of [=serialize as a mapping=] given
               [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
-              |set of known objects| and |realm|.
+              |child ownership|, |set of known objects| and |realm|.
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
-       <code>objectId</code> property set to the [=object id for an object=]
-       given |realm| and |value|, and the <code>value</code> field set to |serialized| if
-       it's not null, or omitted otherwise.
+       <code>objectId</code> property set to |objectId| if it's not null, or omitted
+       otherwise, and the <code>value</code> field set to |serialized| if it's not
+       null, or omitted otherwise.
 
     <dt>|value| has a \[[SetData]] [=internal slot=]
     <dd>
@@ -1685,43 +1700,43 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
-              |set of known objects| and |realm|.
+              |child ownership|, |set of known objects| and |realm|.
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
-        <code>objectId</code> property set to the [=object id for an object=]
-        given |realm| and |value|, and the <code>value</code> field set to |serialized| if
-        it's not null, or omitted otherwise.
+        <code>objectId</code> property set to |objectId| if it's not null, or omitted
+        otherwise, and the <code>value</code> field set to |serialized| if it's not
+        null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakSetRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ErrorRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>[=IsPromise=](|value|)
     <dd>Let |remote value| be a map matching the <code>PromiseRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>TypedArrayRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -1752,8 +1767,8 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
             1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
-               with |child|, |child depth|, |node details|, |set of known objects|
-               and |realm|.
+               with |child|, |child depth|, |node details|, |child ownership|,
+               |set of known objects| and |realm|.
 
             1. Append |serialized| to |children|.
 
@@ -1783,7 +1798,7 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
-                  false, |set of known objects| and |realm|.
+                  false, |child ownership|, |set of known objects| and |realm|.
 
                 Note: this means the <code>objectId</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1793,23 +1808,23 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>objectId</code>
-         property set to the [=object id for an object=] given |realm| and |value|,
+         property set to |objectId| if it's not null, or omitted otherwise,
          and <code>value</code> set to |serialized|, if |serialized| is not null.
 
     <dt>|value| is a [=platform object=] that implements {{WindowProxy}}
     <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] given |realm| and |value|.
+           property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a map matching the <code>ObjectValue</code>
            production in the [=local end definition=], with the <code>objectId</code>
-           property set to the [=object id for an object=] given |realm| and |value|.
+           property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>[=IsCallable=](|value|)
     <dd>Let |remote value| be a map matching the <code>FunctionValue</code>
         production in the [=local end definition=], with the <code>objectId</code>
-        property set to the [=object id for an object=] given |realm| and |value|.
+        property set to |objectId| if it's not null, or omitted otherwise.
 
     <dt>Otherwise:
     <dd>
@@ -1823,12 +1838,13 @@ To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |node details|, |set of known objects| and |realm|.
+          |node details|, |child ownership|, |set of known objects| and
+          |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>objectId</code> property set
-       to the [=object id for an object=] given |realm| and |value|, and the <code>value</code> field
-       set to |serialized|.
+       to |objectId| if it's not null, or omitted otherwise, and the
+       <code>value</code> field set to |serialized|.
   </dl>
 
 1. Return |remote value|
@@ -1851,7 +1867,7 @@ remove optional flag from the field.
 
 <div algorithm>
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
-|node details|, |set of known objects| and |realm|:
+|node details|, |child ownership|, |set of known objects| and |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1862,7 +1878,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
        with arguments |child value|, |child depth|, |node details|,
-       |set of known objects| and |realm|.
+       |child ownership|, |set of known objects| and |realm|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -1873,7 +1889,7 @@ Issue: this assumes for-in works on iterators
 
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
-|node details|, |set of known objects| and |realm|:
+|node details|, |child ownership|, |set of known objects| and |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -1896,7 +1912,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
      |set of known objects|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with arguments |value|, |child depth|, |node details|,
+     with arguments |value|, |child depth|, |node details|, |child ownership|,
      |set of known objects| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
@@ -3342,7 +3358,7 @@ The <code>ExceptionDetails</code> type represents a JavaScript exception.
 
 <div algorithm>
 
-!!@@## To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] |record|:
+To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] |record|:
 
 1. Assert: |record|.\[[Type]] is <code>throw</code>.
 
@@ -3353,8 +3369,9 @@ The <code>ExceptionDetails</code> type represents a JavaScript exception.
    this data with regex or something equally bad.
 
 1. Let |exception| be the result of [=serialize as a remote value=] given
-   |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as |node details|,
-   a <code>new set</code> as |set of known objects| and |realm|.
+   |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
+   |node details|, <code>root</code> as |ownership|, <code>new set</code>
+   as |set of known objects| and |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
 
@@ -3774,6 +3791,9 @@ argument doesn't affect function's <code>this</code> binding.
 
 Issue: TODO: Add timeout argument as described in the script.evaluate.
 
+Issue: TODO: Add ownership model parameter.
+See https://github.com/w3c/webdriver-bidi/issues/90
+
 <div algorithm>
 
 To <dfn>deserialize arguments</dfn> given |realm| and |serialized arguments list|:
@@ -3880,8 +3900,9 @@ The [=remote end steps=] with |command parameters| are:
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
 1. Let |result| be the result of [=serialize as a remote value=] given
-   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>new set</code> as |set of known objects| and |realm|.
+   |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code>
+   as |node details|, <code>root</code> as |ownership|, <code>new set</code> as
+   |set of known objects| and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -3921,6 +3942,9 @@ case the resolved value of the promise is returned.
    </pre>
    </dd>
 </dl>
+
+Issue: TODO: Add ownership model parameter.
+See https://github.com/w3c/webdriver-bidi/issues/90
 
 TODO: Add timeout argument. It's not totally clear how this ought to work; in
 Chrome it seems like the timeout doesn't apply to the promise resolve step, but
@@ -3973,7 +3997,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>new set</code> as |set of known objects| and |realm|.
+   |node details|, <code>root</code> as |ownership|, <code>new set</code> as
+   |set of known objects| and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and

--- a/index.bs
+++ b/index.bs
@@ -1616,9 +1616,6 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
 1. Let |child ownership| be <code>none</code>.
 
-1. If |ownership| is equal to <code>all</code>, set |child ownership| to
-   <code>all</code>.
-
   <dl>
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>

--- a/index.bs
+++ b/index.bs
@@ -1424,9 +1424,9 @@ handles. The object will not be disposed until all the handles are disowned.
 For some non-primitive types, the <code>value</code> property contains a
 representation of the data in the ECMAScript object; for container types this can
 contain further <code>RemoteValue</code> instances. The <code>value</code> property
-can be null if there is a duplicate object i.e. the object has already been
-serialized in the current <code>RemoteValue</code>, perhaps as part of a cycle, or
-otherwise when the maximum serialization depth is reached.
+can be null or emitted if there is a duplicate object i.e. the object has already
+been serialized in the current <code>RemoteValue</code>, perhaps as part of a cycle,
+or otherwise when the maximum serialization depth is reached.
 In case of duplicated objects in the same <code>RemoteValue</code>, the value is
 provided only for one of the remote values, while the unique-per-ECMAScript-object
 <code>internalId</code> is provided for all the duplicated objects.

--- a/index.bs
+++ b/index.bs
@@ -1409,7 +1409,7 @@ values, this contains the value in the <code>value</code> property; in the case
 of non-JSON-representable primitives, the <code>value</code> property contains a
 string representation of the value. For non-primitive objects, the
 <code>handle</code> property contains a string id that provides a unique
-handle to the object, valid for its lifetime inside the engine. For some
+handle to the object, valid for realm's lifetime. For some
 non-primitive types, the <code>value</code> property contains a representation
 of the data in the ECMAScript object; for container types this can contain
 further <code>RemoteValue</code> instances. The <code>value</code> property can

--- a/index.bs
+++ b/index.bs
@@ -1039,12 +1039,12 @@ Issue: handle "stale object reference" case.
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
-1. Let |handle| be the value of the <code>handle</code> field of |remote reference|.
+1. Let |handle id| be the value of the <code>handle</code> field of |remote reference|.
 
 1. If the given |realm|'s [=handle object map=] does not contain |handle value|,
    return [=error=] with [=error code=] [=invalid argument=].
 
-1. Return the |handle| value of the given |realm|'s [=handle object map=].
+1. Return the |handle id| value of the given |realm|'s [=handle object map=].
 
 </div>
 
@@ -1446,11 +1446,11 @@ and |object|:
 
 1. If |ownership| is equal <code>none</code>, return <code>null</code>.
 
-1. Let |handle| be a new, unique, string handle for |object|.
+1. Let |handle id| be a new, unique, string handle for |object|.
 
-1. Set the value of |handle| in |realm|'s [=handle object map=] to |object|.
+1. Set the value of |handle id| in |realm|'s [=handle object map=] to |object|.
 
-1. Return |handle| as a result.
+1. Return |handle id| as a result.
 
 </div>
 
@@ -1665,7 +1665,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
-1. Let |handle| be the [=handle for an object=] given |realm|, |ownership|
+1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership|
    and |value|.
 
 1. Let |child ownership| be <code>none</code>.
@@ -1674,7 +1674,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
     <dd>
@@ -1690,7 +1690,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
        production in the [=local end definition=], with the <code>handle</code>
-       property set to |handle| if it's not null, or omitted otherwise, and the
+       property set to |handle id| if it's not null, or omitted otherwise, and the
        <code>value</code> field set to |serialized| if it's not null, or omitted
        otherwise.
 
@@ -1706,7 +1706,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
            production in the [=local end definition=], with the <code>handle</code>
-           property set to |handle| if it's not null, or omitted otherwise, and
+           property set to |handle id| if it's not null, or omitted otherwise, and
            the <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
@@ -1715,7 +1715,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
       1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
          production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle| if it's not null, or omitted otherwise, and the
+         property set to |handle id| if it's not null, or omitted otherwise, and the
          value set to |serialized|.
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
@@ -1733,7 +1733,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
-       <code>handle</code> property set to |handle| if it's not null, or omitted
+       <code>handle</code> property set to |handle id| if it's not null, or omitted
        otherwise, and the <code>value</code> field set to |serialized| if it's not
        null, or omitted otherwise.
 
@@ -1752,39 +1752,39 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
-        <code>handle</code> property set to |handle| if it's not null, or omitted
+        <code>handle</code> property set to |handle id| if it's not null, or omitted
         otherwise, and the <code>value</code> field set to |serialized| if it's not
         null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakSetRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ErrorRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsPromise=](|value|)
     <dd>Let |remote value| be a map matching the <code>PromiseRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>TypedArrayRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -1858,23 +1858,23 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle| if it's not null, or omitted otherwise,
+         property set to |handle id| if it's not null, or omitted otherwise,
          and <code>value</code> set to |serialized|, if |serialized| is not null.
 
     <dt>|value| is a [=platform object=] that implements {{WindowProxy}}
     <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
            production in the [=local end definition=], with the <code>handle</code>
-           property set to |handle| if it's not null, or omitted otherwise.
+           property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a map matching the <code>ObjectValue</code>
            production in the [=local end definition=], with the <code>handle</code>
-           property set to |handle| if it's not null, or omitted otherwise.
+           property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsCallable=](|value|)
     <dd>Let |remote value| be a map matching the <code>FunctionValue</code>
         production in the [=local end definition=], with the <code>handle</code>
-        property set to |handle| if it's not null, or omitted otherwise.
+        property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>Otherwise:
     <dd>
@@ -1893,7 +1893,7 @@ a |node details|, an |ownership|, a |set of known objects|, an
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
        in the [=local end definition=], with the <code>handle</code> property set
-       to |handle| if it's not null, or omitted otherwise, and the
+       to |handle id| if it's not null, or omitted otherwise, and the
        <code>value</code> field set to |serialized|.
   </dl>
 
@@ -3843,9 +3843,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |handles| the value of the <code>handles</code> field of |command parameters|.
 
-1. For each |handle| of |handles|:
-   1. If |realm|'s [=handle object map=] contains |handle|, remove |handle| from the
-      |realm|'s [=handle object map=].
+1. For each |handle id| of |handles|:
+   1. If |realm|'s [=handle object map=] contains |handle id|, remove |handle id|
+      from the |realm|'s [=handle object map=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1660,8 +1660,7 @@ Issue: handle String / Number / etc. wrapper objects specially?
 <div algorithm>
 
 To <dfn>serialize as a remote value</dfn> given a |value|, a |max depth|,
-a |node details|, an |ownership|, a |set of known objects|, a
-|serialization internal map| and a |realm|:
+a |node details|, an |ownership|, a |serialization internal map| and a |realm|:
 
 1. Let |remote value| be a result of [=serialize primitive protocol value=]
    given a |value|.
@@ -1674,6 +1673,9 @@ a |node details|, an |ownership|, a |set of known objects|, a
 1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership|
    and |value|.
 
+1. Let |known object| be <code>true</code>, if |value| is in the
+   |serialization internal map|, otherwise <code>false</code>.
+
 1. Let |child ownership| be <code>none</code>.
 
   <dl>
@@ -1684,21 +1686,25 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
     <dt>[=IsArray=](|value|)
     <dd>
-    1. Let |serialized| be null.
-
-    1. If |value| is not in the |set of known objects|, and |max depth|
-       is not null and greater than 0, run the following steps:
-           1. Append |value| to the |set of known objects|
-
-           1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
-              |set of known objects|, |serialization internal map| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
        production in the [=local end definition=], with the <code>handle</code>
-       property set to |handle id| if it's not null, or omitted otherwise, and the
-       <code>value</code> field set to |serialized| if it's not null, or omitted
-       otherwise.
+       property set to |handle id| if it's not null, or omitted otherwise.
+
+    1. [=Set internal ids if needed=] given |serialization internal map|,
+       |remote value| and |value|.
+
+    1. Let |serialized| be null.
+
+    1. If |known object| is <code>false</code>, and |max depth| is not null and
+       greater than 0, run the following steps:
+
+           1. Let |serialized| be the result of [=serialize as a list=] given
+              [=CreateArrayIterator=](|value|, value), |max depth|, |node details|,
+              |serialization internal map| and |realm|.
+
+    1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+       |serialized|.
 
     <dt>[=IsRegExp=](|value|)
     <dd>
@@ -1726,41 +1732,47 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
     <dd>
-      1. Let |serialized| be null.
-
-      1. If |value| is not in the |set of known objects|, and |max depth|
-         is not null and greater than 0, run the following steps:
-           1. Append |value| to the |set of known objects|
-
-           1. Let |serialized| be the result of [=serialize as a mapping=] given
-              [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
-              |child ownership|, |set of known objects|, |serialization internal map|
-              and |realm|.
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
        <code>handle</code> property set to |handle id| if it's not null, or omitted
-       otherwise, and the <code>value</code> field set to |serialized| if it's not
-       null, or omitted otherwise.
+       otherwise.
+
+    1. [=Set internal ids if needed=] given |serialization internal map|,
+       |remote value| and |value|.
+
+      1. Let |serialized| be null.
+
+      1. If |known object| is <code>false</code>, and |max depth| is not null and
+         greater than 0, run the following steps:
+
+           1. Let |serialized| be the result of [=serialize as a mapping=] given
+              [=CreateMapIterator=](|value|, key+value), |max depth|, |node details|,
+              |child ownership|, |serialization internal map| and |realm|.
+
+    1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+       |serialized|.
 
     <dt>|value| has a \[[SetData]] [=internal slot=]
     <dd>
-      1. Let |serialized| be null.
-
-      1. If |value| is not in the |set of known objects|, and |max depth|
-         is not null and greater than 0, run the following steps:
-           1. Append |value| to the |set of known objects|
-
-           1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
-              |child ownership|, |set of known objects|, |serialization internal map|
-              and |realm|.
-
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
         <code>handle</code> property set to |handle id| if it's not null, or omitted
-        otherwise, and the <code>value</code> field set to |serialized| if it's not
-        null, or omitted otherwise.
+        otherwise.
+
+    1. [=Set internal ids if needed=] given |serialization internal map|,
+       |remote value| and |value|.
+
+      1. Let |serialized| be null.
+
+      1. If |known object| is <code>false</code>, and |max depth| is not null and
+         greater than 0, run the following steps:
+           1. Let |serialized| be the result of [=serialize as a list=] given
+              [=CreateSetIterator=](|value|, value), |max depth|, |node details|,
+              |child ownership|, |serialization internal map| and |realm|.
+
+    1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+       |serialized|.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
@@ -1794,9 +1806,17 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
+      1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
+         production in the [=local end definition=], with the <code>handle</code>
+         property set to |handle id| if it's not null, or omitted otherwise.
+
+      1. [=Set internal ids if needed=] given |serialization internal map|,
+         |remote value| and |value|.
+
       1. Let |serialized| be null.
 
-      1. If |node details| is true, run the following steps:
+      1. If |known object| is <code>false</code>, and |node details| is true, run the
+         following steps:
 
           1. Let |serialized| be a map.
 
@@ -1822,7 +1842,7 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
                with |child|, |child depth|, |node details|, |child ownership|,
-               |set of known objects|, |serialization internal map| and |realm|.
+               |serialization internal map| and |realm|.
 
             1. Append |serialized| to |children|.
 
@@ -1852,8 +1872,7 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
-                  false, |child ownership|, |set of known objects|,
-                  |serialization internal map| and |realm|.
+                  false, |child ownership|, |serialization internal map| and |realm|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1861,10 +1880,8 @@ a |node details|, an |ownership|, a |set of known objects|, a
 
              1. Set |serialized|["<code>shadowRoot</code>"] to |serialized shadow|.
 
-      1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
-         production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle id| if it's not null, or omitted otherwise,
-         and <code>value</code> set to |serialized|, if |serialized| is not null.
+      1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+         |serialized|.
 
     <dt>|value| is a [=platform object=] that implements {{WindowProxy}}
     <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
@@ -1885,25 +1902,27 @@ a |node details|, an |ownership|, a |set of known objects|, a
     <dd>
     1. [=Assert=]: [=type=](|value|) is Object
 
+    1. Let |remote value| be a map matching the <code>ObjectValue</code> production
+       in the [=local end definition=], with the <code>handle</code> property set
+       to |handle id| if it's not null, or omitted otherwise.
+
+    1. [=Set internal ids if needed=] given |serialization internal map|,
+       |remote value| and |value|.
+
     1. Let |serialized| be null.
 
-    1. If |value| is not in the |set of known objects|, and |max depth|
-       is greater than 0, run the following steps:
-       1. Append |value| to the |set of known objects|
+    1. If |known object| is <code>false</code>, and |max depth| is greater than 0,
+       run the following steps:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |node details|, |child ownership|, |set of known objects|,
-          |serialization internal map| and |realm|.
+          |node details|, |child ownership|, |serialization internal map| and
+          |realm|.
 
-    1. Let |remote value| be a map matching the <code>ObjectValue</code> production
-       in the [=local end definition=], with the <code>handle</code> property set
-       to |handle id| if it's not null, or omitted otherwise, and the
-       <code>value</code> field set to |serialized|.
+    1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+       |serialized|.
+
   </dl>
-
-1. [=Set internal ids if needed=] given |serialization internal map|, |remote value| and
-   |value|.
 
 1. Return |remote value|
 
@@ -1925,8 +1944,7 @@ remove optional flag from the field.
 
 <div algorithm>
 To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
-|node details|, |child ownership|, |set of known objects|,
-|serialization internal map| and |realm|:
+|node details|, |child ownership|, |serialization internal map| and |realm|:
 
   1. Let |serialized| be a new list.
 
@@ -1937,8 +1955,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
        with arguments |child value|, |child depth|, |node details|,
-       |child ownership|, |set of known objects|, |serialization internal map|
-       and |realm|.
+       |child ownership|, |serialization internal map| and |realm|.
 
     1. Append |serialized child| to |serialized|.
 
@@ -1948,9 +1965,8 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|,
 Issue: this assumes for-in works on iterators
 
 <div algorithm>
-To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
-|node details|, |child ownership|, |set of known objects|,
-|serialization internal map| and |realm|:
+To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|, |node details|,
+|child ownership|, |serialization internal map| and |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -1970,11 +1986,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
      with arguments |child key|, |child depth|, |node details|,
-     |set of known objects|, |serialization internal map| and |realm|.
+     |serialization internal map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
      with arguments |value|, |child depth|, |node details|, |child ownership|,
-     |set of known objects|, |serialization internal map| and |realm|.
+     |serialization internal map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).
 
@@ -3430,8 +3446,7 @@ To <dfn>get exception details</dfn> given a |realm| and a [=completion record=] 
 
 1. Let |exception| be the result of [=serialize as a remote value=] given
    |record|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>root</code> as |ownership|, <code>new set</code>
-   as |set of known objects|, <code>new map</code> as
+   |node details|, <code>root</code> as |ownership|, <code>new map</code> as
    |serialization internal map| and |realm|.
 
 1. Let |stack trace| be the [=stack trace for an exception=] given |record|.
@@ -4010,9 +4025,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code>
-   as |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects|, <code>new map</code> as |serialization internal map|
-   and |realm|.
+   as |node details|, <code>root</code> as |ownership|, <code>new map</code> as
+   |serialization internal map| and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
@@ -4107,9 +4121,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |result| be the result of [=serialize as a remote value=] given
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, <code>true</code> as
-   |node details|, <code>root</code> as |ownership|, <code>new set</code> as
-   |set of known objects|, <code>new map</code> as |serialization internal map|
-    and |realm|.
+   |node details|, <code>root</code> as |ownership|, <code>new map</code> as
+   |serialization internal map| and |realm|.
 
 1. Return a new map matching the <code>ScriptResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and

--- a/index.bs
+++ b/index.bs
@@ -1009,17 +1009,17 @@ Issue: Define how this works.
 
 ## Reference ## {#data-types-reference}
 
-Each EMCAScript [=Realm=] has a corresponding <dfn>object id map</dfn>. This is a weak map
-from objects to their corresponding id.
+Each EMCAScript [=Realm=] has a corresponding <dfn>handle map</dfn>. This is a strong map
+from objects to their corresponding handle id.
 
 <dfn>RemoteReference</dfn> represents a remote reference to an exising ECMAScript object in
-[=object id map=] in the given [=Realm=].
+[=handle map=] in the given [=Realm=].
 
 ```
-ObjectId = text;
+Handle = text;
 
 RemoteReference = {
-   objectId: ObjectId,
+   handle: Handle,
    *text => any,
 }
 ```
@@ -1029,11 +1029,11 @@ Issue: handle "stale object reference" case.
 <div algorithm>
 To <dfn>deserialize remote reference</dfn> given |realm| and |remote reference|:
 
-1. Let |object id| be the value of the <code>objectId</code> field of |remote reference|.
+1. Let |handle| be the value of the <code>handle</code> field of |remote reference|.
 
-1. For each |object| → |id value| of the given |realm|'s [=object id map=]:
+1. For each |object| → |handle value| of the given |realm|'s [=handle map=]:
 
-  1. If |id value| is equal to |object id|, return [=success=] with data
+  1. If |handle value| is equal to |handle|, return [=success=] with data
      |object|
 
 1. Return [=error=] with [=error code=] [=invalid argument=].
@@ -1408,7 +1408,7 @@ the <code>type</code> property. In the case of JSON-representable primitive
 values, this contains the value in the <code>value</code> property; in the case
 of non-JSON-representable primitives, the <code>value</code> property contains a
 string representation of the value. For non-primitive objects, the
-<code>objectId</code> property contains a string id that provides a unique
+<code>handle</code> property contains a string id that provides a unique
 handle to the object, valid for its lifetime inside the engine. For some
 non-primitive types, the <code>value</code> property contains a representation
 of the data in the ECMAScript object; for container types this can contain
@@ -1427,21 +1427,21 @@ object is discarded in the runtime, subsequent attempts to access it via the
 protocol will result in an error.
 
 <div algorithm>
-To get the <dfn>object id for an object</dfn> given |realm|, |ownership|
+To get the <dfn>handle for an object</dfn> given |realm|, |ownership|
 and |object|:
 
 1. If |ownership| is equal <code>none</code>, return <code>null</code>.
 
-1. If the given |realm|'s [=object id map=] does not contain |object|, run the
+1. If the given |realm|'s [=handle map=] does not contain |object|, run the
    following steps:
 
-  1. Let |object id| be a new, unique, string identifier for |object|. If |object| is an
+  1. Let |handle| be a new, unique, string identifier for |object|. If |object| is an
      [=/element=] this must be the [=web element reference=] for |object|; if it's a {{WindowProxy}}
      object, this must be the [=browsing context id=] for |object|.
 
-  1. Set the value of |object| in |realm|'s [=object id map=] to |object id|.
+  1. Set the value of |object| in |realm|'s [=handle map=] to |handle|.
 
-1. Return the result of getting the value for |object| in |realm|'s [=object id map=].
+1. Return the result of getting the value for |object| in |realm|'s [=handle map=].
 
 </div>
 
@@ -1476,96 +1476,96 @@ MappingRemoteValue = [*[(RemoteValue / text), RemoteValue]];
 
 SymbolRemoteValue = {
    type: "symbol",
-   ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 ArrayRemoteValue = {
   type: "array",
-  ?objectId: ObjectId,
+   ?handle: Handle,
   ?value: ListRemoteValue,
 }
 
 ObjectRemoteValue = {
   type: "object",
-  ?objectId: ObjectId,
+   ?handle: Handle,
   ?value: MappingRemoteValue,
 }
 
 FunctionRemoteValue = {
    type: "function",
-   ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 RegExpRemoteValue = {
    RegExpLocalValue,
-   ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 DateRemoteValue = {
   DateLocalValue,
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 MapRemoteValue = {
   type: "map",
-  ?objectId: ObjectId,
+   ?handle: Handle,
   value: MappingRemoteValue,
 }
 
 SetRemoteValue = {
   type: "set",
-  ?objectId: ObjectId,
+   ?handle: Handle,
   value: ListRemoteValue
 }
 
 WeakMapRemoteValue = {
   type: "weakmap",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 WeakSetRemoteValue = {
   type: "weakset",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 IteratorRemoteValue = {
   type: "iterator",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 GeneratorRemoteValue = {
   type: "generator",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 ErrorRemoteValue = {
   type: "error",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 ProxyRemoteValue = {
   type: "proxy",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 PromiseRemoteValue = {
   type: "promise",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 TypedArrayRemoteValue = {
   type: "typedarray",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 ArrayBufferRemoteValue = {
   type: "arraybuffer",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 
 NodeRemoteValue = {
   type: "node",
-  ?objectId: ObjectId,
+   ?handle: Handle,
   ?value: NodeProperties,
 }
 
@@ -1582,7 +1582,7 @@ NodeProperties = {
 
 WindowProxyRemoteValue = {
   type: "window",
-  ?objectId: ObjectId,
+   ?handle: Handle,
 }
 ```
 
@@ -1616,7 +1616,7 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 1. In the following list of conditions and associated steps, run the first set
    of steps for which the associated condition is true:
 
-1. Let |objectId| be the [=object id for an object=] given |realm|, |ownership|
+1. Let |handle| be the [=handle for an object=] given |realm|, |ownership|
    and |value|.
 
 1. Let |child ownership| be <code>none</code>.
@@ -1627,8 +1627,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
   <dl>
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a map matching the <code>SymbolRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
     <dd>
@@ -1643,8 +1643,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
               |child ownership|, |set of known objects| and |realm|.
 
     1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
-       production in the [=local end definition=], with the <code>objectId</code>
-       property set to |objectId| if it's not null, or omitted otherwise, and the
+       production in the [=local end definition=], with the <code>handle</code>
+       property set to |handle| if it's not null, or omitted otherwise, and the
        <code>value</code> field set to |serialized| if it's not null, or omitted
        otherwise.
 
@@ -1659,8 +1659,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
            |pattern| and the the <code>flags</code> property set to the |flags|.
 
         1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
-           production in the [=local end definition=], with the <code>objectId</code>
-           property set to |objectId| if it's not null, or omitted otherwise, and
+           production in the [=local end definition=], with the <code>handle</code>
+           property set to |handle| if it's not null, or omitted otherwise, and
            the <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
@@ -1668,8 +1668,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
       1. Let |serialized| be [=Date.ToDateString=]([=thisTimeValue=](|value|)).
 
       1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
-         production in the [=local end definition=], with the <code>objectId</code>
-         property set to |objectId| if it's not null, or omitted otherwise, and the
+         production in the [=local end definition=], with the <code>handle</code>
+         property set to |handle| if it's not null, or omitted otherwise, and the
          value set to |serialized|.
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
@@ -1686,7 +1686,7 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
     1. Let |remote value| be a map matching the <code>MapRemoteValue</code>
        production in the [=local end definition=], with the
-       <code>objectId</code> property set to |objectId| if it's not null, or omitted
+       <code>handle</code> property set to |handle| if it's not null, or omitted
        otherwise, and the <code>value</code> field set to |serialized| if it's not
        null, or omitted otherwise.
 
@@ -1704,39 +1704,39 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
 
      1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
         production in the [=local end definition=], with the
-        <code>objectId</code> property set to |objectId| if it's not null, or omitted
+        <code>handle</code> property set to |handle| if it's not null, or omitted
         otherwise, and the <code>value</code> field set to |serialized| if it's not
         null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakMapRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>WeakSetRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ErrorRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>[=IsPromise=](|value|)
     <dd>Let |remote value| be a map matching the <code>PromiseRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>TypedArrayRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
     <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -1800,31 +1800,31 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
                   false, |child ownership|, |set of known objects| and |realm|.
 
-                Note: this means the <code>objectId</code> for the shadow root
+                Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
                 but no properties of the node will be returned.
 
              1. Set |serialized|["<code>shadowRoot</code>"] to |serialized shadow|.
 
       1. Let |remote value| be a map matching the <code>NodeRemoteValue</code>
-         production in the [=local end definition=], with the <code>objectId</code>
-         property set to |objectId| if it's not null, or omitted otherwise,
+         production in the [=local end definition=], with the <code>handle</code>
+         property set to |handle| if it's not null, or omitted otherwise,
          and <code>value</code> set to |serialized|, if |serialized| is not null.
 
     <dt>|value| is a [=platform object=] that implements {{WindowProxy}}
     <dd>1. Let |remote value| be a map matching the <code>WindowProxyValue</code>
-           production in the [=local end definition=], with the <code>objectId</code>
-           property set to |objectId| if it's not null, or omitted otherwise.
+           production in the [=local end definition=], with the <code>handle</code>
+           property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a map matching the <code>ObjectValue</code>
-           production in the [=local end definition=], with the <code>objectId</code>
-           property set to |objectId| if it's not null, or omitted otherwise.
+           production in the [=local end definition=], with the <code>handle</code>
+           property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>[=IsCallable=](|value|)
     <dd>Let |remote value| be a map matching the <code>FunctionValue</code>
-        production in the [=local end definition=], with the <code>objectId</code>
-        property set to |objectId| if it's not null, or omitted otherwise.
+        production in the [=local end definition=], with the <code>handle</code>
+        property set to |handle| if it's not null, or omitted otherwise.
 
     <dt>Otherwise:
     <dd>
@@ -1842,8 +1842,8 @@ a |node details|, an |ownership|, a |set of known objects| and a |realm|:
           |realm|.
 
     1. Let |remote value| be a map matching the <code>ObjectValue</code> production
-       in the [=local end definition=], with the <code>objectId</code> property set
-       to |objectId| if it's not null, or omitted otherwise, and the
+       in the [=local end definition=], with the <code>handle</code> property set
+       to |handle| if it's not null, or omitted otherwise, and the
        <code>value</code> field set to |serialized|.
   </dl>
 
@@ -3743,6 +3743,14 @@ To <dfn>get a realm from a target</dfn> given |target|:
 
 Issue: This has the wrong error code
 </div>
+
+#### The script.Ownership type #### {#type-script-Ownership}
+
+<pre class="cddl local-cddl remote-cddl">
+SerializationOwnershipModel = "root" // "none"
+
+The <code>SerializationOwnershipModel</code> specifies how the serialized value
+ownership should be treated.
 
 
 ### Commands ### {#module-script-commands}


### PR DESCRIPTION
Step 2 towards addressing #90 and implementing the [proposal](https://github.com/w3c/webdriver-bidi/issues/90#issuecomment-1111052638).

* Add `ownership` logic into serialization with default `root`: https://github.com/w3c/webdriver-bidi/issues/90#issuecomment-1111052638.
* Rename `objectId` -> `handle`.
* Make `handle map` a strong reference.
* Make `handle`-`object` a many-to-one relation.
* Cyclic reference serialization via `internalId` field.
* `script.disown` command.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/206.html" title="Last updated on May 25, 2022, 10:05 AM UTC (94e7cbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/206/f11e1fd...94e7cbf.html" title="Last updated on May 25, 2022, 10:05 AM UTC (94e7cbf)">Diff</a>