### PR TITLE
Fix calling "serialize as a list" for arrays by passing-in the child ownership information

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1708,7 +1708,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
        greater than 0, run the following steps:
 
            1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateArrayIterator=](|value|, value), |max depth|,
+              [=CreateArrayIterator=](|value|, value), |max depth|, |child ownership|,
               |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to


### PR DESCRIPTION
Fixes issue #227.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/228.html" title="Last updated on Jun 8, 2022, 11:52 AM UTC (fc4a1f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/228/bc6aea5...whimboo:fc4a1f0.html" title="Last updated on Jun 8, 2022, 11:52 AM UTC (fc4a1f0)">Diff</a>