### PR TITLE
style: add whitespace to optional params: `?param` -> `? param`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -321,7 +321,7 @@ ErrorResponse = {
   id: js-uint / null,
   error: ErrorCode,
   message: text,
-  ?stacktrace: text,
+  ? stacktrace: text,
   Extensible
 }
 
@@ -1348,8 +1348,8 @@ filter only those that ought to be returned to the local end.
 
 <pre class="cddl remote-cddl local-cddl">
 session.CapabilitiesRequest = {
-  ?alwaysMatch: session.CapabilityRequest,
-  ?firstMatch: [*session.CapabilityRequest]
+  ? alwaysMatch: session.CapabilityRequest,
+  ? firstMatch: [*session.CapabilityRequest]
 }
 </pre>
 
@@ -1362,19 +1362,19 @@ for a session.
 
 <pre class="cddl remote-cddl local-cddl">
 session.CapabilityRequest = {
-  ?acceptInsecureCerts: bool,
-  ?browserName: text,
-  ?browserVersion: text,
-  ?platformName: text,
-  ?proxy: {
-    ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
-    ?proxyAutoconfigUrl: text,
-    ?ftpProxy: text,
-    ?httpProxy: text,
-    ?noProxy: [*text],
-    ?sslProxy: text,
-    ?socksProxy: text,
-    ?socksVersion: 0..255,
+  ? acceptInsecureCerts: bool,
+  ? browserName: text,
+  ? browserVersion: text,
+  ? platformName: text,
+  ? proxy: {
+    ? proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
+    ? proxyAutoconfigUrl: text,
+    ? ftpProxy: text,
+    ? httpProxy: text,
+    ? noProxy: [*text],
+    ? sslProxy: text,
+    ? socksProxy: text,
+    ? socksVersion: 0..255,
   },
   Extensible
 };
@@ -1388,7 +1388,7 @@ requested capabilities.
 <pre class="cddl remote-cddl">
 session.SubscriptionRequest = {
   events: [*text],
-  ?contexts: [*browsingContext.BrowsingContext],
+  ? contexts: [*browsingContext.BrowsingContext],
 }
 </pre>
 
@@ -1481,14 +1481,14 @@ This is a [=static command=].
           browserVersion: text,
           platformName: text,
           proxy: {
-            ?proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
-            ?proxyAutoconfigUrl: text,
-            ?ftpProxy: text,
-            ?httpProxy: text,
-            ?noProxy: [*text],
-            ?sslProxy: text,
-            ?socksProxy: text,
-            ?socksVersion: 0..255,
+            ? proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
+            ? proxyAutoconfigUrl: text,
+            ? ftpProxy: text,
+            ? httpProxy: text,
+            ? noProxy: [*text],
+            ? sslProxy: text,
+            ? socksProxy: text,
+            ? socksVersion: 0..255,
           },
           setWindowRect: bool,
           Extensible
@@ -1886,7 +1886,7 @@ browsingContext.Info = {
   context: browsingContext.BrowsingContext,
   url: text,
   children: browsingContext.InfoList / null
-  ?parent: browsingContext.BrowsingContext / null,
+  ? parent: browsingContext.BrowsingContext / null,
 }
 </pre>
 
@@ -2257,7 +2257,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
 
       browsingContext.CreateParameters = {
         type: browsingContext.CreateType,
-        ?referenceContext: browsingContext.BrowsingContext
+        ? referenceContext: browsingContext.BrowsingContext
       }
       </pre>
    </dd>
@@ -2344,8 +2344,8 @@ or all top-level contexts when no parent is provided.
       }
 
       browsingContext.GetTreeParameters = {
-        ?maxDepth: js-uint,
-        ?root: browsingContext.BrowsingContext,
+        ? maxDepth: js-uint,
+        ? root: browsingContext.BrowsingContext,
       }
       </pre>
    </dd>
@@ -2473,7 +2473,7 @@ browsing context to the given URL.
       browsingContext.NavigateParameters = {
         context: browsingContext.BrowsingContext,
         url: text,
-        ?wait: browsingContext.ReadinessState,
+        ? wait: browsingContext.ReadinessState,
       }
       </pre>
    </dd>
@@ -2540,25 +2540,25 @@ PDF document represented as a Base64-encoded string.
 
       browsingContext.PrintParameters = {
         context: browsingContext.BrowsingContext,
-        ?background: bool .default false,
-        ?margin: browsingContext.PrintMarginParameters,
-        ?orientation: ("portrait" / "landscape") .default "portrait",
-        ?page: browsingContext.PrintPageParameters,
-        ?pageRanges: [*(js-uint / text)],
-        ?scale: 0.1..2.0 .default 1.0,
-        ?shrinkToFit: bool .default true,
+        ? background: bool .default false,
+        ? margin: browsingContext.PrintMarginParameters,
+        ? orientation: ("portrait" / "landscape") .default "portrait",
+        ? page: browsingContext.PrintPageParameters,
+        ? pageRanges: [*(js-uint / text)],
+        ? scale: 0.1..2.0 .default 1.0,
+        ? shrinkToFit: bool .default true,
       }
 
       browsingContext.PrintMarginParameters = {
-        ?bottom: (float .ge 0.0) .default 1.0,
-        ?left: (float .ge 0.0) .default 1.0,
-        ?right: (float .ge 0.0) .default 1.0,
-        ?top: (float .ge 0.0) .default 1.0,
+        ? bottom: (float .ge 0.0) .default 1.0,
+        ? left: (float .ge 0.0) .default 1.0,
+        ? right: (float .ge 0.0) .default 1.0,
+        ? top: (float .ge 0.0) .default 1.0,
       }
 
       browsingContext.PrintPageParameters = {
-        ?height: (float .ge 0.0) .default 27.94,
-        ?width: (float .ge 0.0) .default 21.59,
+        ? height: (float .ge 0.0) .default 27.94,
+        ? width: (float .ge 0.0) .default 21.59,
       }
       </pre>
    </dd>
@@ -2682,8 +2682,8 @@ browsing context.
 
       browsingContext.ReloadParameters = {
         context: browsingContext.BrowsingContext,
-        ?ignoreCache: bool,
-        ?wait: browsingContext.ReadinessState,
+        ? ignoreCache: bool,
+        ? wait: browsingContext.ReadinessState,
       }
       </pre>
    </dd>
@@ -3531,10 +3531,10 @@ To <dfn>get a header</dfn> given |name bytes| and |value bytes|:
 <pre class="cddl local-cddl">
 network.Initiator = {
     type: "parser" / "script" / "preflight" / "other",
-    ?columnNumber: js-uint,
-    ?lineNumber: js-uint,
-    ?stackTrace: script.StackTrace,
-    ?request: network.Request
+    ? columnNumber: js-uint,
+    ? lineNumber: js-uint,
+    ? stackTrace: script.StackTrace,
+    ? request: network.Request
 };
 </pre>
 
@@ -4143,8 +4143,8 @@ script.ChannelValue = {
 
 script.ChannelProperties = {
   channel: script.Channel,
-  ?serializationOptions: script.SerializationOptions,
-  ?ownership: script.ResultOwnership,
+  ? serializationOptions: script.SerializationOptions,
+  ? ownership: script.ResultOwnership,
 }
 </pre>
 
@@ -4307,7 +4307,7 @@ script.ObjectLocalValue = {
 
 script.RegExpValue = {
   pattern: text,
-  ?flags: text,
+  ? flags: text,
 }
 
 script.RegExpLocalValue = {
@@ -4705,7 +4705,7 @@ script.WindowRealmInfo = {
   script.BaseRealmInfo,
   type: "window",
   context: browsingContext.BrowsingContext,
-  ?sandbox: text
+  ? sandbox: text
 }
 
 script.DedicatedWorkerRealmInfo = {
@@ -4889,7 +4889,7 @@ script.RemoteReference = (
 script.SharedReference = {
    sharedId: script.SharedId
    <!-- Ensure that if we have a handle, it at least has the correct type -->
-   ?handle: script.Handle,
+   ? handle: script.Handle,
    Extensible
 }
 
@@ -4897,7 +4897,7 @@ script.RemoteObjectReference = {
    handle: script.Handle,
    <!-- This shouldn't ever match. The problem is that Extensible would
    otherwise allow this to match a non-text sharedId -->
-   ?sharedId: script.SharedId
+   ? sharedId: script.SharedId
    Extensible
 }
 </pre>
@@ -5022,148 +5022,148 @@ script.MappingRemoteValue = [*[(script.RemoteValue / text), script.RemoteValue]]
 
 script.SymbolRemoteValue = {
   type: "symbol",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.ArrayRemoteValue = {
   type: "array",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.ListRemoteValue,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.ListRemoteValue,
 }
 
 script.ObjectRemoteValue = {
   type: "object",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.MappingRemoteValue,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.MappingRemoteValue,
 }
 
 script.FunctionRemoteValue = {
   type: "function",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.RegExpRemoteValue = {
   script.RegExpLocalValue,
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.DateRemoteValue = {
   script.DateLocalValue,
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.MapRemoteValue = {
   type: "map",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.MappingRemoteValue,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.MappingRemoteValue,
 }
 
 script.SetRemoteValue = {
   type: "set",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.ListRemoteValue
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.ListRemoteValue
 }
 
 script.WeakMapRemoteValue = {
   type: "weakmap",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.WeakSetRemoteValue = {
   type: "weakset",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.IteratorRemoteValue = {
   type: "iterator",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.GeneratorRemoteValue = {
   type: "generator",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.ErrorRemoteValue = {
   type: "error",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.ProxyRemoteValue = {
   type: "proxy",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.PromiseRemoteValue = {
   type: "promise",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.TypedArrayRemoteValue = {
   type: "typedarray",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.ArrayBufferRemoteValue = {
   type: "arraybuffer",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 
 script.NodeListRemoteValue = {
   type: "nodelist",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.ListRemoteValue,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.ListRemoteValue,
 }
 
 script.HTMLCollectionRemoteValue = {
   type: "htmlcollection",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.ListRemoteValue,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.ListRemoteValue,
 }
 
 script.NodeRemoteValue = {
   type: "node",
-  ?sharedId: script.SharedId,
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
-  ?value: script.NodeProperties,
+  ? sharedId: script.SharedId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.NodeProperties,
 }
 
 script.NodeProperties = {
   nodeType: js-uint,
   childNodeCount: js-uint,
-  ?attributes: {*text => text},
-  ?children: [*script.NodeRemoteValue],
-  ?localName: text,
-  ?mode: "open" / "closed",
-  ?namespaceURI: text,
-  ?nodeValue: text,
-  ?shadowRoot: script.NodeRemoteValue / null,
+  ? attributes: {*text => text},
+  ? children: [*script.NodeRemoteValue],
+  ? localName: text,
+  ? mode: "open" / "closed",
+  ? namespaceURI: text,
+  ? nodeValue: text,
+  ? shadowRoot: script.NodeRemoteValue / null,
 }
 
 script.WindowProxyRemoteValue = {
   type: "window",
-  ?handle: script.Handle,
-  ?internalId: script.InternalId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 </pre>
 
@@ -5687,9 +5687,9 @@ ownership will be treated.
 
 <pre class="cddl remote-cddl">
 script.SerializationOptions = {
-  ?maxDomDepth: (js-uint / null) .default 0,
-  ?maxObjectDepth: (js-uint / null) .default null,
-  ?includeShadowTree: ("none" / "open" / "all") .default "none",
+  ? maxDomDepth: (js-uint / null) .default 0,
+  ? maxObjectDepth: (js-uint / null) .default null,
+  ? includeShadowTree: ("none" / "open" / "all") .default "none",
 }
 </pre>
 
@@ -5817,7 +5817,7 @@ Record=] of type <code>throw</code>, |exception|, is given by:
 <pre class="cddl local-cddl">
 script.Source = (
   realm: script.Realm,
-  ?context: browsingContext.BrowsingContext
+  ? context: browsingContext.BrowsingContext
 );
 </pre>
 
@@ -5863,7 +5863,7 @@ script.RealmTarget = {
 
 script.ContextTarget = {
   context: browsingContext.BrowsingContext,
-  ?sandbox: text
+  ? sandbox: text
 }
 
 script.Target = (
@@ -5932,8 +5932,8 @@ script=].
 
       script.AddPreloadScriptParameters = {
         functionDeclaration: text,
-        ?arguments: [*script.ChannelValue],
-        ?sandbox: text
+        ? arguments: [*script.ChannelValue],
+        ? sandbox: text
       }
       </pre>
    </dd>
@@ -6042,10 +6042,10 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
         functionDeclaration: text,
         awaitPromise: bool,
         target: script.Target,
-        ?arguments: [*script.ArgumentValue],
-        ?resultOwnership: script.ResultOwnership,
-        ?serializationOptions: script.SerializationOptions,
-        ?this: script.ArgumentValue,
+        ? arguments: [*script.ArgumentValue],
+        ? resultOwnership: script.ResultOwnership,
+        ? serializationOptions: script.SerializationOptions,
+        ? this: script.ArgumentValue,
       }
 
       script.ArgumentValue = (
@@ -6230,8 +6230,8 @@ the promise is returned.
         expression: text,
         target: script.Target,
         awaitPromise: bool,
-        ?resultOwnership: script.ResultOwnership,
-        ?serializationOptions: script.SerializationOptions,
+        ? resultOwnership: script.ResultOwnership,
+        ? serializationOptions: script.SerializationOptions,
       }
       </pre>
    </dd>
@@ -6329,8 +6329,8 @@ realm associated with the [=document=] currently loaded in a specified
       }
 
       script.GetRealmsParameters = {
-        ?context: browsingContext.BrowsingContext,
-        ?type: script.RealmType,
+        ? context: browsingContext.BrowsingContext,
+        ? type: script.RealmType,
       }
       </pre>
    </dd>
@@ -6757,7 +6757,7 @@ log.BaseLogEntry = {
   source: script.Source,
   text: text / null,
   timestamp: js-uint,
-  ?stackTrace: script.StackTrace,
+  ? stackTrace: script.StackTrace,
 }
 
 log.GenericLogEntry = {
@@ -7078,7 +7078,7 @@ specified sequence of user input actions.
       input.PointerType = "mouse" / "pen" / "touch"
 
       input.PointerParameters = {
-        ?pointerType: input.PointerType .default "mouse"
+        ? pointerType: input.PointerType .default "mouse"
       }
 
       input.PointerSourceAction = (


### PR DESCRIPTION
For consistency / uniformity. The choice is arbitrary. We could also have chosen the other way around.

The use of spaces aligns with the examples on RFC 8610.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/437.html" title="Last updated on May 31, 2023, 7:36 PM UTC (df52523)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/437/628c065...df52523.html" title="Last updated on May 31, 2023, 7:36 PM UTC (df52523)">Diff</a>