### PR TITLE
Rename `ownership` to `resultOwnership` in `script.callFunction`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3902,7 +3902,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         ?this: ArgumentValue;
         ?awaitPromise: bool;
         target: Target;
-        ?ownership: OwnershipModel;
+        ?resultOwnership: OwnershipModel;
       }
 
       ArgumentValue = (


### PR DESCRIPTION
Unify `script.evaluate` and `script.callFunction`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/221.html" title="Last updated on Jun 6, 2022, 4:04 PM UTC (eb08a32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/221/7869374...eb08a32.html" title="Last updated on Jun 6, 2022, 4:04 PM UTC (eb08a32)">Diff</a>