### PR TITLE
add `defaultValue` to `browsingContext.UserPromptOpenedParameters`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3501,7 +3501,8 @@ closed</dfn> steps given |window|, |accepted| and optional |user text|
         browsingContext.UserPromptOpenedParameters = {
           context: browsingContext.BrowsingContext,
           type: "alert" / "confirm" / "prompt" / "beforeunload",
-          message: text
+          message: text,
+          ? defaultValue: text
         }
       </pre>
    </dd>
@@ -3509,7 +3510,8 @@ closed</dfn> steps given |window|, |accepted| and optional |user text|
 
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi user prompt
-opened</dfn> steps given |window|, |type| and |message|.
+opened</dfn> steps given |window|, |type|, |message|, and optional |default value|
+(default: null).
 
 1. Let |context| be |window|'s [=/browsing context=].
 
@@ -3518,7 +3520,9 @@ opened</dfn> steps given |window|, |type| and |message|.
 1. Let |params| be a [=/map=] matching the
    <code>browsingContext.UserPromptOpenedParameters</code> production with the
    <code>context</code> field set to |context id|, the <code>type</code> field
-   set to |type|, and the <code>message</code> field set to |message|.
+   set to |type|, the <code>message</code> field set to |message|, and the 
+   <code>defaultValue</code> field set to |default value| if |default value| is 
+   not null or omitted otherwise.
 
 1. Let |body| be a [=/map=] matching the
    <code>browsingContext.UserPromptOpened</code> production, with the


### PR DESCRIPTION
Adds `defaultValue` to the `browsingContext.UserPromptOpenedParameters` so user's know the default value that was provided to the `window.prompt(message, defaultValue)`

HTML spec patch can be found at https://github.com/whatwg/html/pull/9645


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/webdriver-bidi/pull/521.html" title="Last updated on Aug 30, 2023, 1:03 PM UTC (e08309d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/521/ec67d1d...Lightning00Blade:e08309d.html" title="Last updated on Aug 30, 2023, 1:03 PM UTC (e08309d)">Diff</a>