### PR TITLE
Close div tag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4392,7 +4392,7 @@ To <dfn>get the browsing context</dfn> with given |realm|:
 
 1. Return |document|'s [=/browsing context=].
 
-</div
+</div>
 
 <div algorithm>
 To <dfn>get the realm info</dfn> given |environment settings|:


### PR DESCRIPTION
`bikeshed` package got updated and now fails to build because of this issue.
Example of such failure: https://github.com/w3c/webdriver-bidi/actions/runs/4491928751/jobs/7901092699?pr=387


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 22, 2023, 4:04 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebdriver-bidi%2Ffff0819ba7670e688b1054c847a9a3672278b2df%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: LINE 4395:1: Garbage after the tagname in &lt;/div>.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23389.)._
</details>
