### PR TITLE
MapRemoteValue/SetRemoteValue optional value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1581,9 +1581,9 @@ DateRemoteValue = {
 
 MapRemoteValue = {
   type: "map",
-  ?value: MappingRemoteValue,
   ?handle: Handle,
   ?internalId: InternalId,
+  ?value: MappingRemoteValue,
 }
 
 SetRemoteValue = {

--- a/index.bs
+++ b/index.bs
@@ -1588,9 +1588,9 @@ MapRemoteValue = {
 
 SetRemoteValue = {
   type: "set",
-  ?value: ListRemoteValue
   ?handle: Handle,
   ?internalId: InternalId,
+  ?value: ListRemoteValue
 }
 
 WeakMapRemoteValue = {

--- a/index.bs
+++ b/index.bs
@@ -1581,14 +1581,14 @@ DateRemoteValue = {
 
 MapRemoteValue = {
   type: "map",
-  value: MappingRemoteValue,
+  ?value: MappingRemoteValue,
   ?handle: Handle,
   ?internalId: InternalId,
 }
 
 SetRemoteValue = {
   type: "set",
-  value: ListRemoteValue
+  ?value: ListRemoteValue
   ?handle: Handle,
   ?internalId: InternalId,
 }


### PR DESCRIPTION
Like ObjectRemoteValue these aren't always set, if we reached the maximum serialization depth.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/290.html" title="Last updated on Sep 30, 2022, 8:25 PM UTC (086d834)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/290/445498f...086d834.html" title="Last updated on Sep 30, 2022, 8:25 PM UTC (086d834)">Diff</a>