### PR TITLE
editorial remove suffix from PreloadScript commands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5667,12 +5667,12 @@ relating to script realms and execution.
 
 <pre class="cddl remote-cddl">
 ScriptCommand = (
-  script.AddPreloadScriptCommand //
+  script.AddPreloadScript //
   script.CallFunction //
   script.Disown //
   script.Evaluate //
   script.GetRealms //
-  script.RemovePreloadScriptCommand
+  script.RemovePreloadScript
 )
 </pre>
 
@@ -7597,7 +7597,7 @@ script=].
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      script.AddPreloadScriptCommand = (
+      script.AddPreloadScript = (
         method: "script.addPreloadScript",
         params: script.AddPreloadScriptParameters
       )
@@ -8090,7 +8090,7 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      script.RemovePreloadScriptCommand = (
+      script.RemovePreloadScript = (
         method: "script.removePreloadScript",
         params: script.RemovePreloadScriptParameters
       )


### PR DESCRIPTION
No other command has such suffix so removing seem the correct option.