### PR TITLE
Align serialization format with EcmaScript

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1099,7 +1099,7 @@ StringValue = {
   value: text,
 }
 
-SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
+SpecialNumber = "NaN" / "-0" / "Infinity" / "-Infinity";
 
 NumberValue = {
   type: "number",
@@ -1152,8 +1152,8 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
         <dd>Let |serialized| be <code>"NaN"</code>
         <dt>-0
         <dd>Let |serialized| be <code>"-0"</code>
-        <dt>+Infinity
-        <dd>Let |serialized| be <code>"+Infinity"</code>
+        <dt>Infinity
+        <dd>Let |serialized| be <code>"Infinity"</code>
         <dt>-Infinity
         <dd>Let |serialized| be <code>"-Infinity"</code>
         <dt>Otherwise:

--- a/index.bs
+++ b/index.bs
@@ -1170,10 +1170,13 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
         property set to |value|.
 
     <dt>[=Type=](|value|) is BigInt
-    <dd>Let |remote value| be a map matching the <code>BigIntValue</code>
+    <dd>
+    1. Let |string value| be the result of running the [=ToString=] operation on
+       |value|.
+    2. Let |ECMAScript value| be [=concatenate=] «|string value|, "<code>n</code>"».
+    3. Let |remote value| be a map matching the <code>BigIntValue</code>
         production in the [=local end definition=], with the <code>value</code>
-        property set to the result of running the [=ToString=] operation on
-        |value|.
+        property set to |ECMAScript value|.
 
   </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -1170,13 +1170,10 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
         property set to |value|.
 
     <dt>[=Type=](|value|) is BigInt
-    <dd>
-    1. Let |string value| be the result of running the [=ToString=] operation on
-       |value|.
-    2. Let |ECMAScript value| be [=concatenate=] «|string value|, "<code>n</code>"».
-    3. Let |remote value| be a map matching the <code>BigIntValue</code>
+    <dd>Let |remote value| be a map matching the <code>BigIntValue</code>
         production in the [=local end definition=], with the <code>value</code>
-        property set to |ECMAScript value|.
+        property set to the result of running the [=ToString=] operation on
+        |value|.
 
   </dl>
 


### PR DESCRIPTION
It's a bit late, as we have already WPT tests for this part landed, but it's not too late, as it's still in development. Maybe we can align serialization with the ECMAScript:

1. As ECMAScript doesn't have `+Infinity`, I suggest to use `Infinity` instead of `+Infinity` in the serialization as well.
~~2. (Discussible, no strong opinion here) add suffix `n` at the end of BigInt's `value`, so that it can be evaluated directly.~~


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/254.html" title="Last updated on Jul 7, 2022, 1:11 PM UTC (d9e5515)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/254/007295e...d9e5515.html" title="Last updated on Jul 7, 2022, 1:11 PM UTC (d9e5515)">Diff</a>