### PR TITLE
Fix indentation for Serialization steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1736,29 +1736,29 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>[=IsRegExp=](|value|)
     <dd>
-        1. Let |pattern| be [=ToString=]([=Get=](|value|, "source")).
+    1. Let |pattern| be [=ToString=]([=Get=](|value|, "source")).
 
-        1. Let |flags| be [=ToString=]([=Get=](|value|, "flags")).
+    1. Let |flags| be [=ToString=]([=Get=](|value|, "flags")).
 
-        1. Let |value| be a map matching the <code>RegExpValue</code> production in the
-           [=local end definition=], with the <code>pattern</code> property set to the
-           |pattern| and the the <code>flags</code> property set to the |flags|.
+    1. Let |value| be a map matching the <code>RegExpValue</code> production in the
+       [=local end definition=], with the <code>pattern</code> property set to the
+       |pattern| and the the <code>flags</code> property set to the |flags|.
 
-        1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
-           production in the [=local end definition=], with the <code>handle</code>
-           property set to |handle id| if it's not null, or omitted otherwise, and
-           the <code>value</code> property set to |value|.
+    1. Let |remote value| be a map matching the <code>RegExpRemoteValue</code>
+       production in the [=local end definition=], with the <code>handle</code>
+       property set to |handle id| if it's not null, or omitted otherwise, and
+       the <code>value</code> property set to |value|.
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>
-      1. Set |serialized| to [=Call=]([=Date.toISOString=], |value|).
+    1. Set |serialized| to [=Call=]([=Date.toISOString=], |value|).
 
-      1. Assert: |serialized| is not a [=throw completion=].
+    1. Assert: |serialized| is not a [=throw completion=].
 
-      1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
-         production in the [=local end definition=], with the <code>handle</code>
-         property set to |handle id| if it's not null, or omitted otherwise, and the
-         value set to |serialized|.
+    1. Let |remote value| be a map matching the <code>DateRemoteValue</code>
+       production in the [=local end definition=], with the <code>handle</code>
+       property set to |handle id| if it's not null, or omitted otherwise, and the
+       value set to |serialized|.
 
     <dt>|value| has a \[[MapData]] [=internal slot=]
     <dd>
@@ -1771,35 +1771,36 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     1. [=Set internal ids if needed=] given |serialization internal map|,
        |remote value| and |value|.
 
-      1. Let |serialized| be null.
+    1. Let |serialized| be null.
 
-      1. If |known object| is <code>false</code>, and |max depth| is not null and
-         greater than 0, run the following steps:
+    1. If |known object| is <code>false</code>, and |max depth| is not null and
+       greater than 0, run the following steps:
 
-           1. Let |serialized| be the result of [=serialize as a mapping=] given
-              [=CreateMapIterator=](|value|, key+value), |max depth|,
-              |child ownership|, |serialization internal map| and |realm|.
+       1. Let |serialized| be the result of [=serialize as a mapping=] given
+          [=CreateMapIterator=](|value|, key+value), |max depth|,
+          |child ownership|, |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
 
     <dt>|value| has a \[[SetData]] [=internal slot=]
     <dd>
-     1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
-        production in the [=local end definition=], with the
-        <code>handle</code> property set to |handle id| if it's not null, or omitted
-        otherwise.
+    1. Let |remote value| be a map matching the <code>SetRemoteValue</code>
+       production in the [=local end definition=], with the
+       <code>handle</code> property set to |handle id| if it's not null, or omitted
+       otherwise.
 
     1. [=Set internal ids if needed=] given |serialization internal map|,
        |remote value| and |value|.
 
-      1. Let |serialized| be null.
+    1. Let |serialized| be null.
 
-      1. If |known object| is <code>false</code>, and |max depth| is not null and
-         greater than 0, run the following steps:
-           1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,
-              |serialization internal map| and |realm|.
+    1. If |known object| is <code>false</code>, and |max depth| is not null and
+       greater than 0, run the following steps:
+
+       1. Let |serialized| be the result of [=serialize as a list=] given
+          [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,
+          |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.


### PR DESCRIPTION
Fixes #260

The indentation for MapData and SetData serialization have been fixed to avoid unnecessary nesting of steps. 
I tried to roughly follow how the indentation was handled in this section, but it's highly inconsistent overall in the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/261.html" title="Last updated on Aug 23, 2022, 2:19 PM UTC (da4c0fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/261/64563c2...juliandescottes:da4c0fb.html" title="Last updated on Aug 23, 2022, 2:19 PM UTC (da4c0fb)">Diff</a>