### PR TITLE
Do not change maxDepth when serializing shadow root

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2109,8 +2109,8 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
                1. Let |serialized shadow| be the result of
                   [=serialize as a remote value=] with |shadow root|, |max depth|,
-                  false, |ownership type|, |serialization internal map|,
-                  |realm|, and |session|.
+                  |ownership type|, |serialization internal map|, |realm|, and
+                  |session|.
 
                 Note: this means the <code>handle</code> for the shadow root
                 will be serialized irrespective of whether the shadow is open or closed,

--- a/index.bs
+++ b/index.bs
@@ -2107,11 +2107,8 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
              1. If |shadow root| is null, let |serialized shadow| be null.
                 Otherwise run the following substeps:
 
-               1.  Let |child depth| be |max depth| - 1 if |max depth| is not
-                  null, or null otherwise.
-
                1. Let |serialized shadow| be the result of
-                  [=serialize as a remote value=] with |shadow root|, |child depth|,
+                  [=serialize as a remote value=] with |shadow root|, |max depth|,
                   false, |ownership type|, |serialization internal map|,
                   |realm|, and |session|.
 


### PR DESCRIPTION
Since current assumption that we want always to return shadow root id, we shouldn't change maxDepth on this step.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/386.html" title="Last updated on Mar 21, 2023, 10:19 AM UTC (83b2f9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/386/fff0819...lutien:83b2f9a.html" title="Last updated on Mar 21, 2023, 10:19 AM UTC (83b2f9a)">Diff</a>