### PR TITLE
Remove the issue about optional shadowRoot field

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2203,9 +2203,6 @@ reference to <code>childNodes</code>, or it should be renamed to <code>childrenC
 Issue: <code>nodeValue</code> can be null. Omit the field in such a case, or adjust type to allow
 null value.
 
-Issue: <code>shadowRoot</code> field is optional. Omit it in case of |shadow root| is null, or
-remove optional flag from the field.
-
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Removes the issue (see the deiscussion in this PR): https://w3c.github.io/webdriver-bidi/#issue-e8085260


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/392.html" title="Last updated on Mar 29, 2023, 9:47 AM UTC (689d132)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/392/6fdbd49...lutien:689d132.html" title="Last updated on Mar 29, 2023, 9:47 AM UTC (689d132)">Diff</a>