### PR TITLE
cddl: fix choice grouping

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1291,14 +1291,14 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 by reference.
 
 <pre class="cddl remote-cddl local-cddl">
-PrimitiveProtocolValue = {
+PrimitiveProtocolValue = (
   UndefinedValue //
   NullValue //
   StringValue //
   NumberValue //
   BooleanValue //
-  BigIntValue //
-}
+  BigIntValue
+)
 
 UndefinedValue = {
   type: "undefined",
@@ -1461,15 +1461,15 @@ to ECMAScript without reference to existing objects.
 
 
 <pre class="cddl remote-cddl local-cddl">
-LocalValue = {
+LocalValue = (
   PrimitiveProtocolValue //
   ArrayLocalValue //
   DateLocalValue //
   MapLocalValue //
   ObjectLocalValue //
   RegExpLocalValue //
-  SetLocalValue //
-}
+  SetLocalValue
+)
 
 ListLocalValue = [*LocalValue];
 
@@ -1768,7 +1768,7 @@ RemoteValue = (
   NodeListRemoteValue //
   HTMLCollectionRemoteValue //
   NodeRemoteValue //
-  WindowProxyRemoteValue //
+  WindowProxyRemoteValue
 )
 
 InternalId = js-uint;
@@ -5205,7 +5205,7 @@ Issue: This has the wrong error code
 [=Local end definition=]
 
 <pre class="cddl local-cddl">
-script.RealmInfo = {
+script.RealmInfo = (
   script.WindowRealmInfo //
   script.DedicatedWorkerRealmInfo //
   script.SharedWorkerRealmInfo //
@@ -5213,8 +5213,8 @@ script.RealmInfo = {
   script.WorkerRealmInfo //
   script.PaintWorkletRealmInfo //
   script.AudioWorkletRealmInfo //
-  script.WorkletRealmInfo //
-}
+  script.WorkletRealmInfo
+)
 
 script.BaseRealmInfo = {
   realm: script.Realm,


### PR DESCRIPTION
While working on my cddl package I tested it against the current WebDriver-Bidi cddl artifact and recognised some issues:

- group choices can only be wrapped within parentheses
- last group item can not be followed by ending `//` (this might be ambiguous - maybe just not defined well in the spec)

I could be wrong with all this, so feel free to disregard.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/395.html" title="Last updated on Apr 6, 2023, 8:29 AM UTC (402d879)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/395/9904e83...402d879.html" title="Last updated on Apr 6, 2023, 8:29 AM UTC (402d879)">Diff</a>