### PR TITLE
Renameed acceptInsecureCertificates to acceptInsecureCerts for WebDriver classic compatibility

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2218,7 +2218,7 @@ filter only those that ought to be returned to the local end.
 
 <pre class="cddl remote-cddl local-cddl">
 CapabilitiesRequest = {
-  ?acceptInsecureCertificates: bool,
+  ?acceptInsecureCerts: bool,
   ?browserName: text,
   ?browserVersion: text,
   ?platformName: text,
@@ -2322,7 +2322,7 @@ This is a [=static command=].
       SessionNewResult = {
         sessionId: text,
         capabilities: {
-          acceptInsecureCertificates: bool,
+          acceptInsecureCerts: bool,
           browserName: text,
           browserVersion: text,
           platformName: text,


### PR DESCRIPTION
Fixes #317.

@jgraham or @sadym-chromium happy doing a quick review on that one?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/337.html" title="Last updated on Nov 30, 2022, 10:35 AM UTC (c40b6b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/337/a056c3a...whimboo:c40b6b8.html" title="Last updated on Nov 30, 2022, 10:35 AM UTC (c40b6b8)">Diff</a>