### PR TITLE
Switch to new rust-toolchain because actions-rs/toolchain is unmaintained

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,7 @@ jobs:
             ~/.cargo/registry/index/
             ./target/
           key: cddl-${{ hashFiles('cddl.txt') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Validate CDDL files
         run: ./scripts/test.sh
       - name: Archive CDDL files


### PR DESCRIPTION
Lets see if the [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) works for us so that we can get rid of the deprecation warnings.

Closes: #444