### PR TITLE
Use EmptyResult as result type for browsingContext.close

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2352,9 +2352,9 @@ Issue: This needs to be generalized to work with realms too
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+      <pre class="cddl">
       EmptyResult
-    </pre>
+      </pre>
    </dd>
 </dl>
 
@@ -2420,9 +2420,9 @@ Issue: This needs to be generalised to work with realms too
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+      <pre class="cddl">
       EmptyResult
-    </pre>
+      </pre>
    </dd>
 </dl>
 
@@ -2814,6 +2814,13 @@ The <dfn export for=commands>browsingContext.close</dfn> command closes a
       }
       </pre>
    </dd>
+
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl">
+      EmptyResult
+      </pre>
+   </dd>
 </dl>
 
 <div algorithm="remote end steps for browsingContext.close">
@@ -2992,9 +2999,9 @@ command allows closing an open prompt
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+      <pre class="cddl">
       EmptyResult
-    </pre>
+      </pre>
    </dd>
 </dl>
 


### PR DESCRIPTION
Fix #293.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/302.html" title="Last updated on Sep 30, 2022, 4:19 PM UTC (a87351f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/302/33705b4...whimboo:a87351f.html" title="Last updated on Sep 30, 2022, 4:19 PM UTC (a87351f)">Diff</a>