### PR TITLE
Fix type of coordinates in actions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6792,8 +6792,8 @@ specified sequence of user input actions.
 
       input.PointerMoveAction = {
         type: "pointerMove",
-        x: js-uint,
-        y: js-uint,
+        x: js-int,
+        y: js-int,
         ? duration: js-uint,
         ? origin: input.Origin,
         input.PointerCommonProperties
@@ -6801,8 +6801,8 @@ specified sequence of user input actions.
 
       input.WheelScrollAction = {
         type: "scroll",
-        x: js-uint,
-        y: js-uint,
+        x: js-int,
+        y: js-int,
         deltaX: js-int,
         deltaY: js-int,
         ? duration: js-uint,


### PR DESCRIPTION
These can be negative when not relative to the viewport, so the overall definition has to use js-int.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/400.html" title="Last updated on Apr 12, 2023, 9:42 AM UTC (b60ee73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/400/52b8aa5...b60ee73.html" title="Last updated on Apr 12, 2023, 9:42 AM UTC (b60ee73)">Diff</a>