### PR TITLE
Add a CI job to check for warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
 
 jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.x
+      - name: Build spec without warnings
+        run: ./scripts/build.sh --install
   cddl:
     runs-on: ubuntu-18.04
     steps:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -ex
+
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+ROOT=$(dirname $SCRIPT_DIR)
+
+if [ "$1" = "--install" ]; then
+    pip install bikeshed
+fi
+
+bikeshed --die-on=warning spec index.bs


### PR DESCRIPTION
This attempts a build and fails the job if there are any warnings.