### PR TITLE
Use `userText` everywhere in the description of `browsingContext.handleUserPrompt` command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2712,7 +2712,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. Let |accept| be the value of the <code>accept</code> field of |command
    parameters| if present, or true otherwise.
 
-1. Let |text| be the value of the <code>text</code> field of |command
+1. Let |userText| be the value of the <code>userText</code> field of |command
    parameters| if present, or the empty string otherwise.
 
 1. If |context| is currently showing a simple dialog from a call to [=alert=] then
@@ -2723,7 +2723,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    negatively if |accept| is false.
 
    Otherwise if |context| is currently showing a simple dialog from a call to
-   [=prompt=], then respond with the string value |text| if |accept| is
+   [=prompt=], then respond with the string value |userText| if |accept| is
    true, or abort if |accept| is false.
 
    Otherwise, if |context| is currently showing a prompt as part of the [=prompt


### PR DESCRIPTION
Since the parameter in the command type definition is called `userText` we should keep on using it in the algorithm of the command.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/505.html" title="Last updated on Aug 3, 2023, 10:30 AM UTC (2d352c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/505/c10c304...lutien:2d352c9.html" title="Last updated on Aug 3, 2023, 10:30 AM UTC (2d352c9)">Diff</a>