### PR TITLE
Add type `platformObject`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1877,6 +1877,12 @@ WindowProxyRemoteValue = {
   ?handle: Handle,
   ?internalId: InternalId,
 }
+
+PlatformObjectRemoteValue = {
+  type: "platformobject",
+  ?handle: Handle,
+  ?internalId: InternalId,
+}
 </pre>
 
 Issue: Add WASM types?
@@ -2130,7 +2136,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
            property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=]
-    <dd>1. Let |remote value| be a [=/map=] matching the <code>ObjectRemoteValue</code>
+    <dd>1. Let |remote value| be a [=/map=] matching the <code>PlatformObjectRemoteValue</code>
            production in the [=local end definition=], with the <code>handle</code>
            property set to |handle id| if it's not null, or omitted otherwise.
 


### PR DESCRIPTION
Add explicit type `platformobject`, as long as it is treated in other then JS `object` way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/377.html" title="Last updated on Mar 2, 2023, 2:38 PM UTC (552c837)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/377/b3fd58d...552c837.html" title="Last updated on Mar 2, 2023, 2:38 PM UTC (552c837)">Diff</a>