### PR TITLE
Fix "get shared id for a node" to use node's browsing context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5234,13 +5234,13 @@ To get the <dfn>handle for an object</dfn> given |realm|, |ownership type| and
 </div>
 
 <div algorithm>
-To <dfn>get shared id for a node</dfn> given |node|, |realm| and |session|:
+To <dfn>get shared id for a node</dfn> given |node|, and |session|:
 
 1. Let |node| be [=unwrapped=] |node|.
 
 1. If |node| does not implement {{Node}}, return null.
 
-1. Let |browsing context| be [=get the browsing context=] with |realm|.
+1. Let |browsing context| be |node|'s [=node document=]'s [=Document/browsing context=].
 
 1. If |browsing context| is null, return null.
 
@@ -5426,8 +5426,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| is a [=platform object=] that implements {{Node}}
     <dd>
-      1. Let |shared id| be [=get shared id for a node=] with |value|, |realm| and
-         |session|.
+      1. Let |shared id| be [=get shared id for a node=] with |value| and |session|.
 
       1. Let |remote value| be a [=/map=] matching the <code>script.NodeRemoteValue</code>
          production in the [=local end definition=], with the <code>sharedId</code>


### PR DESCRIPTION
When a script evaluation retrieves an element from a different browsing context the `get shared id for a node` method cannot use the browsing context of the realm the command is executing in, but has to use the browsing context of the node. Otherwise the reference will be added to the wrong navigable entry within seenNodes and as such can cause failures in WebDriver classic.

I'll add tests as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1830884.

@jgraham can you please review?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/445.html" title="Last updated on Jun 6, 2023, 2:00 PM UTC (bfb7bcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/445/5d3ee40...whimboo:bfb7bcd.html" title="Last updated on Jun 6, 2023, 2:00 PM UTC (bfb7bcd)">Diff</a>