### PR TITLE
Add `type` for message types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -330,12 +330,14 @@ Message = (
 )
 
 CommandResponse = {
+  type: "success",
   id: js-uint,
   result: ResultData,
   Extensible
 }
 
 ErrorResponse = {
+  type: "error",
   id: js-uint / null,
   error: ErrorCode,
   message: text,
@@ -356,6 +358,7 @@ EmptyResult = {
 }
 
 Event = {
+  type: "event",
   EventData,
   Extensible
 }


### PR DESCRIPTION
Fixed: https://github.com/w3c/webdriver-bidi/issues/480


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/484.html" title="Last updated on Jul 10, 2023, 12:23 PM UTC (770693d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/484/cbc17e9...770693d.html" title="Last updated on Jul 10, 2023, 12:23 PM UTC (770693d)">Diff</a>