### PR TITLE
Fix order of arguments for serialize Array-like object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1789,8 +1789,8 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>[=IsArray=](|value|)
     <dd>Let |remote value| be [=serialize an Array-like=] with
-        <code>ArrayRemoteValue</code>, |handle id|, |value|, |max depth|,
-        |ownership type|, |known object|, |serialization internal map|, and |realm|.
+        <code>ArrayRemoteValue</code>, |handle id|, |known object|, |value|,
+        |max depth|, |ownership type|, |serialization internal map|, and |realm|.
 
     <dt>[=IsRegExp=](|value|)
     <dd>
@@ -1895,14 +1895,14 @@ an |ownership type|, a |serialization internal map| and a |realm|:
 
     <dt>|value| is a [=platform object=] that implements {{NodeList}}
     <dd>Let |remote value| be [=serialize an Array-like=] with
-        <code>NodeListRemoteValue</code>,|handle id|, |value|, |max depth|,
-        |ownership type|, |known object|, |serialization internal map|, and |realm|.
+        <code>NodeListRemoteValue</code>,|handle id|, |known object|, |value|,
+        |max depth|, |ownership type|, |serialization internal map|, and |realm|.
 
     <dt>|value| is a [=platform object=] that implements {{HTMLCollection}}
     <dd>Let |remote value| be [=serialize an Array-like=] with
-        <code>HTMLCollectionRemoteValue</code>, |handle id|, |value|, |max
-        depth|, |ownership type|, |known object|, |serialization internal map|, and
-        |realm|.
+        <code>HTMLCollectionRemoteValue</code>, |handle id|, |known object|, |value|,
+        |max depth|, |ownership type|, |known object|, |serialization internal map|,
+        and |realm|.
 
     <dt>|value| is a [=platform object=] that implements [=Node=]
     <dd>
@@ -2043,8 +2043,8 @@ remove optional flag from the field.
 </div>
 
 <div algorithm>
-To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |value|,
-|max depth|, |ownership type|, |known object|, |serialization internal map|, and |realm|:
+To <dfn>serialize an Array-like</dfn> given |production|, |handle id|, |known object|,
+|value|, |max depth|, |ownership type|, |serialization internal map|, and |realm|:
 
 1. Let |remote value| be a map matching |production|, with the
    <code>handle</code> property set to |handle id| if it's not null, or omitted


### PR DESCRIPTION
Quick follow-up from https://github.com/w3c/webdriver-bidi/pull/333 to fix the order of arguments for the Array-like serialization call.

@jgraham mind a quick review?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/353.html" title="Last updated on Jan 9, 2023, 4:16 PM UTC (b72ed58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/353/fa58031...whimboo:b72ed58.html" title="Last updated on Jan 9, 2023, 4:16 PM UTC (b72ed58)">Diff</a>