### PR TITLE
Revert "Update references to JavaScript primitives"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4900,20 +4900,22 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
    of steps for which the associated condition is true, if any:
 
   <dl>
-    <dt>[=Type=](|value|) is {{undefined}}
+    <dt>[=Type=](|value|) is undefined
     <dd>Let |remote value| be a [=/map=] matching the <code>script.UndefinedValue</code>
     production in the [=local end definition=].
 
-    <dt>[=Type=](|value|) is <code>[=null=]</code>
+    <dt>[=Type=](|value|) is Null
     <dd>Let |remote value| be a [=/map=] matching the <code>script.NullValue</code>
     production in the [=local end definition=].
 
-    <dt>[=Type=](|value|) is {{String}}
+    <dt>[=Type=](|value|) is String
     <dd>Let |remote value| be a [=/map=] matching the <code>script.StringValue</code>
     production in the [=local end definition=], with the <code>value</code>
     property set to |value|.
 
-    <dt>[=Type=](|value|) is {{Number}}
+    Issue: This doesn't handle lone surrogates
+
+    <dt>[=Type=](|value|) is Number
     <dd>
     1. Switch on the value of |value|:
       <dl>
@@ -4933,12 +4935,12 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
        production in the [=local end definition=], with the <code>value</code>
        property set to |serialized|.
 
-    <dt>[=Type=](|value|) is {{Boolean}}
+    <dt>[=Type=](|value|) is Boolean
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BooleanValue</code>
         production in the [=local end definition=], with the <code>value</code>
         property set to |value|.
 
-    <dt>[=Type=](|value|) is {{BigInt}}
+    <dt>[=Type=](|value|) is BigInt
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BigIntValue</code>
         production in the [=local end definition=], with the <code>value</code>
         property set to the result of running the [=ToString=] operation on


### PR DESCRIPTION
Reverts w3c/webdriver-bidi#483


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/485.html" title="Last updated on Jul 10, 2023, 3:57 PM UTC (e1dd031)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/485/a492d0d...e1dd031.html" title="Last updated on Jul 10, 2023, 3:57 PM UTC (e1dd031)">Diff</a>