### PR TITLE
Fix unparenthesized ranges

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2741,7 +2741,7 @@ PDF document represented as a Base64-encoded string.
         ? orientation: ("portrait" / "landscape") .default "portrait",
         ? page: browsingContext.PrintPageParameters,
         ? pageRanges: [*(js-uint / text)],
-        ? scale: 0.1..2.0 .default 1.0,
+        ? scale: (0.1..2.0) .default 1.0,
         ? shrinkToFit: bool .default true,
       }
 
@@ -7416,7 +7416,7 @@ specified sequence of user input actions.
         ? height: js-uint .default 1,
         ? pressure: float .default 0.0,
         ? tangentialPressure: float .default 0.0,
-        ? twist: 0..359 .default 0,
+        ? twist: (0..359) .default 0,
         (input.TiltProperties // input.AngleProperties)
       )
 
@@ -7426,8 +7426,8 @@ specified sequence of user input actions.
       )
 
       input.TiltProperties = (
-        ? tiltX: -90..90 .default 0,
-        ? tiltY: -90..90 .default 0,
+        ? tiltX: (-90..90) .default 0,
+        ? tiltY: (-90..90) .default 0,
       )
 
       input.Origin = "viewport" / "pointer" / input.ElementOrigin


### PR DESCRIPTION
Ranges in CDDL must be parenthesized when using defaults. This follows from operations in CDDL being right associative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver-bidi/pull/457.html" title="Last updated on Jun 30, 2023, 8:46 PM UTC (fd959df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/457/e8bb82d...jrandolf:fd959df.html" title="Last updated on Jun 30, 2023, 8:46 PM UTC (fd959df)">Diff</a>