### PR TITLE
Remove the note about the difference between open and closed shadow root serialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2115,10 +2115,6 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
                   false, |ownership type|, |serialization internal map|,
                   |realm|, and |session|.
 
-                Note: this means the <code>handle</code> for the shadow root
-                will be serialized irrespective of whether the shadow is open or closed,
-                but no properties of the node will be returned.
-
              1. Set |serialized|["<code>shadowRoot</code>"] to |serialized shadow|.
 
       1. If |serialized| is not null, set field <code>value</code> of |remote value| to


### PR DESCRIPTION
This note doesn't really clarify the behavior and just makes things more confusing, we should rather write a proper description.
I've filled the issue to discuss it #388.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 22, 2023, 5:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Flutien%2Fwebdriver-bidi%2F99d8d6e58af7f6fbe3e7444ed5ab32ccc3b5f8e2%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: LINE 4391:1: Garbage after the tagname in &lt;/div>.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23387.)._
</details>
