### PR TITLE
Fix links to Element and Attr

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2037,7 +2037,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
         |max depth|, |ownership type|, |known object|, |serialization internal map|,
         and |realm|.
 
-    <dt>|value| is a [=platform object=] that implements [=Node=]
+    <dt>|value| is a [=platform object=] that implements {{Node}}
     <dd>
       1. Let |shared id| be [=get shared id for a node=] with |value|, |realm| and
          |session|.
@@ -2064,7 +2064,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
           1. If |node value| is not null set
              |serialized|["<code>nodeValue</code>"] to |node value|.
 
-          1. If |value| is an [=/Element=] or an <a spec=dom>Attribute</a>:
+          1. If |value| implements {{Element}} or {{Attr}}:
 
             1. Set |serialized|["<code>localName</code>"] to [=Get=](|value|, "localName").
 
@@ -2088,7 +2088,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
           1. If |children| is not null, set |serialized|["<code>children</code>"] to |children|.
 
-          1. If |value| is an [=/Element=]:
+          1. If |value| implements {{Element}}:
 
              1. Let |attributes| be a new [=/map=].
 


### PR DESCRIPTION
This was breaking the build. Linking to the IDL interfaces is more correct in context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/380.html" title="Last updated on Mar 8, 2023, 3:17 PM UTC (d7c6241)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/380/c4ef5d3...d7c6241.html" title="Last updated on Mar 8, 2023, 3:17 PM UTC (d7c6241)">Diff</a>