### PR TITLE
`browsingContext.captureScreenshot`: support different image formats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2137,7 +2137,9 @@ Base64-encoded string.
       }
 
       browsingContext.CaptureScreenshotParameters = {
-        context: browsingContext.BrowsingContext
+        context: browsingContext.BrowsingContext,
+        ? format: "jpeg" / "png" / "webp",
+        ? quality: (js-uint .le 100),
       }
       </pre>
    </dd>
@@ -2177,8 +2179,12 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
  1. Let |canvas| be the result of [=trying=] to [=draw a bounding box from the
     framebuffer=] with |root rect|.
 
+ 1. Let |format| be the value of the <code>format</code> field of |command parameters|.
+
+ 1. Let |quality| be the value of the <code>quality</code> field of |command parameters|.
+
  1. Let |encoding result| be the result of [=trying=] to [=encode a canvas as
-    Base64=] with |canvas|.
+    Base64=] with |canvas| in the specified image |format| with the given image |quality|.
 
  1. Let |body| be a [=/map=] matching the
     <code>browsingContext.CaptureScreenshotResult</code> production, with the


### PR DESCRIPTION
Reference: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot

Fixes: #383


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/436.html" title="Last updated on May 31, 2023, 7:37 PM UTC (a0b49a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/436/628c065...a0b49a3.html" title="Last updated on May 31, 2023, 7:37 PM UTC (a0b49a3)">Diff</a>