### PR TITLE
Use `.and` instead of composition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5299,16 +5299,14 @@ script.FunctionRemoteValue = {
 }
 
 script.RegExpRemoteValue = {
-  script.RegExpLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-}
+} .and script.RegExpLocalValue
 
 script.DateRemoteValue = {
-  script.DateLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-}
+} .and script.DateLocalValue
 
 script.MapRemoteValue = {
   type: "map",


### PR DESCRIPTION
CDDL doesn't allow composition of maps.

See https://github.com/w3c/webdriver-bidi/pull/460


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver-bidi/pull/461.html" title="Last updated on Jul 3, 2023, 1:53 PM UTC (9442d71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/461/e8bb82d...jrandolf:9442d71.html" title="Last updated on Jul 3, 2023, 1:53 PM UTC (9442d71)">Diff</a>