### PR TITLE
Make bikeshed not die on warning locally

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,4 +9,4 @@ if ! [ -x "$(command -v bikeshed)" ] || [ "$1" = "--upgrade" ]; then
     pip install bikeshed
 fi
 
-bikeshed --die-on=warning spec index.bs
+bikeshed --die-on=fatal spec index.bs


### PR DESCRIPTION
Fixes parts of issue #322 by making the calling convention equal to how bikeshed is run in CI.