### PR TITLE
Make preload scripts take a function declaration instead of expression

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -92,7 +92,6 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Construct; url: sec-construct
     text: CreateArrayFromList; url: sec-createarrayfromlist
     text: CreateArrayIterator; url: sec-createarrayiterator
-    text: CreateBuiltinFunction; url: sec-createbuiltinfunction
     text: CreateListFromArrayLike; url: sec-createlistfromarraylike
     text: CreateMapIterator; url: sec-createmapiterator
     text: CreateSetIterator; url: sec-createsetiterator
@@ -4237,11 +4236,13 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. Let |function declaration| be |preload script|'s <code>function declaration</code>.
 
-    1. Let (|script|, |function body evaluation status|) be the result of [=evaluate function body=]
-       |function declaration|, |environment settings|, |base URL|, and |options|.
+    1. Let (|script|, |function body evaluation status|) be the result of
+       [=evaluate function body=] with |function declaration|,
+       |environment settings|, |base URL|, and |options|.
 
     1. If |function body evaluation status| is an [=abrupt completion=], then
-       [=report the exception=] given by |evaluation status|.\[[Value]] for |script|.
+       [=report the exception=] given by |function body evaluation status|.\[[Value]]
+       for |script|.
 
     1. Let |function object| be |function body evaluation status|.\[[Value]].
 
@@ -4258,7 +4259,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. [=Clean up after running script=] with |environment settings|.
 
-    1. If |function body evaluation status| is an [=abrupt completion=], then
+    1. If |evaluation status| is an [=abrupt completion=], then
        [=report the exception=] given by |evaluation status|.\[[Value]] for |script|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -4864,7 +4864,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |preload script map| be |session|'s [=preload script map=].
 
 1. Set |preload script map|[|script|] to a struct with <code>function
-   declaration</code> |function declaration|, , and <code>sandbox</code> |sandbox|.
+   declaration</code> |function declaration|, and <code>sandbox</code> |sandbox|.
 
 1. Return a new [=/map=] matching the <code>script.AddPreloadScriptResult</code> with the
    <code>script</code> field set to |script|.

--- a/index.bs
+++ b/index.bs
@@ -4853,7 +4853,7 @@ script=].
 <div algorithm="remote end steps for script.addPreloadScript">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |function declaration| be the <code>function declaration</code> field of |command
+1. Let |function declaration| be the <code>functionDeclaration</code> field of |command
    parameters|.
 
 1. Let |script| be the string representation of a [[!RFC4122|UUID]].

--- a/index.bs
+++ b/index.bs
@@ -4203,11 +4203,11 @@ before any author-defined script have run.
 
 TODO: Extend this to scripts in other kinds of realms.
 
-A [=BiDi session=] has a <dfn>preload script map</dfn> which is a [=/map=] in which
-the keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
+A [=BiDi session=] has a <dfn>preload script map</dfn> which is a [=/map=] in
+which the keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
 for=struct>item</a> named <code>function declaration</code>, which is a string,
-<code>arguments</code> which is a list, and an item named <code>sandbox</code>
-which is a string or null.
+<code>arguments</code>, and an item named <code>sandbox</code> which is a string
+or null.
 
 Note: If executing a [=preload script=] fails, either due to a syntax error, or
 a runtime exception, an [[ECMAScript]] exception is reported in the realm in
@@ -4230,8 +4230,6 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
        or create a sandbox realm=] with |preload script|'s <code>sandbox</code> and
        |browsing context|. Otherwise let |realm| be |environment settings|'
        [=realm execution context=]'s Realm component.
-
-    1. Let |options| be the [=default classic script fetch options=].
 
     1. Let |base URL| be the [=API base URL=] of |environment settings|.
 

--- a/index.bs
+++ b/index.bs
@@ -4941,7 +4941,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         target: script.Target,
         ?arguments: [*script.ArgumentValue],
         ?resultOwnership: script.ResultOwnership,
-        ?serializationOptions: script.SerializationOption,
+        ?serializationOptions: script.SerializationOptions,
         ?this: script.ArgumentValue,
       }
 

--- a/index.bs
+++ b/index.bs
@@ -92,6 +92,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Construct; url: sec-construct
     text: CreateArrayFromList; url: sec-createarrayfromlist
     text: CreateArrayIterator; url: sec-createarrayiterator
+    text: CreateBuiltinFunction; url: sec-createbuiltinfunction
     text: CreateListFromArrayLike; url: sec-createlistfromarraylike
     text: CreateMapIterator; url: sec-createmapiterator
     text: CreateSetIterator; url: sec-createsetiterator
@@ -4202,10 +4203,15 @@ before any author-defined script have run.
 
 TODO: Extend this to scripts in other kinds of realms.
 
-A [=BiDi session=] has a <dfn>preload script map</dfn> which is a [=/map=] in
-which the keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
-for=struct>item</a> named <code>expression</code>, which is a string, and an
-item named <code>sandbox</code> which is a string or null.
+A [=BiDi session=] has a <dfn>preload script map</dfn> which is a [=/map=] in which
+the keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
+for=struct>item</a> named <code>function declaration</code>, which is a string,
+<code>arguments</code> which is a list, and an item named <code>sandbox</code>
+which is a string or null.
+
+Note: If executing a [=preload script=] fails, either due to a syntax error, or
+a runtime exception, an [[ECMAScript]] exception is reported in the realm in
+which it was being executed, and other preload scripts run as normal.
 
 <div algorithm>
 To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment settings|:
@@ -4225,23 +4231,37 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
        |browsing context|. Otherwise let |realm| be |environment settings|'
        [=realm execution context=]'s Realm component.
 
-    1. Let |source| be |preload script|'s <code>expression</code>.
-
     1. Let |options| be the [=default classic script fetch options=].
 
     1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
-    1. Let |script| be the result of [=create a classic script=] with |source|,
-       |environment settings|, |base URL|, and |options|.
+    1. Let |options| be the [=default classic script fetch options=].
+
+    1. Let |function declaration| be |preload script|'s <code>function declaration</code>.
+
+    1. Let (|script|, |function body evaluation status|) be the result of [=evaluate function body=]
+       |function declaration|, |environment settings|, |base URL|, and |options|.
+
+    1. If |function body evaluation status| is an [=abrupt completion=], then
+       [=report the exception=] given by |evaluation status|.\[[Value]] for |script|.
+
+    1. Let |function object| be |function body evaluation status|.\[[Value]].
+
+    1. If [=IsCallable=](|function object|) is <code>false</code>:
+
+       1. Let |error| be a new [=TypeError=] object in |realm|.
+
+       1. [=Report the exception=] |error|.
 
     1. [=Prepare to run script=] with |environment settings|.
 
-    1. Let |evaluation status| be [=ScriptEvaluation=](|script|'s record).
-
-    1. If |evaluation status| is an [=abrupt completion=], then [=report the
-       exception=] given by |evaluation status|.\[[Value]] for |script|.
+    1. Set |evaluation status| to
+       [=Call=](|function object|, null, «»).
 
     1. [=Clean up after running script=] with |environment settings|.
+
+    1. If |function body evaluation status| is an [=abrupt completion=], then
+       [=report the exception=] given by |evaluation status|.\[[Value]] for |script|.
 
 </div>
 
@@ -4815,7 +4835,7 @@ script=].
       }
 
       script.AddPreloadScriptParameters = {
-        expression: text;
+        functionDeclaration: text,
         ?sandbox: text
       }
       </pre>
@@ -4833,7 +4853,7 @@ script=].
 <div algorithm="remote end steps for script.addPreloadScript">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |expression| be the <code>expression</code> field of |command
+1. Let |function declaration| be the <code>function declaration</code> field of |command
    parameters|.
 
 1. Let |script| be the string representation of a [[!RFC4122|UUID]].
@@ -4843,8 +4863,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |preload script map| be |session|'s [=preload script map=].
 
-1. Set |preload script map|[|script|] to a struct with <code>expression</code>
-   |expression| and <code>sandbox</code> |sandbox|.
+1. Set |preload script map|[|script|] to a struct with <code>function
+   declaration</code> |function declaration|, , and <code>sandbox</code> |sandbox|.
 
 1. Return a new [=/map=] matching the <code>script.AddPreloadScriptResult</code> with the
    <code>script</code> field set to |script|.
@@ -4923,7 +4943,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         target: script.Target,
         ?arguments: [*script.ArgumentValue],
         ?resultOwnership: script.ResultOwnership,
-        ?serializationOptions: script.SerializationOptions
+        ?serializationOptions: script.SerializationOption,
         ?this: script.ArgumentValue,
       }
 
@@ -4980,10 +5000,12 @@ Note: the |function declaration| is parenthesized and evaluated.
 
 1. [=Clean up after running script=] with |environment settings|.
 
-1. Return |function body evaluation status|.
+1. Return (|function script|, |function body evaluation status|).
 
 </div>
 
+
+<div algorithm="remote end steps for script.callFunction">
 
 The [=remote end steps=] with |session| and |command parameters| are:
 
@@ -5025,8 +5047,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.
 
-1. Let |function body evaluation status| be the result of [=evaluate function body=]
-   (|function declaration|, |environment settings|, |base URL|, and |options|).
+1. Let |base URL| be the [=API base URL=] of |environment settings|.
+
+1. Let |options| be the [=default classic script fetch options=].
+
+1. Let (<var ignore>script</var>, |function body evaluation status|) be the
+   result of [=evaluate function body=] with |function declaration|,
+   |environment settings|, |base URL|, and |options|.
 
 1. If |function body evaluation status|.\[[Type]] is <code>throw</code>:
 
@@ -5118,7 +5145,9 @@ TODO: Add timeout argument. It's not totally clear how this ought to work; in
 Chrome it seems like the timeout doesn't apply to the promise resolve step, but
 that likely isn't what clients want.
 
-The [=remote end steps=] with |session| and |command parameters| are:
+<div algorithm="remote end steps for script.evaluate">
+
+The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.


### PR DESCRIPTION
This is a prerequisite to adding support for arguments, which is required to allow passing in message channels.

This also cleans up a few bugs with evaluating functions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/381.html" title="Last updated on Mar 30, 2023, 11:05 AM UTC (bc976d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/381/99db2d4...bc976d4.html" title="Last updated on Mar 30, 2023, 11:05 AM UTC (bc976d4)">Diff</a>