### PR TITLE
Fail with "no such node" error if origin doesn't match when deserializing a shared reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1224,8 +1224,8 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
    [=realm execution context=]'s Realm component is |realm|.
 
 1. If |node|'s [=node document=]'s [=Document/origin=] is not [=same origin
-   domain=] with |environment settings|'s [=environment settings object/origin=] then
-   return null.
+   domain=] with |environment settings|'s [=environment settings object/origin=]
+   then return [=error=] with [=error code=] [=no such node=].
 
    Note: This ensures that WebDriver-BiDi can not be used to pass objects
    between realms that do not otherwise permit script access.


### PR DESCRIPTION
Fix #376

CC @jgraham and @sadym-chromium.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/379.html" title="Last updated on Mar 3, 2023, 10:37 AM UTC (23f07a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/379/b3fd58d...whimboo:23f07a3.html" title="Last updated on Mar 3, 2023, 10:37 AM UTC (23f07a3)">Diff</a>