### PR TITLE
Disambiguate "url" export

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2540,7 +2540,7 @@ navigation status</dfn> struct, which has the following items:
       "<dfn export id="navigation-status-complete"><code>complete</code></dfn>".
     </dd>
 
-  <dt><dfn export id="navigation-status-url">url</dfn></dt>
+  <dt><dfn export for="WebDriver navigation status" id="navigation-status-url">url</dfn></dt>
   <dd>The URL which is being loaded in the navigation</dd>
 </dl>
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver-bidi/issues/347.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/348.html" title="Last updated on Jan 2, 2023, 11:20 AM UTC (4511268)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/348/d73975c...4511268.html" title="Last updated on Jan 2, 2023, 11:20 AM UTC (4511268)">Diff</a>