### PR TITLE
Remove unused "OwnershipModel" definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1167,10 +1167,6 @@ Issue: Define how this works.
 Each EMCAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong [=/map=] from handle ids to their corresponding objects.
 
-<pre class="cddl remote-cddl">
-OwnershipModel = "root" / "none";
-</pre>
-
 <dfn>RemoteReference</dfn> is either a <code>RemoteObjectReference</code>
 representing a remote reference to an existing ECMAScript object in
 [=handle object map=] in the given [=Realm=], or is a <code>SharedReference</code>


### PR DESCRIPTION
These definitions are exactly the same ("root" / "none"). It would be better to stick to a single one for consistency.

"ResultingOwnership" was picked arbitrarily. Either name would have been fine.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/406.html" title="Last updated on Apr 18, 2023, 9:13 AM UTC (af10fe1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/406/e123a41...af10fe1.html" title="Last updated on Apr 18, 2023, 9:13 AM UTC (af10fe1)">Diff</a>