### PR TITLE
Remove extra multipage/ in window open steps link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -150,7 +150,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: set up a window environment settings object; url: window-object.html#set-up-a-window-environment-settings-object
     text: set up a worker environment settings object; url: workers.html#set-up-a-worker-environment-settings-object
     text: set up a worklet environment settings object; url: worklets.html#set-up-a-worklet-environment-settings-object
-    text: window open steps; url: multipage/window-object.html#window-open-steps
+    text: window open steps; url: window-object.html#window-open-steps
     text: worker event loop; url: webappapis.html#worker-event-loop-2
     text: worklet global scopes; url: worklets.html#concept-document-worklet-global-scopes
 </pre>


### PR DESCRIPTION
Fixes #279 

`multipage` was already provided in the urlPrefix


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/280.html" title="Last updated on Sep 12, 2022, 9:41 AM UTC (45c3aa9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/280/60e4add...45c3aa9.html" title="Last updated on Sep 12, 2022, 9:41 AM UTC (45c3aa9)">Diff</a>