### PR TITLE
Add "session.NewResult" to "SessionResult".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1212,7 +1212,10 @@ SessionCommand = (
 [=local end definition=]
 
 <pre class="cddl local-cddl">
-SessionResult = (session.StatusResult)
+SessionResult = (
+   session.NewResult //
+   session.StatusResult
+)
 </pre>
 
 <div algorithm>


### PR DESCRIPTION
As mentioned in https://github.com/w3c/webdriver-bidi/issues/240 we miss to list the `session.NewResult` in the `SessionResult` return type.