### PR TITLE
Add support for clipping screenshots

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2170,10 +2170,10 @@ Base64-encoded string.
 
       browsingContext.BoxClipRectangle = {
          type: "viewport",
-         x: js-uint,
-         y: js-uint,
-         width: js-uint,
-         height: js-uint
+         x: float,
+         y: float,
+         width: float,
+         height: float
       }
       </pre>
    </dd>
@@ -2272,9 +2272,13 @@ To <dfn>render viewport to a canvas</dfn> given |viewport| and |rect|:
 
 1. Let |scale| be [=determine the device pixel ratio=] for the output device of |viewport|.
 
-1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |scale|.
+1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |scale|,
+   rounded to the nearest integer, so it matches the width of |rect| in device
+   pixels.
 
-1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |scale|.
+1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |scale|,
+   rounded to the nearest integer, so it matches the height of |rect| in device
+   pixels.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.

--- a/index.bs
+++ b/index.bs
@@ -2203,10 +2203,10 @@ Note: This ensures that the resulting rect has positive [=width dimension=] and
 
 1. Let |height| be |rect|'s [=height dimension=].
 
-1. If |width| is less than 0, set |x| to |x| - |width| and then set |width| to
+1. If |width| is less than 0, set |x| to |x| + |width| and then set |width| to
    -|width|.
 
-1. If |height| is less than 0, set |y| to |y| - |height| and then set |height|
+1. If |height| is less than 0, set |y| to |y| + |height| and then set |height|
    to -|height|.
 
 1. Return a new {{DOMRectReadOnly}} with [=x coordinate=] |x|, [=y coordinate=]

--- a/index.bs
+++ b/index.bs
@@ -74,6 +74,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
     text: reset the input state; url: dfn-reset-the-input-state
+    text: scroll into view; url: dfn-scrolls-into-view
     text: session ID; url: dfn-session-id
     text: session not created; url: dfn-session-not-created
     text: session; url: dfn-sessions
@@ -81,6 +82,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: success; url: dfn-success
     text: try; url: dfn-try
     text: trying; url: dfn-try
+    text: unable to capture screen; url: dfn-unable-to-capture-screen
     text: unknown command; url: dfn-unknown-command
     text: unknown error; url: dfn-unknown-error
     text: unsupported operation; url: dfn-unsupported-operation
@@ -143,8 +145,14 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
   type: dfn
     text: rectangle; url: rectangle
+    text: x coordinate; url: rectangle-x-coordinate
+    text: y coordinate; url: rectangle-y-coordinate
+    text: width dimension; url: rectangle-width-dimension
+    text: height dimension; url: rectangle-height-dimension
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
+    text: 2D; url: canvas.html#concept-canvas-2d
+    text: 2D context creation algorithm; url: canvas.html/#2d-context-creation-algorithm
     text: a browsing context is discarded; url: window-object.html#a-browsing-context-is-discarded
     text: active browsing context; url: document-sequences.html#nav-bc
     text: active document; for: browsing context; url: document-sequences.html#active-document
@@ -154,6 +162,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: confirm; url: timers-and-user-prompts.html#dom-confirm
+    text: context mode; url: /canvas.html#offscreencanvas-context-mode
     text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
     text: environment settings object's Realm; url: webappapis.html#environment-settings-object's-realm
     text: handled; url: webappapis.html#concept-error-handled
@@ -183,6 +192,9 @@ spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
 spec: RFC4648; urlPrefix: https://tools.ietf.org/html/rfc4648
   type: dfn
     text: Base64 Encode; url: section-4
+spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
+  type: dfn
+    text: visual viewport; url: #visual-viewport
 </pre>
 
 <pre class="biblio">
@@ -488,6 +500,7 @@ ErrorCode = ("invalid argument" /
              "no such node" /
              "no such script" /
              "session not created" /
+             "unable to capture screen" /
              "unable to close browser" /
              "unknown command" /
              "unknown error" /
@@ -2140,7 +2153,25 @@ Base64-encoded string.
       }
 
       browsingContext.CaptureScreenshotParameters = {
-        context: browsingContext.BrowsingContext
+        context: browsingContext.BrowsingContext,
+        ?clip: browsingContext.ClipRectangle
+      }
+
+      browsingContext.ClipRectangle = (browsingContext.ElementClipRectangle //
+                                       browsingContext.BoxClipRectangle)
+
+      browsingContext.ElementClipRectangle = {
+        type: "element",
+        element: script.SharedReference,
+        ?scrollIntoView: bool
+      }
+
+      browsingContext.BoxClipRectangle = {
+         type: "viewport",
+         x: js-uint,
+         y: js-uint,
+         width: js-uint,
+         height: js-uint
       }
       </pre>
    </dd>
@@ -2156,10 +2187,117 @@ Base64-encoded string.
 
 TODO: Full page screenshots, and multiple output formats
 
+<div algorithm>
+To <dfn>normalise rect</dfn> given |rect|:
+
+Note: This ensures that the resulting rect has positive [=width dimension=] and
+[=height dimension=].
+
+1. Let |x| be |rect|'s [=x coordinate=].
+
+1. Let |width| be |rect|'s [=width dimension=].
+
+1. Let |y| be |rect|'s [=y coordinate=].
+
+1. Let |height| be |rect|'s [=height dimension=].
+
+1. If |width| is less than 0, set |x| to |x| - |width| and then set |width| to
+   -|width|.
+
+1. If |height| is less than 0, set |y| to |y| - |height| and then set |height|
+   to -|height|.
+
+1. Return a new {{DOMRectReadOnly}} with [=x coordinate=] |x|, [=y coordinate=]
+   |y|, [=width dimension=] |width| and [=height dimension=] |height|.
+
+</div>
+
+<div algorithm>
+To <dfn>rectangle intersection</dfn> given |rect1| and |rect2|
+
+1. Let |rect1| be [=normalise rect=] with |rect1|.
+
+1. Let |rect2| be [=normalise rect=] with |rect2|.
+
+1. Let |x1_0| be |rect1|'s [=x coordinate=].
+
+1. Let |x2_0| be |rect2|'s [=x coordinate=].
+
+1. Let |x1_1| be |rect1|'s [=x coordinate=] plus |rect1|'s [=width dimension=].
+
+1. Let |x2_1| be |rect2|'s [=x coordinate=] plus |rect2|'s [=width dimension=].
+
+1. Let |x_0| be the maximum element of «|x1_0|, |x2_0|».
+
+1. Let |x_1| be the minimum element of «|x1_1|, |x2_1|».
+
+1. Let |y1_0| be |rect1|'s [=y coordinate=].
+
+1. Let |y2_0| be |rect2|'s [=y coordinate=].
+
+1. Let |y1_1| be |rect1|'s [=y coordinate=] plus |rect1|'s [=height dimension=].
+
+1. Let |y2_1| be |rect2|'s [=y coordinate=] plus |rect2|'s [=height dimension=].
+
+1. Let |y_0| be the maximum element of «|y1_0|, |y2_0|».
+
+1. Let |y_1| be the minimum element of «|y1_1|, |y2_1|».
+
+1. If |x_1| is less than |x_0|, let |width| be 0. Otherwise let |width| be
+   |x_1| - |x_0|.
+
+1. If |y_1| is less than |y_0|, let |height| be 0. Otherwise let |height| be
+   |y_1| - |y_0|.
+
+1. Return a new {{DOMRectReadOnly}} with [=x coordinate=] |x_0|, [=y coordinate=]
+   |y_0|, [=width dimension=] |width| and [=height dimension=] |height|.
+
+</div>
+
+<div algorithm>
+To <dfn>render viewport to a canvas</dfn> given |viewport| and |rect|:
+
+1. Assert: |rect| is normlaised and represents a non-empty sub-region of |viewport|,
+   i.e. all the following hold:
+     * |rect|'s [=x coordinate=] is greater than or equal to 0.
+     * |rect|'s [=width dimension=] is greater than 0.
+     * |rect|'s [=y coordinate=] is greater than or equal to 0.
+     * |rect|'s [=height dimension=] is greater than 0.
+     * |rect|'s [=x coordinate=] plus |rect|'s [=width dimension=] is less than
+       or equal to |viewport|'s width.
+     * |rect|'s [=y coordinate=] plus |rect|'s [=height dimension=] is less than
+       or equal to |viewport|'s height.
+
+1. Let |scale| be [=determine the device pixel ratio=] for the output device of |viewport|.
+
+1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |scale|.
+
+1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |scale|.
+
+1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
+   width| and {{HTMLCanvasElement/height}} |paint height|.
+
+1. Let |context| be the result of running the [=2D context creation algorithm=]
+   with |canvas| and null.
+
+1. Set |canvas|'s [=context mode=] to [=2D=].
+
+1. Complete implementation specific steps equivalent to drawing the region of
+   the framebuffer representing the region of |viewport| covered by |rect| to
+   |context|, such that each pixel in the framebuffer corresponds to a pixel in
+   |context| with (|rect|'s [=x coordinate=], |rect|'s [=y coordinate=]) in
+   viewport coordinates corresponding to (0,0) in |context| and (|rect|'s
+   [=x coordinate=] + |rect|'s [=width dimension=], |rect|'s
+   [=y coordinate=] + |rect|'s [=height dimension=]) corresponding to (|paint
+   width|, |paint height|).
+
+1. Return [=canvas=].
+
+</div>
+
 The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 
-1. Let |context id| be the value of the <code>context</code> field of
-   |command parameters|.
+1. Let |context id| be |command parameters|["<code>context</code>"].
 
 1. Let |context| be the result of [=trying=] to [=get a browsing context=]
    with |context id|.
@@ -2169,16 +2307,65 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
 1. Let |document| be |context|'s [=active document=].
 
+1. Let |viewport| be |document|'s [=visual viewport=].
+
 1. Immediately after the next invocation of the [=run the animation frame
    callbacks=] algorithm for |document|:
 
    Issue: This ought to be integrated into the update rendering algorithm
    in some more explicit way.
 
- 1. Let |root rect| be |document|’s [=document element=]'s [=rectangle=].
+1. Let |viewport rect| be a {{DOMRectReadOnly}} with [=x coordinate=] 0, [=y
+   coordinate=] 0, [=width dimension=] |viewport| width, and [=height
+   dimension=] |viewport| height.
 
- 1. Let |canvas| be the result of [=trying=] to [=draw a bounding box from the
-    framebuffer=] with |root rect|.
+  1. If |command parameters| contains "<code>clip</code>":
+
+    1. Let |clip| be |command parameters|["<code>clip</code>"].
+
+    1. If |clip| matches the <code>browsingContext.ElementClipRectangle</code>
+       production:
+
+      1. Let |environment settings| be the [=environment settings object=] whose
+         [=relevant global object=]'s <a>associated <code>Document</code></a> is
+        |document|.
+
+      1. Let |realm| be |environment settings|' [=realm execution context=]'s
+         Realm component.
+
+      1. Let |element| be the result of [=trying=] to [=deserialize remote reference=]
+         with |clip|["<code>element</code>"], |realm|, and |session|.
+
+      1. If |element| doesn't implement {{Element}} return [=error=] with [=error code=]
+         [=no such element=].
+
+      1. If |element|'s [=node document=] is not |document|, return [=error=] with
+         [=error code=] [=no such element=].
+
+      1. If |clip| contains "<code>scrollIntoView</code>" and
+         |clip|["<code>scrollIntoView</code>"]:
+
+        1. [=Scroll into view=] with |element|.
+
+      1. Let |clip rect| be [=get the bounding box=] for |element|.
+
+    Otherwise, |clip| matches the
+    <code>browsingContext.BoxClipRectange</code> production:
+
+     1. Let |clip rect| be a {{DOMRectReadOnly}} with x coordinate |clip|["<code>x</code>"],
+        y coordinate |clip|["<code>y</code>"], width |clip|["<code>width</code>"],
+        and height |clip|["<code>height</code>"].
+
+  Otherwise:
+
+   1. Let |clip rect| be |viewport rect|.
+
+ 1. Let |rect| be the [=rectangle intersection=] of |viewport rect| and |clip rect|.
+
+ 1. If |rect|'s [=width dimension=] is 0 or |rect|'s [=height dimension=] is 0,
+    return [=error=] with error code [=unable to capture screen=].
+
+ 1. Let |canvas| be [=render viewport to a canvas=] with |viewport| and |rect|.
 
  1. Let |encoding result| be the result of [=trying=] to [=encode a canvas as
     Base64=] with |canvas|.

--- a/index.bs
+++ b/index.bs
@@ -2154,16 +2154,18 @@ Base64-encoded string.
 
       browsingContext.CaptureScreenshotParameters = {
         context: browsingContext.BrowsingContext,
-        ?clip: browsingContext.ClipRectangle
+        ? clip: browsingContext.ClipRectangle
       }
 
-      browsingContext.ClipRectangle = (browsingContext.ElementClipRectangle //
-                                       browsingContext.BoxClipRectangle)
+      browsingContext.ClipRectangle = (
+        browsingContext.BoxClipRectangle //
+        browsingContext.ElementClipRectangle
+      )
 
       browsingContext.ElementClipRectangle = {
         type: "element",
         element: script.SharedReference,
-        ?scrollIntoView: bool
+        ? scrollIntoView: bool
       }
 
       browsingContext.BoxClipRectangle = {
@@ -2195,9 +2197,9 @@ Note: This ensures that the resulting rect has positive [=width dimension=] and
 
 1. Let |x| be |rect|'s [=x coordinate=].
 
-1. Let |width| be |rect|'s [=width dimension=].
-
 1. Let |y| be |rect|'s [=y coordinate=].
+
+1. Let |width| be |rect|'s [=width dimension=].
 
 1. Let |height| be |rect|'s [=height dimension=].
 
@@ -2257,7 +2259,7 @@ To <dfn>rectangle intersection</dfn> given |rect1| and |rect2|
 <div algorithm>
 To <dfn>render viewport to a canvas</dfn> given |viewport| and |rect|:
 
-1. Assert: |rect| is normlaised and represents a non-empty sub-region of |viewport|,
+1. Assert: |rect| is normalized and represents a non-empty sub-region of |viewport|,
    i.e. all the following hold:
      * |rect|'s [=x coordinate=] is greater than or equal to 0.
      * |rect|'s [=width dimension=] is greater than 0.
@@ -2352,7 +2354,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
     Otherwise, |clip| matches the
     <code>browsingContext.BoxClipRectange</code> production:
 
-     1. Let |clip rect| be a {{DOMRectReadOnly}} with x coordinate |clip|["<code>x</code>"],
+      1. Let |clip rect| be a {{DOMRectReadOnly}} with x coordinate |clip|["<code>x</code>"],
         y coordinate |clip|["<code>y</code>"], width |clip|["<code>width</code>"],
         and height |clip|["<code>height</code>"].
 

--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     text: 2D; url: canvas.html#concept-canvas-2d
-    text: 2D context creation algorithm; url: canvas.html/#2d-context-creation-algorithm
+    text: 2D context creation algorithm; url: canvas.html#2d-context-creation-algorithm
     text: a browsing context is discarded; url: window-object.html#a-browsing-context-is-discarded
     text: active browsing context; url: document-sequences.html#nav-bc
     text: active document; for: browsing context; url: document-sequences.html#active-document
@@ -2325,62 +2325,62 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    coordinate=] 0, [=width dimension=] |viewport| width, and [=height
    dimension=] |viewport| height.
 
-  1. If |command parameters| contains "<code>clip</code>":
+1. Let |clip rect| be |viewport rect|.
 
-    1. Let |clip| be |command parameters|["<code>clip</code>"].
+1. If |command parameters| contains "<code>clip</code>":
 
-    1. If |clip| matches the <code>browsingContext.ElementClipRectangle</code>
+  1. Let |clip| be |command parameters|["<code>clip</code>"].
+
+  1. Run the steps under the first matching condition:
+     <dl>
+       <dt>|clip| matches the <code>browsingContext.ElementClipRectangle</code>
        production:
+       <dd>
+       1. Let |environment settings| be the [=environment settings object=] whose
+          [=relevant global object=]'s <a>associated <code>Document</code></a> is
+         |document|.
 
-      1. Let |environment settings| be the [=environment settings object=] whose
-         [=relevant global object=]'s <a>associated <code>Document</code></a> is
-        |document|.
+       1. Let |realm| be |environment settings|' [=realm execution context=]'s
+          Realm component.
 
-      1. Let |realm| be |environment settings|' [=realm execution context=]'s
-         Realm component.
+       1. Let |element| be the result of [=trying=] to [=deserialize remote reference=]
+          with |clip|["<code>element</code>"], |realm|, and |session|.
 
-      1. Let |element| be the result of [=trying=] to [=deserialize remote reference=]
-         with |clip|["<code>element</code>"], |realm|, and |session|.
+       1. If |element| doesn't implement {{Element}} return [=error=] with [=error code=]
+          [=no such element=].
 
-      1. If |element| doesn't implement {{Element}} return [=error=] with [=error code=]
-         [=no such element=].
+       1. If |element|'s [=node document=] is not |document|, return [=error=] with
+          [=error code=] [=no such element=].
 
-      1. If |element|'s [=node document=] is not |document|, return [=error=] with
-         [=error code=] [=no such element=].
+       1. If |clip| contains "<code>scrollIntoView</code>" and
+          |clip|["<code>scrollIntoView</code>"]:
 
-      1. If |clip| contains "<code>scrollIntoView</code>" and
-         |clip|["<code>scrollIntoView</code>"]:
+         1. [=Scroll into view=] with |element|.
 
-        1. [=Scroll into view=] with |element|.
+       1. Let |clip rect| be [=get the bounding box=] for |element|.
 
-      1. Let |clip rect| be [=get the bounding box=] for |element|.
+       <dt>|clip| matches the <code>browsingContext.BoxClipRectangle</code> production:
+       <dd>
+       1. Let |clip rect| be a {{DOMRectReadOnly}} with x coordinate |clip|["<code>x</code>"],
+          y coordinate |clip|["<code>y</code>"], width |clip|["<code>width</code>"],
+          and height |clip|["<code>height</code>"].
+     </dl>
 
-    Otherwise, |clip| matches the
-    <code>browsingContext.BoxClipRectange</code> production:
+1. Let |rect| be the [=rectangle intersection=] of |viewport rect| and |clip rect|.
 
-      1. Let |clip rect| be a {{DOMRectReadOnly}} with x coordinate |clip|["<code>x</code>"],
-        y coordinate |clip|["<code>y</code>"], width |clip|["<code>width</code>"],
-        and height |clip|["<code>height</code>"].
+1. If |rect|'s [=width dimension=] is 0 or |rect|'s [=height dimension=] is 0,
+   return [=error=] with error code [=unable to capture screen=].
 
-  Otherwise:
+1. Let |canvas| be [=render viewport to a canvas=] with |viewport| and |rect|.
 
-   1. Let |clip rect| be |viewport rect|.
+1. Let |encoding result| be the result of [=trying=] to [=encode a canvas as
+   Base64=] with |canvas|.
 
- 1. Let |rect| be the [=rectangle intersection=] of |viewport rect| and |clip rect|.
+1. Let |body| be a [=/map=] matching the
+   <code>browsingContext.CaptureScreenshotResult</code> production, with the
+   <code>data</code> field set to |encoding result|.
 
- 1. If |rect|'s [=width dimension=] is 0 or |rect|'s [=height dimension=] is 0,
-    return [=error=] with error code [=unable to capture screen=].
-
- 1. Let |canvas| be [=render viewport to a canvas=] with |viewport| and |rect|.
-
- 1. Let |encoding result| be the result of [=trying=] to [=encode a canvas as
-    Base64=] with |canvas|.
-
- 1. Let |body| be a [=/map=] matching the
-    <code>browsingContext.CaptureScreenshotResult</code> production, with the
-    <code>data</code> field set to |encoding result|.
-
- 1. Return [=success=] with data |body|.
+1. Return [=success=] with data |body|.
 
 #### The browsingContext.close Command ####  {#command-browsingContext-close}
 


### PR DESCRIPTION
Support clipping screenshots, either directly, by providing coordinates relative to the viewport, or by providing an element, and using its bounding rect as the coordinates to clip.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/454.html" title="Last updated on Jun 30, 2023, 1:33 PM UTC (6836090)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/454/88f40d0...6836090.html" title="Last updated on Jun 30, 2023, 1:33 PM UTC (6836090)">Diff</a>