### PR TITLE
Spec issue: This assumes for-in works on iterators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -118,11 +118,13 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Date.toISOString; url: sec-date.prototype.toisostring
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
+    text: GetIterator; url: sec-getiterator
     text: HasProperty; url: sec-hasproperty
     text: IsArray; url: sec-isarray
     text: IsCallable; url: sec-iscallable
     text: IsPromise; url: sec-ispromise
     text: IsRegExp; url: sec-isregexp
+    text: IteratorToList; url: sec-iteratortolist
     text: LengthOfArrayLike; url: sec-lengthofarraylike
     text: Map; url: #sec-map-iterable; for: constructor
     text: Number; url: sec-number-constructor

--- a/index.bs
+++ b/index.bs
@@ -6001,7 +6001,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 
 1. Let |serialized| be a new list.
 
-1. For |item| in |iterable|:
+1. For |item| in [=IteratorToList=]([=GetIterator=])(|iterable|):
 
   1. Assert: [=IsArray=](|item|)
 

--- a/index.bs
+++ b/index.bs
@@ -6001,7 +6001,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 
 1. Let |serialized| be a new list.
 
-1. For |item| in [=IteratorToList=]([=GetIterator=](|iterable|, |sync|)):
+1. For |item| in [=IteratorToList=]([=GetIterator=](|iterable|, sync)):
 
   1. Assert: [=IsArray=](|item|)
 

--- a/index.bs
+++ b/index.bs
@@ -6001,7 +6001,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 
 1. Let |serialized| be a new list.
 
-1. For |item| in [=IteratorToList=]([=GetIterator=])(|iterable|):
+1. For |item| in [=IteratorToList=]([=GetIterator=](|iterable|)):
 
   1. Assert: [=IsArray=](|item|)
 

--- a/index.bs
+++ b/index.bs
@@ -5971,7 +5971,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |serialization options|, |ow
 
 1. Let |serialized| be a new list.
 
-1. For each |child value| in |iterable|:
+1. For each |child value| in [=IteratorToList=]([=GetIterator=](|iterable|, sync)):
 
   1. Let |child serialization options| be a [=map/clone=] of
      |serialization options|.
@@ -5992,6 +5992,7 @@ To <dfn>serialize as a list</dfn> given |iterable|, |serialization options|, |ow
 </div>
 
 <div algorithm>
+
 To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 |ownership type|, |serialization internal map|, |realm|, and |session|:
 

--- a/index.bs
+++ b/index.bs
@@ -5989,8 +5989,6 @@ To <dfn>serialize as a list</dfn> given |iterable|, |serialization options|, |ow
 
 </div>
 
-Issue: this assumes for-in works on iterators
-
 <div algorithm>
 To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 |ownership type|, |serialization internal map|, |realm|, and |session|:

--- a/index.bs
+++ b/index.bs
@@ -6001,7 +6001,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 
 1. Let |serialized| be a new list.
 
-1. For |item| in [=IteratorToList=]([=GetIterator=](|iterable|)):
+1. For |item| in [=IteratorToList=]([=GetIterator=](|iterable|, |sync|)):
 
   1. Assert: [=IsArray=](|item|)
 


### PR DESCRIPTION
This is a proposed solution for by converting the iterator into a list so that it can be iterated on, however similar to other parts of WebDriver BiDi as it is currently, this solution mishandles completion records.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/499.html" title="Last updated on Jul 24, 2023, 1:38 PM UTC (3566ecc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/499/63ae894...bocoup:3566ecc.html" title="Last updated on Jul 24, 2023, 1:38 PM UTC (3566ecc)">Diff</a>