### PR TITLE
Add missing child ownership argument when serializing a key

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1990,8 +1990,8 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with arguments |child key|, |child depth|, |serialization internal map| and
-     |realm|.
+     with arguments |child key|, |child depth|, |child ownership|,
+     |serialization internal map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
      with arguments |value|, |child depth|, |child ownership|,


### PR DESCRIPTION
Closes #233


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/234.html" title="Last updated on Jun 10, 2022, 8:14 AM UTC (4190171)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/234/1a78f48...lutien:4190171.html" title="Last updated on Jun 10, 2022, 8:14 AM UTC (4190171)">Diff</a>