### PR TITLE
Fix CDDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -331,8 +331,8 @@ EmptyParams = {
 
 <pre class="cddl local-cddl">
 Message = (
-  CommandResponse //
-  ErrorResponse //
+  CommandResponse /
+  ErrorResponse /
   Event
 )
 
@@ -353,10 +353,10 @@ ErrorResponse = {
 }
 
 ResultData = (
-  BrowsingContextResult //
-  EmptyResult //
-  NetworkResult //
-  ScriptResult //
+  BrowsingContextResult /
+  EmptyResult /
+  NetworkResult /
+  ScriptResult /
   SessionResult
 )
 
@@ -1232,7 +1232,7 @@ SessionCommand = (
 
 <pre class="cddl local-cddl">
 SessionResult = (
-   session.NewResult //
+   session.NewResult /
    session.StatusResult
 )
 </pre>
@@ -1432,10 +1432,10 @@ This is a [=static command=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      session.Status = {
+      session.Status = (
         method: "session.status",
         params: EmptyParams,
-      }
+      )
       </pre>
    </dd>
    <dt>Result Type</dt>
@@ -1482,10 +1482,10 @@ This is a [=static command=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      session.New = {
+      session.New = (
         method: "session.new",
         params: session.NewParameters
-      }
+      )
 
       session.NewParameters = {
         capabilities: session.CapabilitiesRequest
@@ -1559,10 +1559,10 @@ The <dfn export for=commands>session.end</dfn> command ends the current
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      session.End = {
+      session.End = (
         method: "session.end",
         params: EmptyParams
-      }
+      )
 
       </pre>
    </dd>
@@ -1605,10 +1605,10 @@ Issue: This needs to be generalized to work with realms too
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      session.Subscribe = {
+      session.Subscribe = (
         method: "session.subscribe",
         params: session.SubscriptionRequest
-      }
+      )
       </pre>
    </dd>
    <dt>Result Type</dt>
@@ -1673,10 +1673,10 @@ Issue: This needs to be generalised to work with realms too
    <dt>Command Type</dt>
    <dd>
      <pre class="cddl remote-cddl">
-     session.Unsubscribe = {
+     session.Unsubscribe = (
        method: "session.unsubscribe",
        params: session.SubscriptionRequest
-     }
+     )
      </pre>
    </dd>
    <dt>Result Type</dt>
@@ -1736,10 +1736,10 @@ WebDriver sessions and cleans up automation state in the remote browser instance
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browser.Close = {
+      browser.Close = (
         method: "browser.close",
         params: EmptyParams,
-      }
+      )
       </pre>
    </dd>
    <dt>Return Type</dt>
@@ -1847,10 +1847,10 @@ BrowsingContextCommand = (
 
 <pre class="cddl local-cddl">
 BrowsingContextResult = (
-  browsingContext.CaptureScreenshotResult //
-  browsingContext.CreateResult //
-  browsingContext.GetTreeResult //
-  browsingContext.NavigateResult //
+  browsingContext.CaptureScreenshotResult /
+  browsingContext.CreateResult /
+  browsingContext.GetTreeResult /
+  browsingContext.NavigateResult /
   browsingContext.PrintResult
 )
 
@@ -2153,10 +2153,10 @@ The <dfn export for=commands>browsingContext.activate</dfn> command activates an
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      browsingContext.Activate = {
+      browsingContext.Activate = (
         method: "browsingContext.activate",
         params: browsingContext.ActivateParameters
-      };
+      )
 
       browsingContext.ActivateParameters = {
         context: browsingContext.BrowsingContext
@@ -2212,10 +2212,10 @@ Base64-encoded string.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.CaptureScreenshot = {
+      browsingContext.CaptureScreenshot = (
         method: "browsingContext.captureScreenshot",
         params: browsingContext.CaptureScreenshotParameters
-      }
+      )
 
       browsingContext.CaptureScreenshotParameters = {
         context: browsingContext.BrowsingContext,
@@ -2223,7 +2223,7 @@ Base64-encoded string.
       }
 
       browsingContext.ClipRectangle = (
-        browsingContext.BoxClipRectangle //
+        browsingContext.BoxClipRectangle /
         browsingContext.ElementClipRectangle
       )
 
@@ -2456,10 +2456,10 @@ The <dfn export for=commands>browsingContext.close</dfn> command closes a
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.Close = {
+      browsingContext.Close = (
         method: "browsingContext.close",
         params: browsingContext.CloseParameters
-      }
+      )
 
       browsingContext.CloseParameters = {
         context: browsingContext.BrowsingContext
@@ -2509,10 +2509,10 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.Create = {
+      browsingContext.Create = (
         method: "browsingContext.create",
         params: browsingContext.CreateParameters
-      }
+      )
 
       browsingContext.CreateType = "tab" / "window"
 
@@ -2606,10 +2606,10 @@ or all top-level contexts when no parent is provided.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.GetTree = {
+      browsingContext.GetTree = (
         method: "browsingContext.getTree",
         params: browsingContext.GetTreeParameters
-      }
+      )
 
       browsingContext.GetTreeParameters = {
         ? maxDepth: js-uint,
@@ -2667,10 +2667,10 @@ command allows closing an open prompt
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.HandleUserPrompt = {
+      browsingContext.HandleUserPrompt = (
         method: "browsingContext.handleUserPrompt",
         params: browsingContext.HandleUserPromptParameters
-      }
+      )
 
       browsingContext.HandleUserPromptParameters = {
         context: browsingContext.BrowsingContext,
@@ -2733,10 +2733,10 @@ browsing context to the given URL.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.Navigate = {
+      browsingContext.Navigate = (
         method: "browsingContext.navigate",
         params: browsingContext.NavigateParameters
-      }
+      )
 
       browsingContext.NavigateParameters = {
         context: browsingContext.BrowsingContext,
@@ -2801,10 +2801,10 @@ PDF document represented as a Base64-encoded string.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.Print = {
+      browsingContext.Print = (
         method: "browsingContext.print",
         params: browsingContext.PrintParameters
-      }
+      )
 
       browsingContext.PrintParameters = {
         context: browsingContext.BrowsingContext,
@@ -2943,10 +2943,10 @@ browsing context.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browsingContext.Reload = {
+      browsingContext.Reload = (
         method: "browsingContext.reload",
         params: browsingContext.ReloadParameters
-      }
+      )
 
       browsingContext.ReloadParameters = {
         context: browsingContext.BrowsingContext,
@@ -3002,10 +3002,10 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command  specific
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      browsingContext.SetViewport = {
+      browsingContext.SetViewport = (
         method: "browsingContext.setViewport",
         params: browsingContext.SetViewportParameters
-      };
+      )
 
       browsingContext.SetViewportParameters = {
         context: browsingContext.BrowsingContext,
@@ -3059,10 +3059,10 @@ The [=remote end steps=] with |command parameters| are:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.ContextCreated = {
+        browsingContext.ContextCreated = (
          method: "browsingContext.contextCreated",
          params: browsingContext.Info
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3130,10 +3130,10 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 1, given
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.ContextDestroyed = {
+        browsingContext.ContextDestroyed = (
          method: "browsingContext.contextDestroyed",
          params: browsingContext.Info
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3175,10 +3175,10 @@ become inaccessible but not yet get discarded because bfcache.
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.NavigationStarted = {
+        browsingContext.NavigationStarted = (
          method: "browsingContext.navigationStarted",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3214,10 +3214,10 @@ started</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.FragmentNavigated = {
+        browsingContext.FragmentNavigated = (
          method: "browsingContext.fragmentNavigated",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3253,10 +3253,10 @@ navigated</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.DomContentLoaded = {
+        browsingContext.DomContentLoaded = (
          method: "browsingContext.domContentLoaded",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3292,10 +3292,10 @@ loaded</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.Load = {
+        browsingContext.Load = (
          method: "browsingContext.load",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3330,10 +3330,10 @@ complete</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.DownloadWillBegin = {
+        browsingContext.DownloadWillBegin = (
          method: "browsingContext.downloadWillBegin",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3368,10 +3368,10 @@ started</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.NavigationAborted = {
+        browsingContext.NavigationAborted = (
          method: "browsingContext.navigationAborted",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3407,10 +3407,10 @@ aborted</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.NavigationFailed = {
+        browsingContext.NavigationFailed = (
          method: "browsingContext.navigationFailed",
          params: browsingContext.NavigationInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -3445,10 +3445,10 @@ failed</dfn> steps given |context| and |navigation status|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.UserPromptClosed = {
+        browsingContext.UserPromptClosed = (
           method: "browsingContext.userPromptClosed",
           params: browsingContext.UserPromptClosedParameters
-        }
+        )
 
         browsingContext.UserPromptClosedParameters = {
           context: browsingContext.BrowsingContext,
@@ -3493,10 +3493,10 @@ closed</dfn> steps given |window|, |accepted| and optional |user text|
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.UserPromptOpened = {
+        browsingContext.UserPromptOpened = (
           method: "browsingContext.userPromptOpened",
           params: browsingContext.UserPromptOpenedParameters
-        }
+        )
 
         browsingContext.UserPromptOpenedParameters = {
           context: browsingContext.BrowsingContext,
@@ -4476,7 +4476,7 @@ To <dfn>serialize set-cookie header</dfn> given |protocol cookie|:
 
 <pre class="cddl remote-cddl">
 network.UrlPattern = (
-  network.UrlPatternPattern //
+  network.UrlPatternPattern /
   network.UrlPatternString
 )
 
@@ -4758,10 +4758,10 @@ The <dfn export for=commands>network.addIntercept</dfn> command adds a
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.AddIntercept = {
+      network.AddIntercept = (
         method: "network.addIntercept",
         params: network.AddInterceptParameters
-      }
+      )
 
       network.AddInterceptParameters = {
         phases: [+network.InterceptPhase],
@@ -4819,10 +4819,10 @@ that's blocked by a [=network intercept=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.ContinueRequest = {
+      network.ContinueRequest = (
         method: "network.continueRequest",
         params: network.ContinueRequestParameters
-      }
+      )
 
       network.ContinueRequestParameters = {
         request: network.Request,
@@ -4943,10 +4943,10 @@ response, but still provide the network response body.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.ContinueResponse = {
+      network.ContinueResponse = (
         method: "network.continueResponse",
         params: network.ContinueResponseParameters
-      }
+      )
 
       network.ContinueResponseParameters = {
         request: network.Request,
@@ -5077,25 +5077,25 @@ response that's blocked by a [=network intercept=] at the
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.ContinueWithAuth = {
+      network.ContinueWithAuth = (
         method: "network.continueWithAuth",
         params: network.ContinueWithAuthParameters
-      }
+      )
 
       network.ContinueWithAuthParameters = {
         request: network.Request,
         (network.ContinueWithAuthCredentials // network.ContinueWithAuthNoCredentials)
       }
 
-      network.ContinueWithAuthCredentials = {
+      network.ContinueWithAuthCredentials = (
         action: "provideCredentials", <!-- or "provide credentials" or
       "providecredentials" or something else -->
         credentials: network.AuthCredentials
-      }
+      )
 
-      network.ContinueWithAuthNoCredentials = {
+      network.ContinueWithAuthNoCredentials = (
         action: "default" / "cancel"
-      }
+      )
       </pre>
    </dd>
    <dt>Return Type</dt>
@@ -5151,10 +5151,10 @@ fetch that's blocked by a [=network intercept=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.FailRequest = {
+      network.FailRequest = (
         method: "network.failRequest",
         params: network.FailRequestParameters
-      }
+      )
 
       network.FailRequestParameters = {
         request: network.Request,
@@ -5209,10 +5209,10 @@ lifecycle, and therefore emitting other events as it progresses.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.ProvideResponse = {
+      network.ProvideResponse = (
         method: "network.provideResponse",
         params: network.ProvideResponseParameters
-      }
+      )
 
       network.ProvideResponseParameters = {
         request: network.Request,
@@ -5264,10 +5264,10 @@ The <dfn export for=commands>network.removeIntercept</dfn> command removes a
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.RemoveIntercept = {
+      network.RemoveIntercept = (
         method: "network.removeIntercept",
         params: network.RemoveInterceptParameters
-      }
+      )
 
       network.RemoveInterceptParameters = {
         intercept: network.Intercept
@@ -5308,10 +5308,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-      network.AuthRequired = {
+      network.AuthRequired = (
         method: "network.authRequired",
         params: network.AuthRequiredParameters
-      }
+      )
 
       network.AuthRequiredParameters = {
         network.BaseParameters,
@@ -5385,10 +5385,10 @@ steps given |request| and |response|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        network.BeforeRequestSent = {
+        network.BeforeRequestSent = (
          method: "network.beforeRequestSent",
          params: network.BeforeRequestSentParameters
-       }
+        )
 
        network.BeforeRequestSentParameters = {
          network.BaseParameters,
@@ -5469,10 +5469,10 @@ request sent</dfn> steps given |request|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        network.FetchError = {
+        network.FetchError = (
          method: "network.fetchError",
          params: network.FetchErrorParameters
-       }
+        )
 
        network.FetchErrorParameters = {
          network.BaseParameters,
@@ -5527,10 +5527,10 @@ error</dfn> steps given |request|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        network.ResponseCompleted = {
+        network.ResponseCompleted = (
          method: "network.responseCompleted",
          params: network.ResponseCompletedParameters
-       }
+        )
 
        network.ResponseCompletedParameters = {
          network.BaseParameters,
@@ -5586,10 +5586,10 @@ completed</dfn> steps given |request| and |response|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        network.ResponseStarted = {
+        network.ResponseStarted = (
          method: "network.responseStarted",
          params: network.ResponseStartedParameters
-       }
+        )
 
        network.ResponseStartedParameters = {
          network.BaseParameters,
@@ -5680,8 +5680,8 @@ ScriptCommand = (
 
 <pre class="cddl local-cddl">
 ScriptResult = (
-  script.AddPreloadScriptResult //
-  script.EvaluateResult //
+  script.AddPreloadScriptResult /
+  script.EvaluateResult /
   script.GetRealmsResult
 )
 
@@ -5828,7 +5828,7 @@ To <dfn>create a channel</dfn> given |session|, |realm| and |protocol value|:
 
 <pre class="cddl remote-cddl local-cddl">
 script.EvaluateResult = (
-  script.EvaluateResultSuccess //
+  script.EvaluateResultSuccess /
   script.EvaluateResultException
 )
 
@@ -5926,14 +5926,14 @@ strong [=/map=] from handle ids to their corresponding objects.
 
 <pre class="cddl remote-cddl">
 script.LocalValue = (
-  script.RemoteReference //
-  script.PrimitiveProtocolValue //
-  script.ChannelValue //
-  script.ArrayLocalValue //
-  script.DateLocalValue //
-  script.MapLocalValue //
-  script.ObjectLocalValue //
-  script.RegExpLocalValue //
+  script.RemoteReference /
+  script.PrimitiveProtocolValue /
+  script.ChannelValue /
+  script.ArrayLocalValue /
+  script.DateLocalValue /
+  script.MapLocalValue /
+  script.ObjectLocalValue /
+  script.RegExpLocalValue /
   script.SetLocalValue
 )
 
@@ -6172,11 +6172,11 @@ Issue: This has the wrong error code
 
 <pre class="cddl remote-cddl local-cddl">
 script.PrimitiveProtocolValue = (
-  script.UndefinedValue //
-  script.NullValue //
-  script.StringValue //
-  script.NumberValue //
-  script.BooleanValue //
+  script.UndefinedValue /
+  script.NullValue /
+  script.StringValue /
+  script.NumberValue /
+  script.BooleanValue /
   script.BigIntValue
 )
 
@@ -6340,13 +6340,13 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 
 <pre class="cddl local-cddl">
 script.RealmInfo = (
-  script.WindowRealmInfo //
-  script.DedicatedWorkerRealmInfo //
-  script.SharedWorkerRealmInfo //
-  script.ServiceWorkerRealmInfo //
-  script.WorkerRealmInfo //
-  script.PaintWorkletRealmInfo //
-  script.AudioWorkletRealmInfo //
+  script.WindowRealmInfo /
+  script.DedicatedWorkerRealmInfo /
+  script.SharedWorkerRealmInfo /
+  script.ServiceWorkerRealmInfo /
+  script.WorkerRealmInfo /
+  script.PaintWorkletRealmInfo /
+  script.AudioWorkletRealmInfo /
   script.WorkletRealmInfo
 )
 
@@ -6535,7 +6535,7 @@ The <code>script.RealmType</code> type represents the different types of Realm.
 <!-- This is specifically ordered in the order in which matches need to be -->
 <!-- evaluated, since the definitions are overlapping -->
 script.RemoteReference = (
-  script.SharedReference //
+  script.SharedReference /
   script.RemoteObjectReference
 )
 
@@ -6643,27 +6643,27 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 
 <pre class="cddl remote-cddl local-cddl">
 script.RemoteValue = (
-  script.PrimitiveProtocolValue //
-  script.SymbolRemoteValue //
-  script.ArrayRemoteValue //
-  script.ObjectRemoteValue //
-  script.FunctionRemoteValue //
-  script.RegExpRemoteValue //
-  script.DateRemoteValue //
-  script.MapRemoteValue //
-  script.SetRemoteValue //
-  script.WeakMapRemoteValue //
-  script.WeakSetRemoteValue //
-  script.IteratorRemoteValue //
-  script.GeneratorRemoteValue //
-  script.ErrorRemoteValue //
-  script.ProxyRemoteValue //
-  script.PromiseRemoteValue //
-  script.TypedArrayRemoteValue //
-  script.ArrayBufferRemoteValue //
-  script.NodeListRemoteValue //
-  script.HTMLCollectionRemoteValue //
-  script.NodeRemoteValue //
+  script.PrimitiveProtocolValue /
+  script.SymbolRemoteValue /
+  script.ArrayRemoteValue /
+  script.ObjectRemoteValue /
+  script.FunctionRemoteValue /
+  script.RegExpRemoteValue /
+  script.DateRemoteValue /
+  script.MapRemoteValue /
+  script.SetRemoteValue /
+  script.WeakMapRemoteValue /
+  script.WeakSetRemoteValue /
+  script.IteratorRemoteValue /
+  script.GeneratorRemoteValue /
+  script.ErrorRemoteValue /
+  script.ProxyRemoteValue /
+  script.PromiseRemoteValue /
+  script.TypedArrayRemoteValue /
+  script.ArrayBufferRemoteValue /
+  script.NodeListRemoteValue /
+  script.HTMLCollectionRemoteValue /
+  script.NodeRemoteValue /
   script.WindowProxyRemoteValue
 )
 
@@ -7479,10 +7479,10 @@ Record=] of type <code>throw</code>, |exception|, is given by:
 [=Local end definition=]
 
 <pre class="cddl local-cddl">
-script.Source = (
+script.Source = {
   realm: script.Realm,
   ? context: browsingContext.BrowsingContext
-);
+}
 </pre>
 
 The <code>script.Source</code> type represents a <code>script.Realm</code> with
@@ -7531,7 +7531,7 @@ script.ContextTarget = {
 }
 
 script.Target = (
-  script.RealmTarget //
+  script.RealmTarget /
   script.ContextTarget
 );
 </pre>
@@ -7589,10 +7589,10 @@ script=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.AddPreloadScriptCommand = {
+      script.AddPreloadScriptCommand = (
         method: "script.addPreloadScript",
         params: script.AddPreloadScriptParameters
-      }
+      )
 
       script.AddPreloadScriptParameters = {
         functionDeclaration: text,
@@ -7646,10 +7646,10 @@ other handles or strong ECMAScript references.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.Disown = {
+      script.Disown = (
         method: "script.disown",
         params: script.DisownParameters
-      }
+      )
 
       script.DisownParameters = {
         handles: [*script.Handle]
@@ -7697,10 +7697,10 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      script.CallFunction = {
+      script.CallFunction = (
         method: "script.callFunction",
         params: script.CallFunctionParameters
-      }
+      )
 
       script.CallFunctionParameters = {
         functionDeclaration: text,
@@ -7881,10 +7881,10 @@ the promise is returned.
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.Evaluate = {
+      script.Evaluate = (
         method: "script.evaluate",
         params: script.EvaluateParameters
-      }
+      )
 
       script.EvaluateParameters = {
         expression: text,
@@ -7986,10 +7986,10 @@ realm associated with the [=document=] currently loaded in a specified
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.GetRealms = {
+      script.GetRealms = (
         method: "script.getRealms",
         params: script.GetRealmsParameters
-      }
+      )
 
       script.GetRealmsParameters = {
         ? context: browsingContext.BrowsingContext,
@@ -8070,10 +8070,10 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      script.RemovePreloadScriptCommand = {
+      script.RemovePreloadScriptCommand = (
         method: "script.removePreloadScript",
         params: script.RemovePreloadScriptParameters
-      }
+      )
 
       script.RemovePreloadScriptParameters = {
         script: script.PreloadScript
@@ -8114,10 +8114,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        script.Message = {
+        script.Message = (
          method: "script.message",
          params: script.MessageParameters
-       }
+        )
 
        script.MessageParameters = {
          channel: script.Channel,
@@ -8177,10 +8177,10 @@ given |session|, |realm|, |channel properties|, and |message|:
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        script.RealmCreated = {
+        script.RealmCreated = (
          method: "script.realmCreated",
          params: script.RealmInfo
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -8259,10 +8259,10 @@ Issue: Should the order here be better defined?
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-       script.RealmDestroyed = {
+       script.RealmDestroyed = (
          method: "script.realmDestroyed",
          params: script.RealmDestroyedParameters
-       }
+       )
 
        script.RealmDestroyedParameters = {
          realm: script.Realm
@@ -8410,8 +8410,8 @@ LogEvent = (
 log.Level = "debug" / "info" / "warn" / "error"
 
 log.Entry = (
-  log.GenericLogEntry //
-  log.ConsoleLogEntry //
+  log.GenericLogEntry /
+  log.ConsoleLogEntry /
   log.JavascriptLogEntry
 )
 
@@ -8458,10 +8458,10 @@ provide additional fields specific to the entry type.
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        log.EntryAdded = {
+        log.EntryAdded = (
          method: "log.entryAdded",
          params: log.Entry,
-       }
+        )
       </pre>
    </dd>
 </dl>
@@ -8694,10 +8694,10 @@ specified sequence of user input actions.
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      input.PerformActions = {
+      input.PerformActions = (
         method: "input.performActions",
         params: input.PerformActionsParameters
-      };
+      )
 
       input.PerformActionsParameters = {
         context: browsingContext.BrowsingContext,
@@ -8705,9 +8705,9 @@ specified sequence of user input actions.
       }
 
       input.SourceActions = (
-        input.NoneSourceActions //
-        input.KeySourceActions //
-        input.PointerSourceActions //
+        input.NoneSourceActions /
+        input.KeySourceActions /
+        input.PointerSourceActions /
         input.WheelSourceActions
       )
 
@@ -8726,8 +8726,8 @@ specified sequence of user input actions.
       }
 
       input.KeySourceAction = (
-        input.PauseAction //
-        input.KeyDownAction //
+        input.PauseAction /
+        input.KeyDownAction /
         input.KeyUpAction
       )
 
@@ -8745,9 +8745,9 @@ specified sequence of user input actions.
       }
 
       input.PointerSourceAction = (
-        input.PauseAction //
-        input.PointerDownAction //
-        input.PointerUpAction //
+        input.PauseAction /
+        input.PointerDownAction /
+        input.PointerUpAction /
         input.PointerMoveAction
       )
 
@@ -8758,7 +8758,7 @@ specified sequence of user input actions.
       }
 
       input.WheelSourceAction = (
-        input.PauseAction //
+        input.PauseAction /
         input.WheelScrollAction
       )
 
@@ -8875,10 +8875,10 @@ state associated with the current session.
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      input.ReleaseActions = {
+      input.ReleaseActions = (
         method: "input.releaseActions",
         params: input.ReleaseActionsParameters
-      };
+      )
 
       input.ReleaseActionsParameters = {
         context: browsingContext.BrowsingContext,


### PR DESCRIPTION
We need to use `/` instead of `//` as `//` are meant to union groups, not types.

For example, `ResultData` is used as the type for `CommandResponse.result`, but `ResultData` is a group (since it uses `//`). Only types may be used as values.

This will be validated once `cddl` 1.0.0 comes out.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/512.html" title="Last updated on Aug 21, 2023, 12:09 PM UTC (19ecb28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/512/45ceaac...19ecb28.html" title="Last updated on Aug 21, 2023, 12:09 PM UTC (19ecb28)">Diff</a>