### PR TITLE
Handle invalid script in `script.callFunction`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4286,8 +4286,15 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |function body evaluation status| be the result of [=evaluate function body=]
    (|function declaration|, |environment settings|, |base URL|, and |options|).
 
-1. If |function body evaluation status|.\[[Type]] is <code>throw</code>, return [=error=] with
-   [=error code=] [=invalid argument=].
+1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
+
+   1. Let |exception details| be the result of [=get exception details=] given
+      |realm|, |function body evaluation status| as |record| and |result ownership|
+      as |ownership type|.
+
+   1. Return a new map matching the <code>ScriptEvaluateResultException</code>
+      production, with the <code>exceptionDetails</code> field set to
+      |exception details|.
 
 1. Let |function object| be |function body evaluation status|.\[[Value]].
 


### PR DESCRIPTION
Unify the way `script.callFunction` and `script.evaluate` handles invalid JS. Consider such a request as a successful on the transport level.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/242.html" title="Last updated on Jun 22, 2022, 2:57 PM UTC (1eee0fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/242/50d5abe...1eee0fe.html" title="Last updated on Jun 22, 2022, 2:57 PM UTC (1eee0fe)">Diff</a>