### PR TITLE
(cddl): fix ScriptCommand

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4018,7 +4018,7 @@ ScriptCommand = (
   script.CallFunction //
   script.Disown //
   script.Evaluate //
-  script.GetRealms
+  script.GetRealms //
   script.RemovePreloadScriptCommand
 )
 </pre>


### PR DESCRIPTION
Stumbled upon this while working on my [CDDL parser](https://github.com/christian-bromann/cddl).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/419.html" title="Last updated on May 23, 2023, 7:18 AM UTC (175b881)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/419/635b8e8...175b881.html" title="Last updated on May 23, 2023, 7:18 AM UTC (175b881)">Diff</a>