### PR TITLE
Remove `scrollIntoView`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2229,8 +2229,7 @@ Base64-encoded string.
 
       browsingContext.ElementClipRectangle = {
         type: "element",
-        element: script.SharedReference,
-        ? scrollIntoView: bool
+        element: script.SharedReference
       }
 
       browsingContext.BoxClipRectangle = {
@@ -2416,11 +2415,6 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 
        1. If |element|'s [=node document=] is not |document|, return [=error=] with
           [=error code=] [=no such element=].
-
-       1. If |clip| contains "<code>scrollIntoView</code>" and
-          |clip|["<code>scrollIntoView</code>"]:
-
-         1. [=Scroll into view=] with |element|.
 
        1. Let |clip rect| be [=get the bounding box=] for |element|.
 


### PR DESCRIPTION
This operation can be done on the client side without much effort.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/519.html" title="Last updated on Aug 25, 2023, 10:17 AM UTC (90ad853)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/519/0c3a136...90ad853.html" title="Last updated on Aug 25, 2023, 10:17 AM UTC (90ad853)">Diff</a>