### PR TITLE
Fix types for `network.BaseParameters` group

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3251,8 +3251,8 @@ empty map.  It's used to track the network events for which a
 
 <pre class="cddl local-cddl">
 network.BaseParameters = {
-    context: BrowsingContext / null,
-    navigation: Navigation / null,
+    context: browsingContext.BrowsingContext / null,
+    navigation: browsingContext.Navigation / null,
     redirectCount: js-uint,
     request: network.RequestData,
     timestamp: js-uint,


### PR DESCRIPTION
Discovered this after parsing the CDDL into TypeScript using [`cddl2ts`](https://github.com/christian-bromann/cddl2ts).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/431.html" title="Last updated on May 23, 2023, 6:14 AM UTC (93069f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/431/cc806ae...93069f4.html" title="Last updated on May 23, 2023, 6:14 AM UTC (93069f4)">Diff</a>