### PR TITLE
Disambiguate "id" and "status" exports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2529,11 +2529,11 @@ The progress of navigation is communicated using an immutable <dfn export>WebDri
 navigation status</dfn> struct, which has the following items:
 
 <dl>
-  <dt><dfn export id="navigation-status-id">id</dfn></dt>
+  <dt><dfn export for="WebDriver navigation status" id="navigation-status-id">id</dfn></dt>
   <dd>The [=navigation id=] for the navigation, or null when the navigation is
   canceled before making progress.</dd>
 
-  <dt><dfn export id="navigation-status-status">status</dfn></dt>
+  <dt><dfn export for="WebDriver navigation status" id="navigation-status-status">status</dfn></dt>
     <dd>A status code that is either
       "<dfn export id="navigation-status-canceled"><code>canceled</code></dfn>",
       "<dfn export id="navigation-status-pending"><code>pending</code></dfn>", or


### PR DESCRIPTION
Follow-up to https://github.com/w3c/webdriver-bidi/pull/348.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/349.html" title="Last updated on Jan 3, 2023, 2:45 AM UTC (9702152)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/349/a2f64a5...9702152.html" title="Last updated on Jan 3, 2023, 2:45 AM UTC (9702152)">Diff</a>