### PR TITLE
Enforce minimum page size dimensions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2827,9 +2827,11 @@ PDF document represented as a Base64-encoded string.
         ? top: (float .ge 0.0) .default 1.0,
       }
 
+      ; Minimum size is 1pt x 1pt. Conversion follows from 
+      ; https://www.w3.org/TR/css3-values/#absolute-lengths
       browsingContext.PrintPageParameters = {
-        ? height: (float .ge (2.54 / 72)) .default 27.94,
-        ? width: (float .ge (2.54 / 72)) .default 21.59,
+        ? height: (float .ge 0.0353) .default 27.94,
+        ? width: (float .ge 0.0353) .default 21.59,
       }
       </pre>
    </dd>


### PR DESCRIPTION
This original PR (https://github.com/w3c/webdriver-bidi/pull/522) used invalid syntax for the minimum size.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/534.html" title="Last updated on Sep 11, 2023, 10:33 AM UTC (be7c553)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/534/3535c86...be7c553.html" title="Last updated on Sep 11, 2023, 10:33 AM UTC (be7c553)">Diff</a>