### PR TITLE
Do not allow empty string as a `sandbox`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -982,6 +982,9 @@ provides access to platform objects in an existing {{Window}} realm via
 <div algorithm>
 To <dfn>get or create a sandbox realm</dfn> given |name| and |browsing context|:
 
+1. If |name| is an empty string, then return [=error=] with
+   [=error code=] [=invalid argument=].
+
 1. Let |window| be |browsing context|'s [=active window=].
 
 1. If [=sandbox map=] does not contain |window|, set [=sandbox map=][|window|]
@@ -992,7 +995,7 @@ To <dfn>get or create a sandbox realm</dfn> given |name| and |browsing context|:
 1. If |sandboxes| does not contain |name|, set |sandboxes|[|name|] to [=create
    a sandbox realm=] with |browsing context|.
 
-1. Return |sandboxes|[|name|].
+1. Return [=success=] with data |sandboxes|[|name|].
 
 </div>
 
@@ -4122,8 +4125,9 @@ To <dfn>get a realm from a target</dfn> given |target|:
     1. Let |realm| be |environment settings|' [=realm execution context=]'s
        Realm component.
 
-  1. Otherwise: let |realm| be [=get or create a sandbox realm=] given
-     |target|["<code>sandbox</code>"] and |context|.
+  1. Otherwise: let |realm| be result of [=trying=] to
+     [=get or create a sandbox realm=] given |target|["<code>sandbox</code>"] and
+     |context|.
 
 1. Otherwise:
 


### PR DESCRIPTION
In CDP, we consider empty sandbox name as a default realm. So I guess we can just restrict the sandbox to be a non-empty string.

WPT update will be after agreement on this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/300.html" title="Last updated on Sep 28, 2022, 11:54 AM UTC (ea170e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/300/33705b4...ea170e0.html" title="Last updated on Sep 28, 2022, 11:54 AM UTC (ea170e0)">Diff</a>