### PR TITLE
browsing context: print: enforce minimum page size dimensions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -205,6 +205,9 @@ spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
 spec: RFC4648; urlPrefix: https://tools.ietf.org/html/rfc4648
   type: dfn
     text: Base64 Encode; url: section-4
+spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
+  type: dfn
+    text: absolute lengths; url: #absolute-lengths
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
     text: visual viewport; url: #visual-viewport
@@ -2862,7 +2865,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    <code>browsingContext.PrintPageParameters</code> with the fields set to
    their default values.
 
-Note: The minimum page size is 1 point, which is (2.54 / 72) cm.
+Note: The minimum page size is 1 point, which is (2.54 / 72) cm as per
+[=absolute lengths=].
 
 1. Let |page ranges| be the value of the <code>pageRanges</code> field of
    |command parameters| if present or an empty [=/list=] otherwise.

--- a/index.bs
+++ b/index.bs
@@ -2825,8 +2825,8 @@ PDF document represented as a Base64-encoded string.
       }
 
       browsingContext.PrintPageParameters = {
-        ? height: (float .ge 0.0) .default 27.94,
-        ? width: (float .ge 0.0) .default 21.59,
+        ? height: (float .ge (2.54 / 72)) .default 27.94,
+        ? width: (float .ge (2.54 / 72)) .default 21.59,
       }
       </pre>
    </dd>
@@ -2861,6 +2861,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    parameters| if present, or otherwise a [=/map=] matching the
    <code>browsingContext.PrintPageParameters</code> with the fields set to
    their default values.
+
+Note: The minimum page size is 1 point, which is (2.54 / 72) cm.
 
 1. Let |page ranges| be the value of the <code>pageRanges</code> field of
    |command parameters| if present or an empty [=/list=] otherwise.


### PR DESCRIPTION
The minimum possible page size is 1x1 point.

1 point is equal to (2.54 / 72) cm.

Docs: https://www.w3.org/TR/css3-values/#absolute-lengths
Docs: https://stackoverflow.com/questions/139655/convert-pixels-to-points
WPT: https://github.com/web-platform-tests/wpt/pull/40872
Fixed: #473


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/522.html" title="Last updated on Aug 31, 2023, 2:56 PM UTC (14dacc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/522/ec67d1d...14dacc4.html" title="Last updated on Aug 31, 2023, 2:56 PM UTC (14dacc4)">Diff</a>