### PR TITLE
Ensure realm ids are different from handles or context ids

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3730,6 +3730,13 @@ Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm. This is implicitly set when the realm is
 created.
 
+The [=realm id=] for a realm is opaque and must not be derivable from the handle
+id of the corresponding global object in the [=handle object map=] or, where
+relevant, from the [=browsing context id=] of any [=/browsing context=].
+
+Note: this is to ensure that users do not rely on implementation-specific
+relationships between different ids.
+
 <div algorithm>
 To <dfn>get a realm</dfn> given |realm id|:
 


### PR DESCRIPTION
This is to prevent some implementations making e.g. the realm id for a
Window object equal to the handle for that object, and clients
starting to rely on those things always being the same.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/248.html" title="Last updated on Jun 24, 2022, 1:45 PM UTC (91094ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/248/3ca8428...91094ec.html" title="Last updated on Jun 24, 2022, 1:45 PM UTC (91094ec)">Diff</a>