### PR TITLE
Fix link to TypeError definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5082,7 +5082,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. If [=IsCallable=](|function object|) is <code>false</code>:
 
-       1. Let |error| be a new [=TypeError=] object in |realm|.
+       1. Let |error| be a new <a data-link-type="exception">TypeError</a> object in |realm|.
 
        1. [=Report the exception=] |error|.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/401.html" title="Last updated on Apr 12, 2023, 9:58 AM UTC (6cf8bb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/401/52b8aa5...6cf8bb2.html" title="Last updated on Apr 12, 2023, 9:58 AM UTC (6cf8bb2)">Diff</a>