### PR TITLE
Add serialization support for NodeList and HTMLCollection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1888,7 +1888,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>|value| is a [=platform object=] that implements {{HTMLCollection}}
     <dd>Let |remote value| be [=serialize an Array-like=] with
-        <code>HTMLCollectionRemoteValue</code>, |value|, |handle id|, |value|, |max
+        <code>HTMLCollectionRemoteValue</code>, |handle id|, |value|, |max
         depth|, |ownership type|, |known object|, |serialization internal map|, and
         |realm|.
 

--- a/index.bs
+++ b/index.bs
@@ -1748,10 +1748,10 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 1. Let |handle id| be the [=handle for an object=] given |realm|, |ownership type|
    and |value|.
 
+1. Set |ownership type| to "<code>none</code>".
+
 1. Let |known object| be <code>true</code>, if |value| is in the
    |serialization internal map|, otherwise <code>false</code>.
-
-1. Let |child ownership| be "<code>none</code>".
 
   <dl>
     <dt>[=Type=](|value|) is Symbol
@@ -1825,7 +1825,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=CreateMapIterator=](|value|, key+value), |max depth|,
-          |child ownership|, |serialization internal map| and |realm|.
+          |ownership type|, |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
        |serialized|.
@@ -1846,7 +1846,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
        the following steps:
 
        1. Let |serialized| be the result of [=serialize as a list=] given
-          [=CreateSetIterator=](|value|, value), |max depth|, |child ownership|,
+          [=CreateSetIterator=](|value|, value), |max depth|, |ownership type|,
           |serialization internal map| and |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -1921,7 +1921,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
             1. Let |child depth| be |max depth| - 1 if |max depth| is not null, or null otherwise.
 
             1. Let |serialized| be the result of [=serialize as a remote value=]
-               with |child|, |child depth|, |child ownership|,
+               with |child|, |child depth|, |ownership type|,
                |serialization internal map| and |realm|.
 
             1. Append |serialized| to |children|.
@@ -1952,7 +1952,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |child depth|,
-                  false, |child ownership|, |serialization internal map| and |realm|.
+                  false, |ownership type|, |serialization internal map| and |realm|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,
@@ -1996,7 +1996,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
        1. Let |serialized| be the result of [=serialize as a mapping=] given
           [=EnumerableOwnPropertyNames=](|value|, key+value), |max depth|,
-          |child ownership|, |serialization internal map| and
+          |ownership type|, |serialization internal map| and
           |realm|.
 
     1. If |serialized| is not null, set field <code>value</code> of |remote value| to
@@ -2021,7 +2021,7 @@ remove optional flag from the field.
 </div>
 
 <div algorithm>
-To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |child ownership|,
+To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |ownership type|,
 |serialization internal map| and |realm|:
 
   1. Let |serialized| be a new list.
@@ -2032,7 +2032,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |max depth|, |child ownershi
        otherwise.
 
     1. Let |serialized child| be the result of [=serialize as a remote value=]
-       with arguments |child value|, |child depth|, |child ownership|,
+       with arguments |child value|, |child depth|, |ownership type|,
        |serialization internal map| and |realm|.
 
     1. Append |serialized child| to |serialized|.
@@ -2044,7 +2044,7 @@ Issue: this assumes for-in works on iterators
 
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
-|child ownership|, |serialization internal map| and |realm|:
+|ownership type|, |serialization internal map| and |realm|:
 
 1. Let |serialized| be a new list.
 
@@ -2063,11 +2063,11 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |max depth|,
 
   1. If [=Type=](|key|) is String, let |serialized key| be |child key|,
      otherwise let |serialized key| be the result of [=serialize as a remote value=]
-     with arguments |child key|, |child depth|, |child ownership|,
+     with arguments |child key|, |child depth|, |ownership type|,
      |serialization internal map| and |realm|.
 
   1. Let |serialized value| be the result of [=serialize as a remote value=]
-     with arguments |value|, |child depth|, |child ownership|,
+     with arguments |value|, |child depth|, |ownership type|,
      |serialization internal map| and |realm|.
 
   1. Let |serialized child| be («|serialized key|, |serialized value|»).

--- a/index.bs
+++ b/index.bs
@@ -1558,7 +1558,7 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
 [=remote end definition=] and [=local end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
-RemoteValue = {
+RemoteValue = (
   PrimitiveProtocolValue //
   SymbolRemoteValue //
   ArrayRemoteValue //
@@ -1577,9 +1577,11 @@ RemoteValue = {
   PromiseRemoteValue //
   TypedArrayRemoteValue //
   ArrayBufferRemoteValue //
+  NodeListRemoteValue //
+  HTMLCollectionRemoteValue //
   NodeRemoteValue //
   WindowProxyRemoteValue //
-}
+)
 
 InternalId = js-uint;
 
@@ -1693,6 +1695,20 @@ ArrayBufferRemoteValue = {
   ?internalId: InternalId,
 }
 
+NodeListRemoteValue = {
+  type: "nodelist",
+  ?handle: Handle,
+  ?internalId: InternalId,
+  ?value: ListRemoteValue,
+}
+
+HTMLCollectionRemoteValue = {
+  type: "htmlcollection",
+  ?handle: Handle,
+  ?internalId: InternalId,
+  ?value: ListRemoteValue,
+}
+
 NodeRemoteValue = {
   type: "node",
   ?handle: Handle,
@@ -1760,26 +1776,9 @@ an |ownership type|, a |serialization internal map| and a |realm|:
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
-    <dd>
-
-    1. Let |remote value| be a map matching the <code>ArrayRemoteValue</code>
-       production in the [=local end definition=], with the <code>handle</code>
-       property set to |handle id| if it's not null, or omitted otherwise.
-
-    1. [=Set internal ids if needed=] given |serialization internal map|,
-       |remote value| and |value|.
-
-    1. Let |serialized| be null.
-
-    1. If |known object| is <code>false</code>, and |max depth| is not 0, run
-       the following steps:
-
-           1. Let |serialized| be the result of [=serialize as a list=] given
-              [=CreateArrayIterator=](|value|, value), |max depth|, |child ownership|,
-              |serialization internal map| and |realm|.
-
-    1. If |serialized| is not null, set field <code>value</code> of |remote value| to
-       |serialized|.
+    <dd>Let |remote value| be [=serialize an Array-like=] with
+        <code>ArrayRemoteValue</code>, |handle id|, |value|, |max depth|,
+        |ownership type|, |known object|, |serialization internal map|, and |realm|.
 
     <dt>[=IsRegExp=](|value|)
     <dd>
@@ -1881,6 +1880,17 @@ an |ownership type|, a |serialization internal map| and a |realm|:
     <dd>Let |remote value| be a map matching the <code>ArrayBufferRemoteValue</code>
         production in the [=local end definition=], with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
+
+    <dt>|value| is a [=platform object=] that implements {{NodeList}}
+    <dd>Let |remote value| be [=serialize an Array-like=] with
+        <code>NodeListRemoteValue</code>,|handle id|, |value|, |max depth|,
+        |ownership type|, |known object|, |serialization internal map|, and |realm|.
+
+    <dt>|value| is a [=platform object=] that implements {{HTMLCollection}}
+    <dd>Let |remote value| be [=serialize an Array-like=] with
+        <code>HTMLCollectionRemoteValue</code>, |value|, |handle id|, |value|, |max
+        depth|, |ownership type|, |known object|, |serialization internal map|, and
+        |realm|.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -2017,6 +2027,30 @@ null value.
 
 Issue: <code>shadowRoot</code> field is optional. Omit it in case of |shadow root| is null, or
 remove optional flag from the field.
+
+</div>
+
+<div algorithm>
+To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |value|,
+|max depth|, |ownership type|, |known object|, |serialization internal map|, and |realm|:
+
+1. Let |remote value| be a map matching |production|, with the
+   <code>handle</code> property set to |handle id| if it's not null, or omitted
+   otherwise.
+
+1. [=Set internal ids if needed=] given |serialization internal map|,
+   |remote value| and |value|.
+
+1. If |known object| is <code>false</code>, and |max depth| is not 0:
+
+  1. Let |serialized| be the result of [=serialize as a list=] given
+     [=CreateArrayIterator=](|value|, value), |max depth|, |ownership type|,
+     |serialization internal map| and |realm|.
+
+  1. If |serialized| is not null, set field <code>value</code> of |remote value| to
+     |serialized|.
+
+1. Return |remote value|
 
 </div>
 


### PR DESCRIPTION
Fixes #318.

These should serialize like Arrays, in particular for the `document.querySelectorAll` use case where you want to directly get the list of elements back.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/333.html" title="Last updated on Dec 20, 2022, 8:52 AM UTC (ab70ad6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/333/14731db...ab70ad6.html" title="Last updated on Dec 20, 2022, 8:52 AM UTC (ab70ad6)">Diff</a>