### PR TITLE
Empty string `sandbox` is a default realm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4132,7 +4132,8 @@ To <dfn>get a realm from a target</dfn> given |target|:
   1. Let |context| be the result of [=trying=] to [=get a browsing context=]
      with |target|["<code>context</code>"].
 
-  1. If |target| does not contain a field named "<code>sandbox</code>":
+  1. If |target| does not contain a field named "<code>sandbox</code>", or
+     target|["<code>sandbox</code>"] is an empty string:
 
     1. Let |document| be |context|'s [=active document=].
 


### PR DESCRIPTION
Implement suggestion from #258. Empty string sandbox is a default realm.
Follow up after #300.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/304.html" title="Last updated on Oct 4, 2022, 12:34 PM UTC (072d5cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/304/5d088cd...072d5cd.html" title="Last updated on Oct 4, 2022, 12:34 PM UTC (072d5cd)">Diff</a>