### PR TITLE
Add definition of RealmType

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3818,6 +3818,9 @@ WorkletRealmInfo = {
 }
 </pre>
 
+Note: there's a 1:1 relationship between the <code>RealmInfo</code> variants and values of
+      <a href="#type-script-RealmType"><code>RealmType</code></a>.
+
 The <code>RealmInfo</code> type represents the properties of a realm.
 
 <div algorithm>
@@ -3898,8 +3901,21 @@ Note: Future variations of this specification will retain the invariant that
          will always be "<code>worker</code>" for globals implementing
          {{WorkerGlobalScope}}, and "<code>worklet</code>" for globals
          implementing {{WorkletGlobalScope}}.
-
 </div>
+
+#### The script.RealmType type ####  {#type-script-RealmType}
+
+[=Local end definition=]
+
+<pre class="cddl local-cddl">
+RealmType = {
+  type: "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
+        "worker" / "paint-worklet" / "audio-worklet" / "worklet";
+}
+</pre>
+
+The <code>RealmType</code> type represents the different types of Realm.
+
 
 #### The script.StackFrame type #### {#types-script-StackFrame}
 

--- a/index.bs
+++ b/index.bs
@@ -3908,10 +3908,8 @@ Note: Future variations of this specification will retain the invariant that
 [=Local end definition=]
 
 <pre class="cddl local-cddl">
-RealmType = {
-  type: "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
-        "worker" / "paint-worklet" / "audio-worklet" / "worklet";
-}
+RealmType = "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
+                       "worker" / "paint-worklet" / "audio-worklet" / "worklet"
 </pre>
 
 The <code>RealmType</code> type represents the different types of Realm.


### PR DESCRIPTION
We need a RealmType production that allows only valid names of Realms. Each
corresponds to a specific RealmInfo variant.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/269.html" title="Last updated on Sep 6, 2022, 10:31 AM UTC (967ad19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/269/baf6726...967ad19.html" title="Last updated on Sep 6, 2022, 10:31 AM UTC (967ad19)">Diff</a>