### PR TITLE
Fix case for realm/global object reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -828,8 +828,8 @@ To <dfn>get related browsing contexts</dfn> given an [=script/settings object=]
    [=relevant global object=]'s <a>associated <code>Document</code></a>'s
    [=Document/browsing context=] to |related browsing contexts|.
 
-   Otherwise if the [=Realm/global object=] specified by |settings| is a
-   {{WorkerGlobalScope}}, for each |owner| in the [=Realm/global object=]'s
+   Otherwise if the [=realm/global object=] specified by |settings| is a
+   {{WorkerGlobalScope}}, for each |owner| in the [=realm/global object=]'s
    [=owner set=], if |owner| is a [=Document=], append |owner|'s
    [=Document/browsing context=] to |related browsing contexts|.
 
@@ -3881,7 +3881,7 @@ To <dfn>get the realm info</dfn> given |environment settings|:
 
 1. Let |origin| be the [=serialization of an origin=] given |environment settings|'s |origin|.
 
-1. Let |global object| be the [=Realm/global object=] specified by |environment settings|
+1. Let |global object| be the [=realm/global object=] specified by |environment settings|
 
 1. Run the steps under the first matching condition:
 
@@ -4565,7 +4565,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
       * The <a>associated <code>Document</code></a> of |settings|'
         [=relevant global object=] is |document|
 
-      * The [=Realm/global object=] specified by |settings| is a
+      * The [=realm/global object=] specified by |settings| is a
         {{WorkerGlobalScope}} with |document| in its [=owner set=]
 
       Append |settings| to |context environment settings|.


### PR DESCRIPTION
It seems that the case for this reference was changed from Realm to realm in https://github.com/whatwg/html/commit/4ce0c6ca22c1e8cbeb84778d60c66282a669bc52 which breaks our build


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/311.html" title="Last updated on Oct 13, 2022, 7:38 AM UTC (8ab7e59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/311/ad6f828...juliandescottes:8ab7e59.html" title="Last updated on Oct 13, 2022, 7:38 AM UTC (8ab7e59)">Diff</a>