### PR TITLE
context capture screenshot: add optional focus top-level context step

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2175,6 +2175,9 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    Issue: This ought to be integrated into the update rendering algorithm
    in some more explicit way.
 
+ 1. An implementation may invoke the [=/focusing steps=] for the
+    [=top-level browsing context=] of |context|.
+
  1. Let |root rect| be |document|’s [=document element=]'s [=rectangle=].
 
  1. Let |canvas| be the result of [=trying=] to [=draw a bounding box from the


### PR DESCRIPTION
CDP's Page.captureScreenshot command[1] is blocked until the active context gets focus.

[1]: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot

Follow-up-of: https://github.com/w3c/webdriver-bidi/pull/183
Spec: https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/440.html" title="Last updated on Jun 14, 2023, 4:03 PM UTC (063de20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/440/5d3ee40...063de20.html" title="Last updated on Jun 14, 2023, 4:03 PM UTC (063de20)">Diff</a>