### PR TITLE
Extend roadmap: permissions automation

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -107,8 +107,8 @@ This scenario changes the browser window dimensions and position, maximizes/mini
 - [x] Some items from the previous milestones
 - [ ] [Add commands for resizing and positioning browser windows](https://github.com/w3c/webdriver-bidi/issues/398)
 
-### Managing permissions
+### Extensions
 
-This scenario automates user granting permission for a browser to access different private information.
+[Define how extension modules could be created.](https://github.com/w3c/webdriver-bidi/issues/506)
 
-- [ ] Bluetooth device chooser
+- [ ] Document a general device access pattern (for use with Web Bluetooth and other APIs)

--- a/roadmap.md
+++ b/roadmap.md
@@ -111,4 +111,4 @@ This scenario changes the browser window dimensions and position, maximizes/mini
 
 This scenario automates user granting permission for a browser to access different private information.
 
-- [ ] Device access: bluetooth
+- [ ] Bluetooth device chooser

--- a/roadmap.md
+++ b/roadmap.md
@@ -109,6 +109,6 @@ This scenario changes the browser window dimensions and position, maximizes/mini
 
 ### Extensions
 
-[Define how extension modules could be created.](https://github.com/w3c/webdriver-bidi/issues/506)
+[As a spec author I want to extend WebDriver BiDi functionality, therefore I define a WebDriver BiDi extension in the spec following WebDriver BiDi extension guidelines.](https://github.com/w3c/webdriver-bidi/issues/506)
 
-- [ ] Document a general device access pattern (for use with Web Bluetooth and other APIs)
+- [ ] [Manage Bluetooth device permissions](https://github.com/WebBluetoothCG/web-bluetooth/issues/613)

--- a/roadmap.md
+++ b/roadmap.md
@@ -106,3 +106,9 @@ This scenario changes the browser window dimensions and position, maximizes/mini
 
 - [x] Some items from the previous milestones
 - [ ] [Add commands for resizing and positioning browser windows](https://github.com/w3c/webdriver-bidi/issues/398)
+
+### Managing permissions
+
+This scenario automates user granting permission for a browser to access different private information.
+
+- [ ] Device access: bluetooth


### PR DESCRIPTION
My team is working on automated bluetooth testing in WPT, which has no way to automate managing device permissions. Instead of implementing something chrome specific, we’d like to explore device access/permission automation in BiDi. We’ll follow up with a design approach in an issue but wanted to start alignment conversations now.

- BiDi extensions: https://github.com/w3c/webdriver-bidi/issues/506
- Manage Bluetooth device permissions: https://github.com/WebBluetoothCG/web-bluetooth/issues/613