### PR TITLE
Remove redundant parenthesis in ErrorCode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -492,19 +492,19 @@ with the following additional codes:
 
 
 <pre class="cddl local-cddl">
-ErrorCode = ("invalid argument" /
-             "invalid session id" /
-             "no such alert" /
-             "no such frame" /
-             "no such handle" /
-             "no such node" /
-             "no such script" /
-             "session not created" /
-             "unable to capture screen" /
-             "unable to close browser" /
-             "unknown command" /
-             "unknown error" /
-             "unsupported operation")
+ErrorCode = "invalid argument" /
+            "invalid session id" /
+            "no such alert" /
+            "no such frame" /
+            "no such handle" /
+            "no such node" /
+            "no such script" /
+            "session not created" /
+            "unable to capture screen" /
+            "unable to close browser" /
+            "unknown command" /
+            "unknown error" /
+            "unsupported operation"
 </pre>
 
 ## Events ## {#events}


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver-bidi/pull/458.html" title="Last updated on Jun 30, 2023, 8:48 PM UTC (925b14c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/458/e8bb82d...jrandolf:925b14c.html" title="Last updated on Jun 30, 2023, 8:48 PM UTC (925b14c)">Diff</a>