### PR TITLE
Fix contexts type for browsingContext.GetTreeResult

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2353,7 +2353,7 @@ or all top-level contexts when no parent is provided.
    <dd>
     <pre class="cddl local-cddl">
         browsingContext.GetTreeResult = {
-          contexts: browsingContext.Info
+          contexts: browsingContext.InfoList
         }
     </pre>
    </dd>


### PR DESCRIPTION
Sending the command `browsingContext.getTree` returns a result defined as following:

```
browsingContext.GetTreeResult = {
  contexts: browsingContext.Info
}
```

In reality however `contexts` seems to be `browsingContext.InfoList`, e.g.:

```
2023-05-25T15:46:20.582Z INFO webdriver: BIDI COMMAND browsingContextGetTree({})
2023-05-25T15:46:20.586Z INFO webdriver: BIDI RESULT {"id":1,"result":{"contexts":[{"children":[],"context":"174C29B18C6F01582E53E55A7F28DC47","parent":null,"url":"about:blank"}]}}
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/433.html" title="Last updated on May 25, 2023, 3:51 PM UTC (e51884c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/433/6db7b72...e51884c.html" title="Last updated on May 25, 2023, 3:51 PM UTC (e51884c)">Diff</a>