### PR TITLE
Allow numbers in pageRanges

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3458,7 +3458,7 @@ PDF document represented as a Base64-encoded string.
         ?margin: browsingContext.PrintMarginParameters,
         ?orientation: ("portrait" / "landscape") .default "portrait",
         ?page: browsingContext.PrintPageParameters,
-        ?pageRanges: [*text],
+        ?pageRanges: [*(js-uint / text)],
         ?scale: 0.1..2.0 .default 1.0,
         ?shrinkToFit: bool .default true,
       }


### PR DESCRIPTION
To make it easier for the clients and align with [Webdriver spec ](https://www.w3.org/TR/webdriver/#print) we should allow `pageRanges` accept not just strings but numbers as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/372.html" title="Last updated on Feb 24, 2023, 1:29 PM UTC (3f547e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/372/ade713d...lutien:3f547e2.html" title="Last updated on Feb 24, 2023, 1:29 PM UTC (3f547e2)">Diff</a>