### PR TITLE
Make `awaitPromise` param obligatory.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1578,16 +1578,16 @@ DateRemoteValue = {
 
 MapRemoteValue = {
   type: "map",
+  value: MappingRemoteValue,
   ?handle: Handle,
   ?internalId: InternalId,
-  value: MappingRemoteValue,
 }
 
 SetRemoteValue = {
   type: "set",
+  value: ListRemoteValue
   ?handle: Handle,
   ?internalId: InternalId,
-  value: ListRemoteValue
 }
 
 WeakMapRemoteValue = {
@@ -1654,9 +1654,9 @@ NodeRemoteValue = {
 NodeProperties = {
   nodeType: uint,
   nodeValue: text,
+  childNodeCount: uint,
   ?localName: text,
   ?namespaceURI: text,
-  childNodeCount: uint,
   ?children: [*NodeRemoteValue],
   ?attributes: {*text => text},
   ?shadowRoot: NodeRemoteValue / null,
@@ -2540,9 +2540,9 @@ BrowsingContextInfoList = [* BrowsingContextInfo]
 
 BrowsingContextInfo = {
   context: BrowsingContext,
-  ?parent: BrowsingContext / null,
   url: text,
   children: BrowsingContextInfoList / null
+  ?parent: BrowsingContext / null,
 }
 
 </pre>
@@ -4185,9 +4185,9 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
       ScriptCallFunctionParameters = {
         functionDeclaration: text;
         awaitPromise: bool;
+        target: Target;
         ?arguments: [ArgumentValue];
         ?this: ArgumentValue;
-        target: Target;
         ?resultOwnership: OwnershipModel;
       }
 

--- a/index.bs
+++ b/index.bs
@@ -4186,7 +4186,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         functionDeclaration: text;
         ?arguments: [ArgumentValue];
         ?this: ArgumentValue;
-        ?sync: bool;
+        ?awaitPromise: bool;
         target: Target;
         ?resultOwnership: OwnershipModel;
       }
@@ -4277,8 +4277,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
-1. Let |sync| be the value of the <code>sync</code> field of
-   |command parameters|, if present, or <code>false</code> otherwise.
+1. Let |await promise| be the value of the <code>awaitPromise</code> field of
+   |command parameters|, if present, or <code>true</code> otherwise.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.
@@ -4300,8 +4300,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Set |evaluation status| to
    [=Call=](|function object|, |this object|, |deserialized arguments|).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |sync| is
-   <code>false</code>, and [=IsPromise=](|evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is
+   <code>true</code>, and [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to
       <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
@@ -4336,7 +4336,7 @@ place of a realm, in which case the realm used is the realm of the browsing
 context's active document.
 
 The method returns the value of executing the provided script, unless it returns
-a promise and <code>sync</code> is false (which is the default), in which
+a promise and <code>awaitPromise</code> is true (which is the default), in which
 case the resolved value of the promise is returned.
 
 <dl>
@@ -4351,7 +4351,7 @@ case the resolved value of the promise is returned.
       ScriptEvaluateParameters = {
         expression: text;
         target: Target;
-        ?sync: bool;
+        ?awaitPromise: bool;
         ?resultOwnership: OwnershipModel;
       }
       </pre>
@@ -4381,7 +4381,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |source| be the value of the <code>expression</code> field of |command
    parameters|.
 
-1. Let |sync| be the value of the <code>sync</code> field of
+1. Let |await promise| be the value of the <code>awaitPromise</code> field of
    |command parameters|, if present, or <code>true</code> otherwise.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
@@ -4398,8 +4398,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Set |evaluation status| to [=ScriptEvaluation=](|script|'s record).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, |sync| is false, and
-   [=IsPromise=](|evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
+   true, and [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
 

--- a/index.bs
+++ b/index.bs
@@ -4186,7 +4186,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         functionDeclaration: text;
         ?arguments: [ArgumentValue];
         ?this: ArgumentValue;
-        ?awaitPromise: bool;
+        ?sync: bool;
         target: Target;
         ?resultOwnership: OwnershipModel;
       }
@@ -4277,8 +4277,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |function declaration| be the value of the
    <code>functionDeclaration</code> field of |command parameters|.
 
-1. Let |await promise| be the value of the <code>awaitPromise</code> field of
-   |command parameters|, if present, or <code>true</code> otherwise.
+1. Let |sync| be the value of the <code>sync</code> field of
+   |command parameters|, if present, or <code>false</code> otherwise.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.
@@ -4300,8 +4300,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Set |evaluation status| to
    [=Call=](|function object|, |this object|, |deserialized arguments|).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |await promise| is
-   <code>true</code>, and [=IsPromise=](|evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, and |sync| is
+   <code>false</code>, and [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to
       <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
@@ -4336,7 +4336,7 @@ place of a realm, in which case the realm used is the realm of the browsing
 context's active document.
 
 The method returns the value of executing the provided script, unless it returns
-a promise and <code>awaitPromise</code> is true (which is the default), in which
+a promise and <code>sync</code> is false (which is the default), in which
 case the resolved value of the promise is returned.
 
 <dl>
@@ -4351,7 +4351,7 @@ case the resolved value of the promise is returned.
       ScriptEvaluateParameters = {
         expression: text;
         target: Target;
-        ?awaitPromise: bool;
+        ?sync: bool;
         ?resultOwnership: OwnershipModel;
       }
       </pre>
@@ -4381,7 +4381,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |source| be the value of the <code>expression</code> field of |command
    parameters|.
 
-1. Let |await promise| be the value of the <code>awaitPromise</code> field of
+1. Let |sync| be the value of the <code>sync</code> field of
    |command parameters|, if present, or <code>true</code> otherwise.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
@@ -4398,8 +4398,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Set |evaluation status| to [=ScriptEvaluation=](|script|'s record).
 
-1. If |evaluation status|.\[[Type]] is <code>normal</code>, |await promise| is
-   true, and [=IsPromise=](|evaluation status|.\[[Value]]):
+1. If |evaluation status|.\[[Type]] is <code>normal</code>, |sync| is false, and
+   [=IsPromise=](|evaluation status|.\[[Value]]):
 
    1. Set |evaluation status| to <a spec=ECMASCRIPT>Await</a>(|evaluation status|.\[[Value]]).
 

--- a/index.bs
+++ b/index.bs
@@ -4184,9 +4184,9 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
 
       ScriptCallFunctionParameters = {
         functionDeclaration: text;
+        awaitPromise: bool;
         ?arguments: [ArgumentValue];
         ?this: ArgumentValue;
-        ?awaitPromise: bool;
         target: Target;
         ?resultOwnership: OwnershipModel;
       }
@@ -4278,7 +4278,7 @@ The [=remote end steps=] with |command parameters| are:
    <code>functionDeclaration</code> field of |command parameters|.
 
 1. Let |await promise| be the value of the <code>awaitPromise</code> field of
-   |command parameters|, if present, or <code>true</code> otherwise.
+   |command parameters|.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.
@@ -4336,8 +4336,8 @@ place of a realm, in which case the realm used is the realm of the browsing
 context's active document.
 
 The method returns the value of executing the provided script, unless it returns
-a promise and <code>awaitPromise</code> is true (which is the default), in which
-case the resolved value of the promise is returned.
+a promise and <code>awaitPromise</code> is true, in which case the resolved value of
+the promise is returned.
 
 <dl>
    <dt>Command Type</dt>
@@ -4351,7 +4351,7 @@ case the resolved value of the promise is returned.
       ScriptEvaluateParameters = {
         expression: text;
         target: Target;
-        ?awaitPromise: bool;
+        awaitPromise: bool;
         ?resultOwnership: OwnershipModel;
       }
       </pre>
@@ -4382,7 +4382,7 @@ The [=remote end steps=] with |command parameters| are:
    parameters|.
 
 1. Let |await promise| be the value of the <code>awaitPromise</code> field of
-   |command parameters|, if present, or <code>true</code> otherwise.
+   |command parameters|.
 
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.


### PR DESCRIPTION
https://github.com/w3c/webdriver-bidi/issues/238

Make `awaitPromise` obligatory to avoid confusion by default `true` value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/239.html" title="Last updated on Jun 22, 2022, 11:41 AM UTC (d18d927)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/239/0825f8b...d18d927.html" title="Last updated on Jun 22, 2022, 11:41 AM UTC (d18d927)">Diff</a>