### PR TITLE
Use `normalize` instead `normalise`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2263,7 +2263,7 @@ Base64-encoded string.
 TODO: Full page screenshots, and multiple output formats
 
 <div algorithm>
-To <dfn>normalise rect</dfn> given |rect|:
+To <dfn>normalize rect</dfn> given |rect|:
 
 Note: This ensures that the resulting rect has positive [=width dimension=] and
 [=height dimension=].
@@ -2290,9 +2290,9 @@ Note: This ensures that the resulting rect has positive [=width dimension=] and
 <div algorithm>
 To <dfn>rectangle intersection</dfn> given |rect1| and |rect2|
 
-1. Let |rect1| be [=normalise rect=] with |rect1|.
+1. Let |rect1| be [=normalize rect=] with |rect1|.
 
-1. Let |rect2| be [=normalise rect=] with |rect2|.
+1. Let |rect2| be [=normalize rect=] with |rect2|.
 
 1. Let |x1_0| be |rect1|'s [=x coordinate=].
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 17, 2023, 9:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Flutien%2Fwebdriver-bidi%2F13648c099b16f7ab9fffb5c457eadf7d85ac3a02%2Findex.bs&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23497.)._
</details>
