### PR TITLE
Editorial: correct command return values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3009,6 +3009,10 @@ The [=remote end steps=] with |command parameters| are:
 
   1. [=Close=] |context|.
 
+  1. Let |body| be a new map.
+
+  1. Return [=success=] with data |body|.
+
 Issue(w3c/webdriver-bidi#170): There is an open discussion about the behavior
 when closing the last [=top-level browsing context=]. We could expect to close
 the browser, close the session or leave this up to the implementation.
@@ -4487,8 +4491,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Set |preload script map|[|script|] to a struct with <code>expression</code>
    |expression| and <code>sandbox</code> |sandbox|.
 
-1. Return a new map matching the <code>script.AddPreloadScriptResult</code> with the
+1. Let |body| be a new map matching the <code>script.AddPreloadScriptResult</code> with the
    <code>script</code> field set to |script|.
+
+1. Return [=success=] with data |body|.
 
 </div>
 
@@ -4528,6 +4534,10 @@ The [=remote end steps=] with |command parameters| are:
    1. Let |handle map| be |realm|'s [=handle object map=]
 
    1. If |handle map| contains |handle id|, remove |handle id| from the |handle map|.
+
+1. Let |body| be a new map.
+
+1. Return [=success=] with data |body|.
 
 </div>
 
@@ -4659,9 +4669,11 @@ The [=remote end steps=] with |command parameters| are:
    1. Let |exception details| be the result of [=get exception details=] given
       |realm|, |function body evaluation status| and |result ownership|.
 
-   1. Return a new map matching the <code>script.EvaluateResultException</code>
+   1. Let |body| be a new map matching the <code>script.EvaluateResultException</code>
       production, with the <code>exceptionDetails</code> field set to
       |exception details|.
+
+   1. Return [=success=] with data |body|.
 
 1. Let |function object| be |function body evaluation status|.\[[Value]].
 
@@ -4687,9 +4699,11 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given
      |realm|, |evaluation status| and |result ownership|.
 
-  1. Return a new map matching the <code>script.EvaluateResultException</code>
+  1. Let |body| be a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>exceptionDetails</code> field set to
      |exception details|.
+
+  1. Return [=success=] with data |body|.
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
@@ -4697,9 +4711,11 @@ The [=remote end steps=] with |command parameters| are:
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
    ownership|, <code>new map</code> as |serialization internal map| and |realm|.
 
-1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
+1. Let |body| be a new map matching the <code>script.EvaluateResultSuccess</code>
    production, with the <code>realm</code> field set to |realm id|,
    and the <code>result</code> field set to |result|.
+
+1. Return [=success=] with data |body|.
 
 #### The script.evaluate Command ####  {#command-script-evaluate}
 
@@ -4783,9 +4799,11 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |exception details| be the result of [=get exception details=] given
      |realm|, |evaluation status| and |result ownership|.
 
-  1. Return a new map matching the <code>script.EvaluateResultException</code>
+  1. Let |body| be a new map matching the <code>script.EvaluateResultException</code>
      production, with the <code>realm</code> field set to |realm id|, and the
      <code>exceptionDetails</code> field set to |exception details|.
+
+  1. Return [=success=] with data |body|.
 
 1. Assert: |evaluation status|.\[[Type]] is <code>normal</code>.
 
@@ -4793,9 +4811,11 @@ The [=remote end steps=] with |command parameters| are:
    |evaluation status|.\[[Value]], <code>1</code> as |max depth|, |result
    ownership|, <code>new map</code> as |serialization internal map| and |realm|.
 
-1. Return a new map matching the <code>script.EvaluateResultSuccess</code>
+1. Let |body| be a new map matching the <code>script.EvaluateResultSuccess</code>
    production, with the with the <code>realm</code> field set to |realm id|, and
    the <code>result</code> field set to |result|.
+
+1. Return [=success=] with data |body|.
 
 #### The script.getRealms Command ####  {#command-script-getRealms}
 
@@ -4923,7 +4943,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. <a for=set>Remove</a> |script| from |preload script map|.
 
-1. Return null
+1. Let |body| be a new map.
+
+1. Return [=success=] with data |body|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2508,7 +2508,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
   1. Run the [=remote end subscribe steps=] for the [=event=] with [=event name=]
      |event name| given |session|, |contexts| and |include global|.
 
-1. Return [=success=] with data null.
+1. Let |body| be a new map.
+
+1. Return [=success=] with data |body|.
 
 </div>
 
@@ -2549,7 +2551,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. [=Try=] to [=update the event map=] with |session|,
    |list of event names|, |list of contexts| and enabled false.
 
-1. Return [=success=] with data null.
+1. Let |body| be a new map.
+
+1. Return [=success=] with data |body|.
 
 </div>
 
@@ -3225,7 +3229,9 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
    Otherwise return [=error=] with [=error code=] [=no such alert=].
 
-1. Return [=success=] with data null.
+1. Let |body| be a new map.
+
+1. Return [=success=] with data |body|.
 
 </div>
 


### PR DESCRIPTION
- Editorial: correct command return value
  
  The "handle an incoming message" algorithm expects every command to return either a "success" value or an "error" value.
  
  >      1. Let |result| be the result of running the [=remote end steps=] for
  >         |command| given |session| and [=command parameters=]
  >         |matched|["<code>params</code>"]
  >
  >     1. If |result| is an [=error=], then [=send an error response=] given
  >        |connection|, |command id|, and |result|'s [=error code=], and finally
  >        return.
  >
  >     1. Let |value| be |result|'s data.
  
  Update the command algorithms to satisfy this expectation.

- Editorial: return appropriate val. for EmptyResult
  
  The "handle an incoming message" algorithm asserts that values returned by command algorithms always match the documented type:
  
  >      1. Let |result| be the result of running the [=remote end steps=] for
  >         |command| given |session| and [=command parameters=]
  >         |matched|["<code>params</code>"]
  >
  >     1. If |result| is an [=error=], then [=send an error response=] given
  >        |connection|, |command id|, and |result|'s [=error code=], and finally
  >        return.
  >
  >     1. Let |value| be |result|'s data.
  >
  >     1. Assert: |value| matches the definition for the [=result type=]
  >        corresponding to the command with [=command name=] |method|.
  
  However, some algorithms which are documented to return the EmptyResult type instead return null. Update those algorithms to return an empty map in order to satisfy the assertion.

