### PR TITLE
Spec issue: Differentiate between `List` and `Array`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ node_modules
 /index.html
 *.cddl
 *.json
-._index.html
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 /index.html
 *.cddl
 *.json
+._index.html
+.idea/

--- a/index.bs
+++ b/index.bs
@@ -4711,8 +4711,6 @@ and |session|:
 
 <div algorithm>
 
-Issue: TODO distinguish between `List` and `Array`.
-
 To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and
 |session|:
 

--- a/index.bs
+++ b/index.bs
@@ -4709,6 +4709,8 @@ and |session|:
 
 </div>
 
+Issue:  TODO distinguish between `List` and `Array`. This has been partially completed as the "value" parameter
+of "deserialize value list" could be an ECMAScript Array or an ECMAScript Set.
 <div algorithm>
 
 To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and

--- a/index.bs
+++ b/index.bs
@@ -4708,9 +4708,6 @@ and |session|:
 1. Return [=success=] with data |deserialized key-value list|.
 
 </div>
-
-Issue:  TODO distinguish between `List` and `Array`. This has been partially completed as the "value" parameter
-of "deserialize value list" could be an ECMAScript Array or an ECMAScript Set.
 <div algorithm>
 
 To <dfn>deserialize value list</dfn> given |serialized value list|, |realm| and

--- a/index.bs
+++ b/index.bs
@@ -4705,7 +4705,7 @@ and |session|:
    1. Append [=CreateArrayFromList=](«|deserialized key|, |deserialized value|») to
       |deserialized key-value list|.
 
-1. Return [=success=] with data [=CreateArrayFromList=](|deserialized key-value list|).
+1. Return [=success=] with data |deserialized key-value list|.
 
 </div>
 


### PR DESCRIPTION
This solution returns a list instead of an array so that it can be used later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/500.html" title="Last updated on Jul 27, 2023, 5:12 PM UTC (bc29541)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/500/63ae894...bocoup:bc29541.html" title="Last updated on Jul 27, 2023, 5:12 PM UTC (bc29541)">Diff</a>