### PR TITLE
Update references to JavaScript primitives

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4882,22 +4882,20 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
    of steps for which the associated condition is true, if any:
 
   <dl>
-    <dt>[=Type=](|value|) is undefined
+    <dt>[=Type=](|value|) is {{undefined}}
     <dd>Let |remote value| be a [=/map=] matching the <code>script.UndefinedValue</code>
     production in the [=local end definition=].
 
-    <dt>[=Type=](|value|) is Null
+    <dt>[=Type=](|value|) is <code>[=null=]</code>
     <dd>Let |remote value| be a [=/map=] matching the <code>script.NullValue</code>
     production in the [=local end definition=].
 
-    <dt>[=Type=](|value|) is String
+    <dt>[=Type=](|value|) is {{String}}
     <dd>Let |remote value| be a [=/map=] matching the <code>script.StringValue</code>
     production in the [=local end definition=], with the <code>value</code>
     property set to |value|.
 
-    Issue: This doesn't handle lone surrogates
-
-    <dt>[=Type=](|value|) is Number
+    <dt>[=Type=](|value|) is {{Number}}
     <dd>
     1. Switch on the value of |value|:
       <dl>
@@ -4917,12 +4915,12 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
        production in the [=local end definition=], with the <code>value</code>
        property set to |serialized|.
 
-    <dt>[=Type=](|value|) is Boolean
+    <dt>[=Type=](|value|) is {{Boolean}}
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BooleanValue</code>
         production in the [=local end definition=], with the <code>value</code>
         property set to |value|.
 
-    <dt>[=Type=](|value|) is BigInt
+    <dt>[=Type=](|value|) is {{BigInt}}
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BigIntValue</code>
         production in the [=local end definition=], with the <code>value</code>
         property set to the result of running the [=ToString=] operation on


### PR DESCRIPTION
Fixed: https://github.com/w3c/webdriver-bidi/issues/455


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/483.html" title="Last updated on Jul 10, 2023, 11:57 AM UTC (5935640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/483/6736ff3...5935640.html" title="Last updated on Jul 10, 2023, 11:57 AM UTC (5935640)">Diff</a>