### PR TITLE
Replace `null` with `nil` in CDDL spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -318,7 +318,7 @@ CommandResponse = {
 }
 
 ErrorResponse = {
-  id: js-uint / null,
+  id: js-uint / nil,
   error: ErrorCode,
   message: text,
   ?stacktrace: text,
@@ -1885,8 +1885,8 @@ browsingContext.InfoList = [*browsingContext.Info]
 browsingContext.Info = {
   context: browsingContext.BrowsingContext,
   url: text,
-  children: browsingContext.InfoList / null
-  ?parent: browsingContext.BrowsingContext / null,
+  children: browsingContext.InfoList / nil
+  ?parent: browsingContext.BrowsingContext / nil,
 }
 </pre>
 
@@ -2083,7 +2083,7 @@ TODO: Link to the definition in the HTML spec.
 <pre class="cddl local-cddl">
 browsingContext.NavigationInfo = {
   context: browsingContext.BrowsingContext,
-  navigation: browsingContext.Navigation / null,
+  navigation: browsingContext.Navigation / nil,
   timestamp: js-uint,
   url: text,
 }
@@ -2481,7 +2481,7 @@ browsing context to the given URL.
    <dd>
     <pre class="cddl local-cddl">
         browsingContext.NavigateResult = {
-          navigation: browsingContext.Navigation / null,
+          navigation: browsingContext.Navigation / nil,
           url: text,
         }
     </pre>
@@ -3251,8 +3251,8 @@ empty map.  It's used to track the network events for which a
 
 <pre class="cddl local-cddl">
 network.BaseParameters = {
-    context: BrowsingContext / null,
-    navigation: Navigation / null,
+    context: BrowsingContext / nil,
+    navigation: Navigation / nil,
     redirectCount: js-uint,
     request: network.RequestData,
     timestamp: js-uint,
@@ -3605,7 +3605,7 @@ network.RequestData = {
     headers: [*network.Header],
     cookies: [*network.Cookie],
     headersSize: js-uint,
-    bodySize: js-uint / null,
+    bodySize: js-uint / nil,
     timings: network.FetchTimingInfo,
 };
 </pre>
@@ -3707,8 +3707,8 @@ network.ResponseData = {
     headers: [*network.Header],
     mimeType: text,
     bytesReceived: js-uint,
-    headersSize: js-uint / null,
-    bodySize: js-uint / null,
+    headersSize: js-uint / nil,
+    bodySize: js-uint / nil,
     content: network.ResponseContent
 };
 </pre>
@@ -5157,7 +5157,7 @@ script.NodeProperties = {
   ?mode: "open" / "closed",
   ?namespaceURI: text,
   ?nodeValue: text,
-  ?shadowRoot: script.NodeRemoteValue / null,
+  ?shadowRoot: script.NodeRemoteValue / nil,
 }
 
 script.WindowProxyRemoteValue = {
@@ -5687,8 +5687,8 @@ ownership will be treated.
 
 <pre class="cddl remote-cddl">
 script.SerializationOptions = {
-  ?maxDomDepth: (js-uint / null) .default 0,
-  ?maxObjectDepth: (js-uint / null) .default null,
+  ?maxDomDepth: (js-uint / nil) .default 0,
+  ?maxObjectDepth: (js-uint / nil) .default nil,
   ?includeShadowTree: ("none" / "open" / "all") .default "none",
 }
 </pre>
@@ -6755,7 +6755,7 @@ log.Entry = (
 log.BaseLogEntry = {
   level: log.Level,
   source: script.Source,
-  text: text / null,
+  text: text / nil,
   timestamp: js-uint,
   ?stackTrace: script.StackTrace,
 }


### PR DESCRIPTION
As far as I can see the CDDL specification doesn't has a native type `null` but there is `nil`. This patch removes occurrences of `null` and replaces it with `nil`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/430.html" title="Last updated on May 20, 2023, 10:28 PM UTC (027f192)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/430/cc806ae...027f192.html" title="Last updated on May 20, 2023, 10:28 PM UTC (027f192)">Diff</a>