### PR TITLE
Run `maxObjectDepth` assertion only when it is not null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2272,8 +2272,9 @@ and |session|:
 To <dfn>serialize as a list</dfn> given |iterable|, |serialization options|, |ownership type|,
 |serialization internal map|, |realm|, and |session|:
 
-1. Assert: |serialization options|["<code>maxObjectDepth</code>"] is greater
-   than 0.
+1. If |serialization options|["<code>maxObjectDepth</code>"] is not null,
+   assert: |serialization options|["<code>maxObjectDepth</code>"] is
+   greater than 0.
 
 1. Let |serialized| be a new list.
 
@@ -2303,8 +2304,9 @@ Issue: this assumes for-in works on iterators
 To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 |ownership type|, |serialization internal map|, |realm|, and |session|:
 
-1. Assert: |serialization options|["<code>maxObjectDepth</code>"] is greater
-   than 0.
+1. If |serialization options|["<code>maxObjectDepth</code>"] is not null,
+   assert: |serialization options|["<code>maxObjectDepth</code>"] is
+   greater than 0.
 
 1. Let |serialized| be a new list.
 


### PR DESCRIPTION
Since `maxObjectDepth` can also be `null` we should first check for it before asserting for positive number.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/404.html" title="Last updated on Apr 12, 2023, 3:39 PM UTC (ed04645)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/404/6e40aba...lutien:ed04645.html" title="Last updated on Apr 12, 2023, 3:39 PM UTC (ed04645)">Diff</a>