### PR TITLE
Add a timestamp to NavigationInfo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2812,7 +2812,7 @@ TODO: Link to the definition in the HTML spec.
 browsingContext.NavigationInfo = {
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
-  timestamp: int,
+  timestamp: js-uint,
   url: text,
 }
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -2812,6 +2812,7 @@ TODO: Link to the definition in the HTML spec.
 browsingContext.NavigationInfo = {
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
+  timestamp: int,
   url: text,
 }
 </pre>
@@ -2825,13 +2826,15 @@ To <dfn>get the navigation info</dfn>, given |context| and |navigation status|:
 
 1. Let |navigation id| be |navigation status|'s id.
 
+1. Let |timestamp| be a [=time value=] representing the current date and time in UTC.
+
 1. Let |url| be |navigation status|'s url.
 
-1. Return a [=map=] matching the
-   <code>browsingContext.NavigationInfo</code> production, with the
-   <code>context</code> field set to |context id|, the <code>navigation</code>
-   field set to |navigation id|, and the <code>url</code> field set to the
-   result of the [=URL serializer=] given |url|.
+1. Return a [=map=] matching the <code>browsingContext.NavigationInfo</code>
+   production, with the <code>context</code> field set to |context id|, the
+   <code>navigation</code> field set to |navigation id|, the
+   <code>timestamp</code> field set to |timestamp|, and the <code>url</code>
+   field set to the result of the [=URL serializer=] given |url|.
 
 </div>
 


### PR DESCRIPTION
This ensures that navigation events get a (wall clock) timestamp.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/346.html" title="Last updated on Jan 3, 2023, 10:09 AM UTC (4e62ce8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/346/14731db...4e62ce8.html" title="Last updated on Jan 3, 2023, 10:09 AM UTC (4e62ce8)">Diff</a>