### PR TITLE
Allow parsing of pre tags for multiple CDDL names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2351,8 +2351,8 @@ Issue: This needs to be generalized to work with realms too
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
-        EmptyResult
+    <pre class="cddl">
+      EmptyResult
     </pre>
    </dd>
 </dl>
@@ -2419,9 +2419,9 @@ Issue: This needs to be generalised to work with realms too
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
-        EmptyResult
-      </pre>
+    <pre class="cddl">
+      EmptyResult
+    </pre>
    </dd>
 </dl>
 
@@ -2991,7 +2991,7 @@ command allows closing an open prompt
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl">
       EmptyResult
     </pre>
    </dd>
@@ -4211,7 +4211,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl">
       ScriptEvaluateResult
     </pre>
    </dd>
@@ -4374,7 +4374,7 @@ the promise is returned.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl">
     ScriptEvaluateResult
    </pre>
    </dd>


### PR DESCRIPTION
Fix #275.

Until now the parsing of the individual `pre` tags did not allow multiple CDDL names to be listed. This resulted in writing these entries only to the file which name was listed last in the `pre` class name.

Also I removed filtering out of lines that miss a declaration. This actually drops lines unexpectedly. Instead we should get the validation step fail and report it appropriately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/276.html" title="Last updated on Sep 9, 2022, 10:34 AM UTC (5fbe1aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/276/22530a8...whimboo:5fbe1aa.html" title="Last updated on Sep 9, 2022, 10:34 AM UTC (5fbe1aa)">Diff</a>