### PR TITLE
Always add `parent` to `BrowsingContextInfo`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2547,7 +2547,7 @@ BrowsingContextInfo = {
   context: BrowsingContext,
   url: text,
   children: BrowsingContextInfoList / null
-  ?parent: BrowsingContext / null,
+  parent: BrowsingContext / null,
 }
 
 </pre>
@@ -2556,8 +2556,7 @@ The <code>BrowsingContextInfo</code> type represents the properties of a
 browsing context.
 
 <div algorithm>
-To <dfn>get the browsing context info</dfn> given |context|,
-|max depth| and |is root|:
+To <dfn>get the browsing context info</dfn> given |context| and |max depth|:
 
 1. Let |context id| be the [=browsing context id=] for |context|.
 
@@ -2584,16 +2583,16 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
   1. For each |context| of |child contexts|:
 
-    1. Let |info| be the result of [=get the browsing context info=] given
-       |context|, |child depth|, and false.
+    1. Let |info| be the result of [=get the browsing context info=] given |context|
+       and |child depth|.
 
     1. Append |info| to |child infos|
 
 1. Let |context info| be a [=map=] matching the
-   <code>BrowsingContextInfo</code> production with the <code>context</code>
-   field set to |context id|, the <code>parent</code> field set to |parent id|
-   if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, and the <code>children</code> field set to |child infos|.
+   <code>BrowsingContextInfo</code> production with the <code>context</code> field
+   set to |context id|, the <code>parent</code> field set to |parent id|, the
+   <code>url</code> field set to |url|, and the <code>children</code> field set to
+   |child infos|.
 
 1. Return |context info|.
 
@@ -2957,7 +2956,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. For each |context| of |contexts|:
 
   1. Let |info| be the result of [=get the browsing context info=] given
-     |context|, |max depth|, and true.
+     |context|, |max depth|.
 
   1. Append |info| to |contexts info|
 
@@ -3186,7 +3185,7 @@ To <dfn>Recursively emit context created events</dfn> given |session| and |conte
 To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=] given
-   |context|, 0, and true.
+   |context|, 0.
 
 1. Let |body| be a [=map=] matching the
    <code>BrowsingContextCreatedEvent</code> production, with the
@@ -3248,7 +3247,7 @@ Define the following [=browsing context tree discarded=] steps:
 1. Let |context| be the browsing context being discarded.
 
 1. Let |params| be the result of [=get the browsing context info=], given
-   |context|, 0, and true.
+   |context|, 0.
 
 1. Let |body| be a [=map=] matching the
     <code>BrowsingContextDestroyedEvent</code> production, with the


### PR DESCRIPTION
Suggestion to always provide `parent` when serialising `BrowsingContextInfo`. Current approach can be confusing, and doesn't allow to process contexts received by `getTree` recursively, and requires to pass `parent` to process each child.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/250.html" title="Last updated on Jun 28, 2022, 11:56 AM UTC (87b4792)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/250/007295e...87b4792.html" title="Last updated on Jun 28, 2022, 11:56 AM UTC (87b4792)">Diff</a>