### PR TITLE
Empty lines should not affect space removal

### DIFF
--- a/scripts/cddl/generate.js
+++ b/scripts/cddl/generate.js
@@ -24,7 +24,7 @@ Object.entries(cddl).forEach(([cddlName, entries]) => {
      */
     .map((entry) => {
       const preceedingSpace = entry.split('\n').reduce((prev, line) => {
-        if (line.length === 0) {
+        if (line.trim().length === 0) {
           return prev
         }
 


### PR DESCRIPTION
For example, previously some commands were formatted with extra whitespace in the CDL file:

```
  ScriptCallFunctionCommand = {
    method: "script.callFunction",
    params: ScriptCallFunctionParameters
  }
```

With this change, it becomes:

```
ScriptCallFunctionCommand = {
  method: "script.callFunction",
  params: ScriptCallFunctionParameters
}
```

I am not sure where those lines containing only spaces come from though.