### PR TITLE
Add browsingContext.setViewport

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,6 +291,7 @@ Command = {
 CommandData = (
   BrowserCommand //
   BrowsingContextCommand //
+  EmulationCommand //
   InputCommand //
   NetworkCommand //
   ScriptCommand //
@@ -3209,6 +3210,76 @@ opened</dfn> steps given |window|, |type| and |message|.
    given "<code>browsingContext.userPromptOpened</code>" and |related browsing contexts|:
 
   1. [=Emit an event=] with |session| and |body|.
+
+</div>
+
+## Emulation ## {#module-emulation}
+
+The <dfn export for=modules>emulation</dfn> module contains functionality for
+emulating device-dependent and system-dependent parameters.
+
+### Definition ### {#module-emulation-definition}
+
+[=remote end definition=]
+
+<pre class="cddl remote-cddl">
+
+EmulationCommand = (
+  emulation.SetViewport
+)
+</pre>
+
+### Types ### {#module-emulation-types}
+
+### Commands ### {#module-emulation-commands}
+
+#### The emulation.setViewport Command ####  {#command-emulation-setViewport}
+
+The <dfn export for=commands>emulation.setViewport</dfn> command turns the emulation of the specified viewport on.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      emulation.SetViewport = {
+        method: "emulation.setViewport",
+        params: emulation.SetViewportParameters
+      };
+
+      emulation.SetViewportParameters = {
+        context: browsingContext.BrowsingContext,
+        ? viewport: emulation.Viewport
+      }
+
+      emulation.Viewport = {
+        ? width: js-uint,
+        ? height: js-uint,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl">
+     EmptyResult
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for emulation.setViewport">
+
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |context id| be the value of the <code>context</code> field of
+   |command parameters|.
+
+1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+   with |context id|.
+
+1. Let |viewport| be value of the <code>viewport</code> field of |command parameters| in [[webdriver#dfn-css-pixels]].
+
+1. Apply |viewport| as the actual vieport as defined in [[css-viewport#the-viewport]] to the |context| and all current and future sub-contexts that have a concept of a viewport.
+
+1. Return [=success=] with data null.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3281,9 +3281,10 @@ The [=remote end steps=] with |command parameters| are:
     1. Let |width| be the <code>width</code> field of |viewport parameter| in CSS pixels.
     1. Let |height| be the <code>height</code> field of |viewport parameter| in CSS pixels.
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
-    1. Change the layout viewport of the |context| to be |width| pixels wide and |height| pixels high and run the [[cssom-view-1#resizing-viewports]] steps.
+    1. Set the layout [[css2#viewport]] of the |context| to be |width| pixels wide and |height| pixels high.
 1. Else:
-    1. Turn off the viewport emulation on the |context|, reset it to the original value and run the [[cssom-view-1#resizing-viewports]] steps.
+    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
+1. Run the [[cssom-view-1#resizing-viewports]] steps.
 1. Return [=success=] with data null.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,6 @@ Command = {
 CommandData = (
   BrowserCommand //
   BrowsingContextCommand //
-  EmulationCommand //
   InputCommand //
   NetworkCommand //
   ScriptCommand //
@@ -2730,6 +2729,62 @@ The [=remote end steps=] with |command parameters| are:
 
 </div>
 
+#### The browsingContext.setViewport Command ####  {#command-browsingContext-setViewport}
+
+The <dfn export for=commands>browsingContext.setViewport</dfn> command  specific viewport characteristics (e.g. viewport width and viewport height) on the given top-level browsing context.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      browsingContext.SetViewport = {
+        method: "browsingContext.setViewport",
+        params: browsingContext.SetViewportParameters
+      };
+
+      browsingContext.SetViewportParameters = {
+        context: browsingContext.BrowsingContext,
+        viewport: browsingContext.Viewport / null,
+      }
+
+      browsingContext.Viewport = {
+        width: js-uint,
+        height: js-uint,
+      }
+    </pre>
+   </dd>
+   <dt>Result Type</dt>
+   <dd>
+    <pre class="cddl">
+     EmptyResult
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.setViewport">
+
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |context id| be the value of the |command parameters|["<code>context</code>"] field.
+
+1. Let |context| be the result of [=trying=] to [=get a browsing context=] with |context id|.
+
+1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
+
+1. If |viewport parameter| is not null:
+    1. Let |width| be the |viewport parameter|'s["<code>width</code>""] field in CSS pixels.
+    1. Let |height| be the |viewport parameter|'s["<code>height</code>""] field in CSS pixels.
+    1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
+    1. Set the layout [[css2#viewport]] of the |context| to be |width| pixels wide and |height| pixels high.
+1. Else:
+    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
+1. Run the [[cssom-view-1#resizing-viewports]] steps.
+1. Return [=success=] with data null.
+
+</div>
+
 
 ### Events ### {#module-contexts-events}
 
@@ -3213,81 +3268,6 @@ opened</dfn> steps given |window|, |type| and |message|.
 
 </div>
 
-## Emulation ## {#module-emulation}
-
-The <dfn export for=modules>emulation</dfn> module contains functionality for
-emulating device-dependent and system-dependent parameters.
-
-### Definition ### {#module-emulation-definition}
-
-[=remote end definition=]
-
-<pre class="cddl remote-cddl">
-
-EmulationCommand = (
-  emulation.SetViewport
-)
-</pre>
-
-### Types ### {#module-emulation-types}
-
-### Commands ### {#module-emulation-commands}
-
-#### The emulation.setViewport Command ####  {#command-emulation-setViewport}
-
-The <dfn export for=commands>emulation.setViewport</dfn> command emulates specific viewport characteristics (e.g. viewport width and viewport height) on the given top-level browsing context.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl remote-cddl">
-      emulation.SetViewport = {
-        method: "emulation.setViewport",
-        params: emulation.SetViewportParameters
-      };
-
-      emulation.SetViewportParameters = {
-        context: browsingContext.BrowsingContext,
-        viewport: emulation.Viewport / null,
-      }
-
-      emulation.Viewport = {
-        width: js-uint,
-        height: js-uint,
-      }
-    </pre>
-   </dd>
-   <dt>Result Type</dt>
-   <dd>
-    <pre class="cddl">
-     EmptyResult
-    </pre>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for emulation.setViewport">
-
-The [=remote end steps=] with |command parameters| are:
-
-1. Let |context id| be the value of the |command parameters|["<code>context</code>"] field.
-
-1. Let |context| be the result of [=trying=] to [=get a browsing context=] with |context id|.
-
-1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
-
-1. If |viewport parameter| is not null:
-    1. Let |width| be the |viewport parameter|'s["<code>width</code>""] field in CSS pixels.
-    1. Let |height| be the |viewport parameter|'s["<code>height</code>""] field in CSS pixels.
-    1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
-    1. Set the layout [[css2#viewport]] of the |context| to be |width| pixels wide and |height| pixels high.
-1. Else:
-    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
-1. Run the [[cssom-view-1#resizing-viewports]] steps.
-1. Return [=success=] with data null.
-
-</div>
 
 ## The network Module ## {#module-network}
 

--- a/index.bs
+++ b/index.bs
@@ -3274,7 +3274,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |context| be the result of [=trying=] to [=get a browsing context=] with |context id|.
 
-1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=unsupported operation=].
+1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |command parameters| [=map/contains=] "<code>viewport</code>", then:
     1. Let |viewport parameters| be the <code>viewport</code> attribute of |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -2774,8 +2774,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
 
 1. If |viewport parameter| is not null:
-    1. Let |width| be the |viewport parameter|["<code>width</code>"]`
-    1. Let |height| be the |viewport parameter|["<code>height</code>"]`
+    1. Let |width| be the |viewport parameter|["<code>width</code>"]
+    1. Let |height| be the |viewport parameter|["<code>height</code>"]
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the layout [[css2#viewport]] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:

--- a/index.bs
+++ b/index.bs
@@ -3248,7 +3248,7 @@ The <dfn export for=commands>emulation.setViewport</dfn> command emulates specif
 
       emulation.SetViewportParameters = {
         context: browsingContext.BrowsingContext,
-        ? viewport: emulation.Viewport
+        viewport: emulation.Viewport / null,
       }
 
       emulation.Viewport = {
@@ -3257,7 +3257,7 @@ The <dfn export for=commands>emulation.setViewport</dfn> command emulates specif
       }
     </pre>
    </dd>
-   <dt>Return Type</dt>
+   <dt>Result Type</dt>
    <dd>
     <pre class="cddl">
      EmptyResult
@@ -3269,17 +3269,17 @@ The <dfn export for=commands>emulation.setViewport</dfn> command emulates specif
 
 The [=remote end steps=] with |command parameters| are:
 
-1. Let |context id| be the value of the <code>context</code> field of
-   |command parameters|.
+1. Let |context id| be the value of the |command parameters|["<code>context</code>"] field.
 
 1. Let |context| be the result of [=trying=] to [=get a browsing context=] with |context id|.
 
 1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |command parameters| [=map/contains=] "<code>viewport</code>", then:
-    1. Let |viewport parameter| be the <code>viewport</code> field of |command parameters|.
-    1. Let |width| be the <code>width</code> field of |viewport parameter| in CSS pixels.
-    1. Let |height| be the <code>height</code> field of |viewport parameter| in CSS pixels.
+1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
+
+1. If |viewport parameter| is not null:
+    1. Let |width| be the |viewport parameter|'s["<code>width</code>""] field in CSS pixels.
+    1. Let |height| be the |viewport parameter|'s["<code>height</code>""] field in CSS pixels.
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the layout [[css2#viewport]] of the |context| to be |width| pixels wide and |height| pixels high.
 1. Else:

--- a/index.bs
+++ b/index.bs
@@ -2774,10 +2774,10 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
 
 1. If |viewport parameter| is not null:
-    1. Let |width| be the |viewport parameter|'s["<code>width</code>""] field in CSS pixels.
-    1. Let |height| be the |viewport parameter|'s["<code>height</code>""] field in CSS pixels.
+    1. Let |width| be the |viewport parameter|["<code>width</code>"]`
+    1. Let |height| be the |viewport parameter|["<code>height</code>"]`
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
-    1. Set the layout [[css2#viewport]] of the |context| to be |width| pixels wide and |height| pixels high.
+    1. Set the layout [[css2#viewport]] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
     1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
 1. Run the [[cssom-view-1#resizing-viewports]] steps.

--- a/index.bs
+++ b/index.bs
@@ -3235,7 +3235,7 @@ EmulationCommand = (
 
 #### The emulation.setViewport Command ####  {#command-emulation-setViewport}
 
-The <dfn export for=commands>emulation.setViewport</dfn> command turns the emulation of the specified viewport on.
+The <dfn export for=commands>emulation.setViewport</dfn> command turns the emulation of the viewport on.
 
 <dl>
    <dt>Command Type</dt>
@@ -3252,8 +3252,8 @@ The <dfn export for=commands>emulation.setViewport</dfn> command turns the emula
       }
 
       emulation.Viewport = {
-        ? width: js-uint,
-        ? height: js-uint,
+        width: js-uint,
+        height: js-uint,
       }
     </pre>
    </dd>
@@ -3272,13 +3272,20 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |context id| be the value of the <code>context</code> field of
    |command parameters|.
 
-1. Let |context| be the result of [=trying=] to [=get a browsing context=]
-   with |context id|.
+1. Let |context| be the result of [=trying=] to [=get a browsing context=] with |context id|.
 
-1. Let |viewport| be value of the <code>viewport</code> field of |command parameters| in [[webdriver#dfn-css-pixels]].
+1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Apply |viewport| as the actual vieport as defined in [[css-viewport#the-viewport]] to the |context| and all current and future sub-contexts that have a concept of a viewport.
-
+1. If |command parameters| [=map/contains=] "<code>viewport</code>", then:
+    1. Let |viewport parameters| be the <code>viewport</code> attribute of |command parameters|.
+    1. If |viewport parameters| [=map/contains=] "<code>width</code>" and |viewport parameters| [=map/contains=] "<code>height</code>", then:
+        1. Let |width| be the <code>width</code> attribute of |viewport parameters| in CSS pixels.
+        1. Let |height| be the <code>height</code> attribute of |viewport parameters| in CSS pixels.
+        1. Change the layout viewport of the |context| to be |width| pixels wide and |height| pixels high and run the [[cssom-view-1#resizing-viewports]] steps.
+    1. Else:
+        1. Return [=error=] with [=error code=] [=invalid argument=].
+1. Else:
+    1. Reset any previously emulated viewport on the |context|.
 1. Return [=success=] with data null.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -3235,7 +3235,7 @@ EmulationCommand = (
 
 #### The emulation.setViewport Command ####  {#command-emulation-setViewport}
 
-The <dfn export for=commands>emulation.setViewport</dfn> command turns the emulation of the viewport on.
+The <dfn export for=commands>emulation.setViewport</dfn> command emulates specific viewport characteristics (e.g. viewport width and viewport height) on the given top-level browsing context.
 
 <dl>
    <dt>Command Type</dt>
@@ -3277,16 +3277,13 @@ The [=remote end steps=] with |command parameters| are:
 1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |command parameters| [=map/contains=] "<code>viewport</code>", then:
-    1. Let |viewport parameters| be the <code>viewport</code> attribute of |command parameters|.
-    1. If |viewport parameters| [=map/contains=] "<code>width</code>" and |viewport parameters| [=map/contains=] "<code>height</code>", then:
-        1. Let |width| be the <code>width</code> attribute of |viewport parameters| in CSS pixels.
-        1. Let |height| be the <code>height</code> attribute of |viewport parameters| in CSS pixels.
-        1. If the |width| or |height| is outside of the implementation-specific bounds, return an [=error=] with the [=error code=] [=invalid argument=].
-        1. Change the layout viewport of the |context| to be |width| pixels wide and |height| pixels high and run the [[cssom-view-1#resizing-viewports]] steps.
-    1. Else:
-        1. Return [=error=] with [=error code=] [=invalid argument=].
+    1. Let |viewport parameter| be the <code>viewport</code> field of |command parameters|.
+    1. Let |width| be the <code>width</code> field of |viewport parameter| in CSS pixels.
+    1. Let |height| be the <code>height</code> field of |viewport parameter| in CSS pixels.
+    1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
+    1. Change the layout viewport of the |context| to be |width| pixels wide and |height| pixels high and run the [[cssom-view-1#resizing-viewports]] steps.
 1. Else:
-    1. Reset any previously emulated viewport on the |context|.
+    1. Turn off the viewport emulation on the |context|, reset it to the original value and run the [[cssom-view-1#resizing-viewports]] steps.
 1. Return [=success=] with data null.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -3268,7 +3268,6 @@ opened</dfn> steps given |window|, |type| and |message|.
 
 </div>
 
-
 ## The network Module ## {#module-network}
 
 The <dfn export for=modules>network</dfn> module contains commands and events

--- a/index.bs
+++ b/index.bs
@@ -3281,6 +3281,7 @@ The [=remote end steps=] with |command parameters| are:
     1. If |viewport parameters| [=map/contains=] "<code>width</code>" and |viewport parameters| [=map/contains=] "<code>height</code>", then:
         1. Let |width| be the <code>width</code> attribute of |viewport parameters| in CSS pixels.
         1. Let |height| be the <code>height</code> attribute of |viewport parameters| in CSS pixels.
+        1. If the |width| or |height| is outside of the implementation-specific bounds, return an [=error=] with the [=error code=] [=invalid argument=].
         1. Change the layout viewport of the |context| to be |width| pixels wide and |height| pixels high and run the [[cssom-view-1#resizing-viewports]] steps.
     1. Else:
         1. Return [=error=] with [=error code=] [=invalid argument=].


### PR DESCRIPTION
This PR proposes a command to emulate the viewport of the top-level browsing context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OrKoN/webdriver-bidi/pull/425.html" title="Last updated on Jun 15, 2023, 2:19 PM UTC (7b15d58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/425/88b5c82...OrKoN:7b15d58.html" title="Last updated on Jun 15, 2023, 2:19 PM UTC (7b15d58)">Diff</a>