### PR TITLE
Fix typo for result type in script.evaluate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4880,7 +4880,7 @@ the promise is returned.
    <dt>Result Type</dt>
    <dd>
     <pre class="cddl">
-    ScriptEvaluateResult
+    script.EvaluateResult
    </pre>
    </dd>
 </dl>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/webdriver-bidi/pull/365.html" title="Last updated on Feb 10, 2023, 1:10 PM UTC (afb3a87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/365/a0d9ee0...Lightning00Blade:afb3a87.html" title="Last updated on Feb 10, 2023, 1:10 PM UTC (afb3a87)">Diff</a>