### PR TITLE
Use parenthesis for base types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3502,13 +3502,13 @@ empty map.  It's used to track the network events for which a
 #### The network.BaseParameters Type #### {#type-network-BaseParameters}
 
 <pre class="cddl local-cddl">
-network.BaseParameters = {
+network.BaseParameters = (
     context: browsingContext.BrowsingContext / null,
     navigation: browsingContext.Navigation / null,
     redirectCount: js-uint,
     request: network.RequestData,
     timestamp: js-uint,
-}
+)
 </pre>
 
 The <code>network.BaseParameters</code> type is an abstract type representing
@@ -4948,10 +4948,10 @@ script.RealmInfo = (
   script.WorkletRealmInfo
 )
 
-script.BaseRealmInfo = {
+script.BaseRealmInfo = (
   realm: script.Realm,
   origin: text
-}
+)
 
 script.WindowRealmInfo = {
   script.BaseRealmInfo,
@@ -7018,13 +7018,13 @@ log.Entry = (
   log.JavascriptLogEntry
 )
 
-log.BaseLogEntry = {
+log.BaseLogEntry = (
   level: log.Level,
   source: script.Source,
   text: text / null,
   timestamp: js-uint,
   ? stackTrace: script.StackTrace,
-}
+)
 
 log.GenericLogEntry = {
   log.BaseLogEntry,


### PR DESCRIPTION
CDDL doesn't allow composition with non-groups.

Basically, you have the following ABNF:

```
   grpent = [occur S] [memberkey S] type
            / [occur S] groupname [genericarg]  ; preempted by above
            / [occur S] "(" S group S ")"
```

When you you don't use parenthesis, it matches the first branch, but this is bad because for maps (types declared with { ... }), this is not valid ("If the memberkey is not given, the entry can only be used for matching arrays, not for maps." (Ctrl + F this)).

Thus we need to declare the base types with parenthesis.

See https://www.rfc-editor.org/rfc/rfc8610.html#appendix-C for the relevant spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver-bidi/pull/460.html" title="Last updated on Jul 3, 2023, 9:23 AM UTC (1431ad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/460/e8bb82d...jrandolf:1431ad5.html" title="Last updated on Jul 3, 2023, 9:23 AM UTC (1431ad5)">Diff</a>