### PR TITLE
Fix "nodeValue" and "childNodeCount" serialization for DOM nodes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1700,12 +1700,12 @@ NodeRemoteValue = {
 
 NodeProperties = {
   nodeType: js-uint,
-  nodeValue: text,
   childNodeCount: js-uint,
+  ?attributes: {*text => text},
+  ?children: [*NodeRemoteValue],
   ?localName: text,
   ?namespaceURI: text,
-  ?children: [*NodeRemoteValue],
-  ?attributes: {*text => text},
+  ?nodeValue: text,
   ?shadowRoot: NodeRemoteValue / null,
 }
 
@@ -1897,7 +1897,10 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
           1. Set |serialized|["<code>nodeType</code>"] to [=Get=](|value|, "nodeType").
 
-          1. Set |serialized|["<code>nodeValue</code>"] to [=Get=](|value|, "nodeValue")
+          1. Set |node value| to [=Get=](|value|, "nodeValue").
+
+          1. If |node value| is not null set
+             |serialized|["<code>nodeValue</code>"] to |node value|.
 
           1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
 
@@ -1905,7 +1908,7 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
             1. Set |serialized|["<code>namespaceURI</code>"] to [=Get=](|value|, "namespaceURI")
 
-          1. Let |child node count| be the [=list/size=] of |serialized|'s [=children=].
+          1. Let |child node count| be the [=list/size=] of |value|'s [=children=].
 
           1. Set |serialized|["<code>childNodeCount</code>"] to |child node count|.
 


### PR DESCRIPTION
While implementing the DOM node serialization in Firefox I noticed the following bug and a situation for improvement:

* `childNodeCount` is set based on the length of the still to be serialized `childNodes`.
* `nodeValue` is set for all kind of nodes even that it [is `null` for most of the known node types](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/335.html" title="Last updated on Nov 25, 2022, 12:37 PM UTC (a7c7735)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/335/a676ae9...whimboo:a7c7735.html" title="Last updated on Nov 25, 2022, 12:37 PM UTC (a7c7735)">Diff</a>