### PR TITLE
Add method enum for script domain

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4275,6 +4275,15 @@ ScriptCommand = (
   script.GetRealms //
   script.RemovePreloadScriptCommand
 )
+
+ScriptCommandMethod = (
+  "script.addPreloadScript" /
+  "script.callFunction" /
+  "script.disown" /
+  "script.evaluate" /
+  "script.getRealms" /
+  "script.removePreloadScript"
+)
 </pre>
 
 [=local end definition=]
@@ -4290,6 +4299,12 @@ ScriptEvent = (
   script.Message //
   script.RealmCreated //
   script.RealmDestroyed
+)
+
+ScriptEventMethod = (
+  "script.message" /
+  "script.realmCreated" /
+  "script.realmDestroyed"
 )
 </pre>
 
@@ -6193,7 +6208,7 @@ script=].
    <dd>
       <pre class="cddl remote-cddl">
       script.AddPreloadScriptCommand = {
-        method: "script.addPreloadScript",
+        method: "script.addPreloadScript" .within ScriptCommandMethod,
         params: script.AddPreloadScriptParameters
       }
 
@@ -6250,7 +6265,7 @@ other handles or strong ECMAScript references.
    <dd>
       <pre class="cddl remote-cddl">
       script.Disown = {
-        method: "script.disown",
+        method: "script.disown" .within ScriptCommandMethod,
         params: script.DisownParameters
       }
 
@@ -6301,7 +6316,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
    <dd>
     <pre class="cddl remote-cddl">
       script.CallFunction = {
-        method: "script.callFunction",
+        method: "script.callFunction" .within ScriptCommandMethod,
         params: script.CallFunctionParameters
       }
 
@@ -6489,7 +6504,7 @@ the promise is returned.
    <dd>
       <pre class="cddl remote-cddl">
       script.Evaluate = {
-        method: "script.evaluate",
+        method: "script.evaluate" .within ScriptCommandMethod,
         params: script.EvaluateParameters
       }
 
@@ -6591,7 +6606,7 @@ realm associated with the [=document=] currently loaded in a specified
    <dd>
       <pre class="cddl remote-cddl">
       script.GetRealms = {
-        method: "script.getRealms",
+        method: "script.getRealms" .within ScriptCommandMethod,
         params: script.GetRealmsParameters
       }
 
@@ -6675,7 +6690,7 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
    <dd>
     <pre class="cddl remote-cddl">
       script.RemovePreloadScriptCommand = {
-        method: "script.removePreloadScript",
+        method: "script.removePreloadScript" .within ScriptCommandMethod,
         params: script.RemovePreloadScriptParameters
       }
 
@@ -6719,7 +6734,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
    <dd>
       <pre class="cddl local-cddl">
         script.Message = {
-         method: "script.message",
+         method: "script.message" .within ScriptEventMethod,
          params: script.MessageParameters
        }
 
@@ -6782,7 +6797,7 @@ given |session|, |realm|, |channel properties|, and |message|:
    <dd>
       <pre class="cddl local-cddl">
         script.RealmCreated = {
-         method: "script.realmCreated",
+         method: "script.realmCreated" .within ScriptEventMethod,
          params: script.RealmInfo
        }
       </pre>
@@ -6864,7 +6879,7 @@ Issue: Should the order here be better defined?
    <dd>
       <pre class="cddl local-cddl">
        script.RealmDestroyed = {
-         method: "script.realmDestroyed",
+         method: "script.realmDestroyed" .within ScriptEventMethod,
          params: script.RealmDestroyedParameters
        }
 


### PR DESCRIPTION
This PR adds some helper types for understanding relevant method names for events and commands.

If this is merged, I'll add this for other domains as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/471.html" title="Last updated on Jul 5, 2023, 8:34 AM UTC (6ea7d48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/471/4f6ffa4...6ea7d48.html" title="Last updated on Jul 5, 2023, 8:34 AM UTC (6ea7d48)">Diff</a>