### PR TITLE
Add support for preload scripts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3792,12 +3792,12 @@ relating to script realms and execution.
 
 <pre class="cddl remote-cddl">
 ScriptCommand = (
-  script.AddLoadScriptCommand //
+  script.AddPreloadScriptCommand //
   script.CallFunction //
   script.Disown //
   script.Evaluate //
   script.GetRealms
-  script.RemoveLoadScriptCommand
+  script.RemovePreloadScriptCommand
 )
 </pre>
 
@@ -3805,7 +3805,7 @@ ScriptCommand = (
 
 <pre class="cddl local-cddl">
 ScriptResult = (
-  script.AddLoadScriptResult //
+  script.AddPreloadScriptResult //
   script.EvaluateResult //
   script.GetRealmsResult
 )
@@ -3816,20 +3816,20 @@ ScriptEvent = (
 )
 </pre>
 
-### Load Scripts ### {#load-scripts}
+### Preload Scripts ### {#preload-scripts}
 
-A <dfn>load script</dfn> is one which runs on creation of a new {{Window}},
+A <dfn>Preload script</dfn> is one which runs on creation of a new {{Window}},
 before any author-defined script have run.
 
 TODO: Extend this to scripts in other kinds of realms.
 
-A [=BiDi session=] has a <dfn>load script map</dfn> which is a map in which the
+A [=BiDi session=] has a <dfn>preload script map</dfn> which is a map in which the
 keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
 for=struct>item</a> named <code>expression</code>, which is a string, and an
 item named <code>sandbox</code> which is a string or null.
 
 <div algorithm>
-To <dfn export>run WebDriver BiDi load scripts</dfn> given |environment settings|:
+To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment settings|:
 
 1. Let |document| be |environment settings|' [=relevant global object=]'s
    <a>associated <code>Document</code></a>.
@@ -3838,14 +3838,15 @@ To <dfn export>run WebDriver BiDi load scripts</dfn> given |environment settings
 
 1. For each |session| in [=active BiDi sessions=]:
 
-  1. For each |load script| in |session|'s [=load script map=]'s [=values=]:
+  1. For each |preload script| in |session|'s [=preload script map=]'s
+     [=values=]:
 
-    1. If |load script|'s <code>sandbox</code> is not null, let |realm| be [=get
-       or create a sandbox realm=] with load script|'s <code>sandbox</code> and
+    1. If |preload script|'s <code>sandbox</code> is not null, let |realm| be [=get
+       or create a sandbox realm=] with |preload script|'s <code>sandbox</code> and
        |browsing context|. Otherwise let |realm| be |environment settings|'
        [=realm execution context=]'s Realm component.
 
-    1. Let |source| be |load script|'s <code>expression</code>.
+    1. Let |source| be |preload script|'s <code>expression</code>.
 
     1. Let |options| be the [=default classic script fetch options=].
 
@@ -3918,15 +3919,15 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
 
 </div>
 
-#### The script.LoadScript type #### {#type-script-LoadScript}
+#### The script.PreloadScript type #### {#type-script-PreloadScript}
 
 [=Remote end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
-script.LoadScript = text;
+script.PreloadScript = text;
 </pre>
 
-The <code>script.LoadScript</code> type represents a handle to a script that will run
+The <code>script.PreloadScript</code> type represents a handle to a script that will run
 on realm creation.
 
 #### The script.Realm type #### {#type-script-Realm}
@@ -4385,21 +4386,21 @@ Issue: This has the wrong error code
 
 ### Commands ### {#module-script-commands}
 
-#### The script.addLoadScript Command ####  {#command-script-addLoadScript}
+#### The script.addPreloadScript Command ####  {#command-script-addPreloadScript}
 
-The <dfn export for=commands>script.addLoadScript</dfn> command adds a [=load
+The <dfn export for=commands>script.addPreloadScript</dfn> command adds a [=preload
 script=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.AddLoadScriptCommand = {
-        method: "script.addLoadScript",
-        params: ScriptAddLoadScriptParameters
+      script.AddPreloadScriptCommand = {
+        method: "script.addPreloadScript",
+        params: script.AddPreloadScriptParameters
       }
 
-      script.AddLoadScriptParameters = {
+      script.AddPreloadScriptParameters = {
         expression: text;
         ?sandbox: text
       }
@@ -4408,14 +4409,14 @@ script=].
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      script.AddLoadScriptResult = {
-        script: LoadScript
+      script.AddPreloadScriptResult = {
+        script: script.PreloadScript
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for script.addLoadScript">
+<div algorithm="remote end steps for script.addPreloadScript">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |expression| be the <code>expression</code> field of |command
@@ -4426,12 +4427,12 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |sandbox| be the value of the "<code>sandbox</code>" field in |command
    parameters|, if present, or null otherwise.
 
-1. Let |load script map| be |session|'s [=load script map=].
+1. Let |preload script map| be |session|'s [=preload script map=].
 
-1. Set |load script map|[|script|] to a struct with <code>expression</code>
+1. Set |preload script map|[|script|] to a struct with <code>expression</code>
    |expression| and <code>sandbox</code> |sandbox|.
 
-1. Return a new map matching the <code>script.AddLoadScriptResult</code> with the
+1. Return a new map matching the <code>script.AddPreloadScriptResult</code> with the
    <code>script</code> field set to |script|.
 
 </div>
@@ -4827,22 +4828,22 @@ Issue: We might want to have a more sophisticated filter system than just a
 
 </div>
 
-#### The script.removeLoadScript Command ####  {#command-script-removeLoadScript}
+#### The script.removePreloadScript Command ####  {#command-script-removePreloadScript}
 
-The <dfn export for=commands>script.removeLoadScript</dfn> command removes a
-[=load script=].
+The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
+[=preload script=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      script.RemoveLoadScriptCommand = {
-        method: "script.removeLoadScript",
-        params: ScriptRemoveLoadScriptParameters
+      script.RemovPreloadScriptCommand = {
+        method: "script.removePreloadScript",
+        params: script.RemovePreloadScriptParameters
       }
 
-      script.RemoveLoadScriptParameters = {
-        script: script.LoadScript
+      script.RemovePreloadScriptParameters = {
+        script: script.PreloadScript
       }
     </pre>
    </dd>
@@ -4854,20 +4855,20 @@ The <dfn export for=commands>script.removeLoadScript</dfn> command removes a
    </dd>
 </dl>
 
-<div algorithm="remote end steps for script.removeLoadScript">
+<div algorithm="remote end steps for script.removePreloadScript">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |script| be the value of the "<code>script</code>" field in |command
    parameters|.
 
-1. Let |load script map| be |session|'s [=load script map=].
+1. Let |preload script map| be |session|'s [=preload script map=].
 
-1. If |load script map| does not <a for=map>contain</a> |script|, return
+1. If |preload script map| does not <a for=map>contain</a> |script|, return
    [=error=] with [=error code=] [=invalid argument=].
 
    TODO: Should this be a "no such script" error?
 
-1. <a for=set>Remove</a> |script| from |load script map|.
+1. <a for=set>Remove</a> |script| from |preload script map|.
 
 1. Return null
 

--- a/index.bs
+++ b/index.bs
@@ -3792,10 +3792,12 @@ relating to script realms and execution.
 
 <pre class="cddl remote-cddl">
 ScriptCommand = (
+  script.AddLoadScriptCommand //
   script.CallFunction //
   script.Disown //
   script.Evaluate //
   script.GetRealms
+  script.RemoveLoadScriptCommand
 )
 </pre>
 
@@ -3803,6 +3805,7 @@ ScriptCommand = (
 
 <pre class="cddl local-cddl">
 ScriptResult = (
+  script.AddLoadScriptResult //
   script.EvaluateResult //
   script.GetRealmsResult
 )
@@ -3813,6 +3816,54 @@ ScriptEvent = (
 )
 </pre>
 
+### Load Scripts ### {#load-scripts}
+
+A <dfn>load script</dfn> is one which runs on creation of a new {{Window}},
+before any author-defined script have run.
+
+TODO: Extend this to scripts in other kinds of realms.
+
+A [=BiDi session=] has a <dfn>load script map</dfn> which is a map in which the
+keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
+for=struct>item</a> named <code>expression</code>, which is a string, and an
+item named <code>sandbox</code> which is a string or null.
+
+<div algorithm>
+To <dfn export>run WebDriver BiDi load scripts</dfn> given |environment settings|:
+
+1. Let |document| be |environment settings|' [=relevant global object=]'s
+   <a>associated <code>Document</code></a>.
+
+1. Let |browsing context| be |document|'s [=/browsing context=].
+
+1. For each |session| in [=active BiDi sessions=]:
+
+  1. For each |load script| in |session|'s [=load script map=]'s [=values=]:
+
+    1. If |load script|'s <code>sandbox</code> is not null, let |realm| be [=get
+       or create a sandbox realm=] with load script|'s <code>sandbox</code> and
+       |browsing context|. Otherwise let |realm| be |environment settings|'
+       [=realm execution context=]'s Realm component.
+
+    1. Let |source| be |load script|'s <code>expression</code>.
+
+    1. Let |options| be the [=default classic script fetch options=].
+
+    1. Let |base URL| be the [=API base URL=] of |environment settings|.
+
+    1. Let |script| be the result of [=create a classic script=] with |source|,
+       |environment settings|, |base URL|, and |options|.
+
+    1. [=Prepare to run script=] with |environment settings|.
+
+    1. Let |evaluation status| be [=ScriptEvaluation=](|script|'s record).
+
+    1. If |evaluation status| is an [=abrupt completion=], then [=report the
+       exception=] given by given by |evaluation status|.\[[Value]] for |script|.
+
+    1. [=Clean up after running script=] with |environment settings|.
+
+</div>
 
 ### Types ### {#module-script-types}
 
@@ -3866,6 +3917,17 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
 1. Return |exception details|.
 
 </div>
+
+#### The script.LoadScript type #### {#type-script-LoadScript}
+
+[=Remote end definition=]
+
+<pre class="cddl remote-cddl loacl-cddl">
+script.LoadScript = text;
+</pre>
+
+The <code>script.LoadScript</code> type represents a handle to a script that will run
+on realm creation.
 
 #### The script.Realm type #### {#type-script-Realm}
 
@@ -4323,6 +4385,57 @@ Issue: This has the wrong error code
 
 ### Commands ### {#module-script-commands}
 
+#### The script.addLoadScript Command ####  {#command-script-addLoadScript}
+
+The <dfn export for=commands>script.addLoadScript</dfn> command adds a [=load
+script=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      script.AddLoadScriptCommand = {
+        method: "script.addLoadScript",
+        params: ScriptAddLoadScriptParameters
+      }
+
+      script.AddLoadScriptParameters = {
+        expression: text;
+        ?sandbox: text
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      script.AddLoadScriptResult = {
+        script: LoadScript
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for script.addLoadScript">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |expression| be the <code>expression</code> field of |command
+   parameters|.
+
+1. Let |script| be the string representation of a [[!RFC4122|UUID]].
+
+1. Let |sandbox| be the value of the "<code>sandbox</code>" field in |command
+   parameters|, if present, or null otherwise.
+
+1. Let |load script map| be |session|'s [=load script map=].
+
+1. Set |load script map|[|script|] to a struct with <code>expression</code>
+   |expression| and <code>sandbox</code> |sandbox|.
+
+1. Return a new map matching the <code>script.AddLoadScriptResult</code> with the
+   <code>script</code> field set to |script|.
+
+</div>
+
 #### The script.disown Command ####  {#command-script-disown}
 
 The <dfn export for=commands>script.disown</dfn> command disowns the given handles.
@@ -4713,6 +4826,53 @@ Issue: We might want to have a more sophisticated filter system than just a
        literal match.
 
 </div>
+
+#### The script.removeLoadScript Command ####  {#command-script-removeLoadScript}
+
+The <dfn export for=commands>script.removeLoadScript</dfn> command removes a
+[=load script=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      script.RemoveLoadScriptCommand = {
+        method: "script.removeLoadScript",
+        params: ScriptRemoveLoadScriptParameters
+      }
+
+      script.RemoveLoadScriptParameters = {
+        script: script.LoadScript
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl">
+      EmptyResult
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for script.removeLoadScript">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |script| be the value of the "<code>script</code>" field in |command
+   parameters|.
+
+1. Let |load script map| be |session|'s [=load script map=].
+
+1. If |load script map| does not <a for=map>contain</a> |script|, return
+   [=error=] with [=error code=] [=invalid argument=].
+
+   TODO: Should this be a "no such script" error?
+
+1. <a for=set>Remove</a> |script| from |load script map|.
+
+1. Return null
+
+</div>
+
 
 ### Events ### {#module-script-events}
 

--- a/index.bs
+++ b/index.bs
@@ -3872,7 +3872,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
     1. Let |evaluation status| be [=ScriptEvaluation=](|script|'s record).
 
     1. If |evaluation status| is an [=abrupt completion=], then [=report the
-       exception=] given by given by |evaluation status|.\[[Value]] for |script|.
+       exception=] given by |evaluation status|.\[[Value]] for |script|.
 
     1. [=Clean up after running script=] with |environment settings|.
 

--- a/index.bs
+++ b/index.bs
@@ -289,16 +289,6 @@ ErrorResponse = {
   Extensible
 }
 
-ErrorCode = {
-   "invalid argument" /
-   "no such alert" /
-   "no such frame" /
-   "session not created" /
-   "unknown command" /
-   "unknown error" /
-   "unsupported operation"
-}
-
 ResultData = (
   EmptyResult //
   SessionResult //
@@ -423,6 +413,28 @@ end=] which ignores all responses could use the same command id for each command
 The <dfn export for=command>set of all command names</dfn> is a set containing
 all the defined [=command names=], including any belonging to [=extension
 modules=].
+
+## Errors ## {#errors}
+
+WebDriver BiDi extends the set of [=error codes=] from [[WEBDRIVER|WebDriver]]
+with the following additional codes:
+
+<dl>
+  <dt><dfn>No such script</dfn>
+  <dd>Tried to remove an unknown [=preload script=].
+</dl>
+
+<pre class="cddl local-cddl">
+ErrorCode = ("invalid argument" /
+             "invalid session id" /
+             "no such alert" /
+             "no such frame" /
+             "no such script" /
+             "session not created" /
+             "unknown command" /
+             "unknown error" /
+             "unsupported operation")
+</pre>
 
 ## Events ## {#events}
 
@@ -4864,9 +4876,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |preload script map| be |session|'s [=preload script map=].
 
 1. If |preload script map| does not <a for=map>contain</a> |script|, return
-   [=error=] with [=error code=] [=invalid argument=].
-
-   TODO: Should this be a "no such script" error?
+   [=error=] with [=error code=] [=no such script=].
 
 1. <a for=set>Remove</a> |script| from |preload script map|.
 

--- a/index.bs
+++ b/index.bs
@@ -4849,7 +4849,7 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      script.RemovPreloadScriptCommand = {
+      script.RemovePreloadScriptCommand = {
         method: "script.removePreloadScript",
         params: script.RemovePreloadScriptParameters
       }

--- a/index.bs
+++ b/index.bs
@@ -3922,7 +3922,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl loacl-cddl">
+<pre class="cddl remote-cddl local-cddl">
 script.LoadScript = text;
 </pre>
 


### PR DESCRIPTION
These are scripts which are run when a realm (initially only for realms with a Window global) is created. They allow a test harness to inject functionality that's guaranteed to be available for any content scripts that are subsequently loaded, and before any later scripts that WebDriver injects into the context.

Registering a preload script happens with the script.addPreloadScript command. This returns a handle to the added script.

Load scripts can later be removed by passing the handle to script.removePreloadScript.

Load scripts can either be run directly in the newly created Window, or in a named sandbox.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/292.html" title="Last updated on Dec 21, 2022, 9:26 PM UTC (8681af4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/292/14731db...8681af4.html" title="Last updated on Dec 21, 2022, 9:26 PM UTC (8681af4)">Diff</a>