### PR TITLE
`browsingContext.print`: minimum page size: round down instead of up

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2827,11 +2827,11 @@ PDF document represented as a Base64-encoded string.
         ? top: (float .ge 0.0) .default 1.0,
       }
 
-      ; Minimum size is 1pt x 1pt. Conversion follows from 
+      ; Minimum size is 1pt x 1pt. Conversion follows from
       ; https://www.w3.org/TR/css3-values/#absolute-lengths
       browsingContext.PrintPageParameters = {
-        ? height: (float .ge 0.0353) .default 27.94,
-        ? width: (float .ge 0.0353) .default 21.59,
+        ? height: (float .ge 0.0352) .default 27.94,
+        ? width: (float .ge 0.0352) .default 21.59,
       }
       </pre>
    </dd>


### PR DESCRIPTION
This is a small correction of #534.

The minimum page size is (2.54 / 72) = 0.03527...

We need to round it down to 0.0352 instead of up to 0.0353 in order to make 0.03527 (1x1 point) an acceptable value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/536.html" title="Last updated on Sep 11, 2023, 6:43 PM UTC (5ccce6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/536/bcf5601...5ccce6e.html" title="Last updated on Sep 11, 2023, 6:43 PM UTC (5ccce6e)">Diff</a>