### PR TITLE
Editorial: use method name as defined by ECMA262

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6996,7 +6996,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>
-    1. Set |serialized| to [=Call=]([=Date.toISOString=], |value|).
+    1. Set |serialized| to [=Call=]([=Date.toISOString=], «|value|»).
 
     1. Assert: |serialized| is not a [=throw completion=].
 

--- a/index.bs
+++ b/index.bs
@@ -115,7 +115,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: CreateSetIterator; url: sec-createsetiterator
     text: Date; url: sec-date-constructor
     text: Date Time String Format; url: sec-date-time-string-format
-    text: Date.toISOString; url: sec-date.prototype.toisostring
+    text: Date.prototype.toISOString; url: sec-date.prototype.toisostring
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
     text: Get; url: sec-get
     text: GetIterator; url: sec-getiterator
@@ -6996,7 +6996,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| has a \[[DateValue]] [=internal slot=].
     <dd>
-    1. Set |serialized| to [=Call=]([=Date.toISOString=], «|value|»).
+    1. Set |serialized| to [=Call=]([=Date.prototype.toISOString=], |value|).
 
     1. Assert: |serialized| is not a [=throw completion=].
 


### PR DESCRIPTION
~~The third argument to the Call abstract operation, if present, is expected to be a List.~~

~~https://tc39.es/ecma262/#sec-call~~

Refer to `Date.prototype.toISOString` by that name in order to more clearly communicate its intended use as an instance method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/539.html" title="Last updated on Sep 13, 2023, 4:40 PM UTC (afcefce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/539/43abc3c...bocoup:afcefce.html" title="Last updated on Sep 13, 2023, 4:40 PM UTC (afcefce)">Diff</a>