### PR TITLE
Set the correct result type for browsingContext.Reload

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2958,7 +2958,7 @@ browsing context.
    <dt>Return Type</dt>
    <dd>
       <pre class="cddl">
-         EmptyResult
+      browsingContext.NavigateResult
       </pre>
    </dd>
 </dl>
@@ -2989,8 +2989,6 @@ The [=remote end steps=] with |command parameters| are:
 1. Return the result of [=await a navigation=] with |context|, |request|, |wait
    condition|, history handling "<code>reload</code>", and ignore
    cache |ignore cache|.
-
-1. Return [=success=] with data null.
 
 </div>
 


### PR DESCRIPTION
The prose here has two different return statements, the first that returns a `browsingContext.NavigateResult` and the second that returns `null`.

Based on the history it seems like the intent was always to return `browsingContext.NavigateResult`, and the `return null` was erronously added during cleanup when it was noticed that the return type CDDL was missing, and so was assuemd to be empty.

From a user perspective, having some way to track progress of a reload, just like any other navigation, seems important, so this is the right behaviour.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/528.html" title="Last updated on Sep 5, 2023, 11:50 AM UTC (fb2d59c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/528/835858f...fb2d59c.html" title="Last updated on Sep 5, 2023, 11:50 AM UTC (fb2d59c)">Diff</a>