### PR TITLE
Add missing `|` in "get a realm from a target"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4198,7 +4198,7 @@ To <dfn>get a realm from a target</dfn> given |target|:
      with |target|["<code>context</code>"].
 
   1. If |target| does not contain a field named "<code>sandbox</code>", or
-     target|["<code>sandbox</code>"] is an empty string:
+     |target|["<code>sandbox</code>"] is an empty string:
 
     1. Let |document| be |context|'s [=active document=].
 


### PR DESCRIPTION
Leftover from #304


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/316.html" title="Last updated on Oct 25, 2022, 5:02 PM UTC (fb57c60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/316/85191bc...fb57c60.html" title="Last updated on Oct 25, 2022, 5:02 PM UTC (fb57c60)">Diff</a>