### PR TITLE
Correct interpretation of null maximum depth

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1837,7 +1837,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     1. Let |serialized| be null.
 
     1. If |known object| is <code>false</code>, and |max depth| is not 0, run
-       run the following steps:
+       the following steps:
 
        1. Let |serialized| be the result of [=serialize as a list=] given
           [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,

--- a/index.bs
+++ b/index.bs
@@ -1765,8 +1765,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     1. Let |serialized| be null.
 
-    1. If |known object| is <code>false</code>, and |max depth| is not null and
-       greater than 0, run the following steps:
+    1. If |known object| is <code>false</code>, and |max depth| is not 0, run
+       the following steps:
 
            1. Let |serialized| be the result of [=serialize as a list=] given
               [=CreateArrayIterator=](|value|, value), |max depth|, |child ownership|,
@@ -1814,8 +1814,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     1. Let |serialized| be null.
 
-    1. If |known object| is <code>false</code>, and |max depth| is not null and
-       greater than 0, run the following steps:
+    1. If |known object| is <code>false</code>, and |max depth| is not 0, run
+       the following steps:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=CreateMapIterator=](|value|, key+value), |max depth|,
@@ -1836,8 +1836,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     1. Let |serialized| be null.
 
-    1. If |known object| is <code>false</code>, and |max depth| is not null and
-       greater than 0, run the following steps:
+    1. If |known object| is <code>false</code>, and |max depth| is not 0, run
+       run the following steps:
 
        1. Let |serialized| be the result of [=serialize as a list=] given
           [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,
@@ -1982,8 +1982,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     1. Let |serialized| be null.
 
-    1. If |known object| is <code>false</code>, and |max depth| is greater than 0,
-       run the following steps:
+    1. If |known object| is <code>false</code>, and |max depth| is not 0, run
+       the following steps:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,


### PR DESCRIPTION
In the serialization steps for specific container types, when recursion continues when "max depth" take the value "null". However, when determining whether to begin serialization of nested data structures, the value "null" was generally interpreted to mean "do not serialize." For the case of Object values, null was not handled at all.

Update the algorithm to consistently interpret null as a signal for unlimited recursion.

---

Expressing these conditions is a bit tricky because they're part of a conjunction. I initially tried:

    1. If |known object| is <code>false</code> and |max depth| is either
       null or greater than 0, run the following steps:

...but I'm on the fence about whether the verbosity is helpful.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/325.html" title="Last updated on Nov 18, 2022, 12:49 AM UTC (4a6571c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/325/60b640b...bocoup:4a6571c.html" title="Last updated on Nov 18, 2022, 12:49 AM UTC (4a6571c)">Diff</a>