### PR TITLE
Emit `children` if it wasn't collected.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2082,7 +2082,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
             1. Append |serialized| to |children|.
 
-          1. Set |serialized|["<code>children</code>"] to |children|.
+          1. If |children| is not null, set |serialized|["<code>children</code>"] to |children|.
 
           1. If |value| is an [=/Element=]:
 


### PR DESCRIPTION
Align node's `children` with `value`, where emitted field means didn't try to get the value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver-bidi/pull/367.html" title="Last updated on Feb 21, 2023, 4:09 PM UTC (0a05a37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/367/6a3b650...sadym-chromium:0a05a37.html" title="Last updated on Feb 21, 2023, 4:09 PM UTC (0a05a37)">Diff</a>