### PR TITLE
Pin CI to Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.x
+          python-version: "3.10"
       - name: Build spec without warnings
         run: ./scripts/build.sh --install
   cddl:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
+          # Python 3.11 is broken: https://github.com/tabatkins/bikeshed/issues/2386
           python-version: "3.10"
       - name: Build spec without warnings
         run: ./scripts/build.sh --install


### PR DESCRIPTION
This avoid an issue where Bikeshed doesn't work with 3.11