### PR TITLE
Fix indentation for browsingContext.create

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2914,7 +2914,7 @@ The [=remote end steps=] with |command parameters| are:
      result of [=trying=] to [=get a browsing context=] with
      |reference context id|. Otherwise let |reference context| be null.
 
- 1. If |reference context| is not null and is not a [=top-level browsing context=],
+  1. If |reference context| is not null and is not a [=top-level browsing context=],
     return [=error=] with [=error code=] [=invalid argument=].
 
   1. If the implementation is unable to create a new browsing context for any


### PR DESCRIPTION
Missing space seems to break the steps for browsingContext.create


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/310.html" title="Last updated on Oct 13, 2022, 9:44 AM UTC (831b905)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/310/565a52b...juliandescottes:831b905.html" title="Last updated on Oct 13, 2022, 9:44 AM UTC (831b905)">Diff</a>