### PR TITLE
Implement browsingContext.locateNodes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -177,6 +177,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: handled; url: webappapis.html#concept-error-handled
     text: hidden; url: document-sequences.html#system-visibility-state
     text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
+    text: innerText getter steps; url:dom.html#dom-innertext
     text: navigables; url: document-sequences.html#navigables
     text: navigation id; url: browsing-the-web.html#navigation-id
     text: parent; for:navigable; url: document-sequences.html#nav-parent
@@ -2844,14 +2845,14 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
    1. Let |evaluateResult| be the result of calling [=evaluate=] on |context target|'s
       [=active document=], with arguments |selector|, |context node|, null,
-      [=ORDERED_NODE_SNAPSHOT_TYPE=], and null.
+      [=ORDERED_NODE_SNAPSHOT_TYPE=], and null. If this throws an [=XPathException=]
+      return [=error=] with [=error code=] [=invalid selector=], otherwise if this
+      throws any other exception return [=error=] with [=error code=] [=unknown error=].
 
    1. Let |index| be 0.
 
    1. Let |length| be the result of getting the <code>snapshotLength</code> property
-      from |evaluateResult|. If this throws an [=XPathException=] return [=error=]
-      with [=error code=] [=invalid selector=], otherwise if this throws any other
-      exception return [=error=] with [=error code=] [=unknown error=].
+      from |evaluateResult|.
 
    1. Repeat, while |index| is less than |length|:
 
@@ -2864,7 +2865,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
          |returned nodes| is greater than or equal to |maximum returned nodes|,
          return |returned nodes|.
 
-      1. Increment |index| by 1. 
+      1. Set |index| to |index| + 1. 
 
 1. Return |returned nodes|
 
@@ -2881,7 +2882,8 @@ To <dfn>locate nodes using regexp</dfn> with given |context target|, |context no
 
 1. For each |element node| in |element nodes|:
 
-  1. Let |node text| be the <code>innerText</code> property of |element node|.
+  1. Let |node text| be the result of calling the [=innerText getter steps=] with
+     |element node| as the [=this=] value.
 
   1. Let |is text match| be the result of calling [=test=] with |regexp| as
      this and |node text| as the argument.
@@ -2920,8 +2922,6 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |locator| be the value of the <code>locator</code> field
    of |command parameters|.
-
-1. Assert: |locator| is not null.
 
 1. Let |start nodes parameter| be the value of the <code>startNodes</code> field
    of |command parameters|.
@@ -2976,7 +2976,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |regexp|, |maximum returned
             nodes| and |session|.
 
-1. If |maximum returned nodes| is greater than 0, truncate |result nodes| to the
+1. Assert  |maximum returned nodes| is greater than 0, truncate |result nodes| to the
    first |maximum returned nodes| values.
 
 1. Let |serialization options| be the <code>serializationOptions</code> field of

--- a/index.bs
+++ b/index.bs
@@ -2952,7 +2952,7 @@ and |session|:
           |returned nodes| is greater than or equal to |maximum returned nodes|,
           return |returned nodes|.
          
-         Otherwise, perform the following steps:
+       Otherwise, perform the following steps:
 
        1. Let |child nodes| be an empty list and, for each node |child| in the
           <a spec=dom>children</a> of |context node|:

--- a/index.bs
+++ b/index.bs
@@ -2875,7 +2875,8 @@ To <dfn>locate nodes using text</dfn> with given |context target|, |context node
 
   1. Let |node text| be the <code>innerText</code> property of |element node|.
 
-  1. Let |is text match| be the result of calling [=test=] on |regexp| with |node text|.
+  1. Let |is text match| be the result of calling [=test=] with |regexp| as
+     this and |node text| as the argument.
 
   1. If |is text match| is true, append |element node| to |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -2879,25 +2879,27 @@ To <dfn>locate nodes using text</dfn> with given |context target|, |context node
   1. In the following list of conditions and associated steps, run the first set 
      of steps for which the associated condition is true, if any:
 
-     <dl>|match content| is "partial" and |match case| is true
-     <dd>
-       1. If |node text| contains the substring |selector|, including case,
-          append |element node| to |returned nodes|.
+     <dl>
 
-     <dl>|match content| is "partial" and |match case| is false
-     <dd>
-       1. If |node text| contains the substring |selector|, ignoring case,
-          append |element node| to |returned nodes|.
+       <dt>|match content| is "partial" and |match case| is true
+       <dd>
+         1. If |node text| contains the substring |selector|, including case,
+            append |element node| to |returned nodes|.
 
-     <dl>|match content| is "full" and |match case| is true
-     <dd>
-       1. If |node text| is equal to |selector|, including case, append
-          |element node| to |returned nodes|.
+       <dt>|match content| is "partial" and |match case| is false
+       <dd>
+         1. If |node text| contains the substring |selector|, ignoring case,
+            append |element node| to |returned nodes|.
 
-     <dl>|match content| is "full" and |match case| is false
-     <dd>
-       1. If |node text| is equal to |selector|, ignoring case, append
-          |element node| to |returned nodes|.
+       <dt>|match content| is "full" and |match case| is true
+       <dd>
+         1. If |node text| is equal to |selector|, including case, append
+            |element node| to |returned nodes|.
+
+       <dt>|match content| is "full" and |match case| is false
+       <dd>
+         1. If |node text| is equal to |selector|, ignoring case, append
+            |element node| to |returned nodes|.
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -3011,13 +3011,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned nodes|.
 
-1. Let |serialization options| be the <code>serializationOptions</code> field of
-   |command parameters| if present, otherwise a [=/map=] matching the 
+1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",
+   let |serialization options| be |command parameters|["<code>serializationOptions</code>"|.
+   Otherwise let |serialization options| be a [=/map=] matching the 
    <code>script.SerializationOptions</code> production with the fields
    set to their default values.
 
-1. Let |result ownership| be the value of the <code>ownership</code> field of
-   |command parameters|, if it exits, otherwise "none".
+1. If |command parameters| [=map/contains=] "<code>ownership</code>",
+   let |result ownership| be |command parameters|["<code>ownership</code>"|.
+   Otherwise let |result ownership| be "none".
 
 1. Let |serialized nodes| be the result of [=serialize as a remote value=] with
    |result nodes|, |serialization options|, |result ownership|, a new map as

--- a/index.bs
+++ b/index.bs
@@ -2844,7 +2844,7 @@ list of all nodes matching the specified locator.
 To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes|,
 |selector|, |maximum returned node count|, and <var ignore>session</var>:
 
-1. Let |returned nodes| be an empty list.
+1. Let |returned nodes| be an empty [=/list=].
 
 1. Let |parse result| be the result of [=parse a selector=] given |selector|.
 
@@ -2858,7 +2858,7 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
   1. For each |element| in |elements|:
 
-    1. [=list/append=] |element| to |returned nodes|.
+    1. [=list/Append=] |element| to |returned nodes|.
 
     1. If |maximum returned node count| is greater than 0 and [=list/size=] of
        |returned nodes| is greater than or equal to |maximum returned node count|,
@@ -2878,7 +2878,7 @@ is phrased as if making calls to the XPath DOM APIs. However this is to be under
 as equivalent to spec-internal calls directly accessing the underlying algorithms,
 without going via the ECMAScript runtime.
 
-1. Let |returned nodes| be an empty list.
+1. Let |returned nodes| be an empty [=/list=].
 
 1. For each |context node| of |context nodes|:
 
@@ -2899,7 +2899,7 @@ without going via the ECMAScript runtime.
       1. Let |node| be the result of calling [=snapshotItem=] with |evaluate result|
          as this and |index| as the argument.
 
-      1. [=list/append=] |node| to |returned nodes|.
+      1. [=list/Append=] |node| to |returned nodes|.
       
       1. If |maximum returned node count| is greater than 0 and [=list/size=] of
          |returned nodes| is greater than or equal to |maximum returned node count|,
@@ -2916,7 +2916,7 @@ To <dfn>locate nodes using text</dfn> with given |context target|, |context node
 |selector|, |max depth|, |match type|, |ignore case|, |maximum returned node count|,
 and |session|:
 
-1. Let |returned nodes| be an empty list.
+1. Let |returned nodes| be an empty [=/list=].
 
 1. For each |context node| in |context nodes|:
 
@@ -2930,25 +2930,25 @@ and |session|:
 
        <dt>|match type| is "full" and |ignore case| is false
        <dd>
-         1. If |node text| [=strings/string-is] |selector|, [=list/append=]
+         1. If |node text| [=is=] |selector|, [=list/append=]
             |context node| to |returned nodes|.
 
        <dt>|match type| is "full" and |ignore case| is true
        <dd>
-         1. If |node text| [=strings/string-is] |selector|, ignoring case,
+         1. If |node text| [=is=] |selector|, ignoring case,
             [=list/append=] |context node| to |returned nodes|.
 
        <dt>Otherwise
        <dd>
-         1. If |ignore case| is false and |selector| is a [=strings/code-point-substring=]
+         1. If |ignore case| is false and |selector| is a [=code point substring=]
             of |node text| set |contains text| to true.
 
-         1. If |ignore case| is false and |selector| is a [=strings/code-point-substring=]
+         1. If |ignore case| is false and |selector| is a [=code point substring=]
             of |node text|, ignoring case, set |contains text| to true.
 
          1. If |contains text| is true, perform the following steps:
 
-           1. Let |child nodes| be an empty list and, for each node |child| in the
+           1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
               <a spec=dom>children</a> of |context node|:
 
              1. If |child| implements {{Element}}, [=list/append=] |child| to
@@ -3010,22 +3010,20 @@ The [=remote end steps=] with |session| and |command parameters| are:
    |start nodes parameter| be |command parameters|["<code>startNodes</code>"].
    Otherwise let |start nodes parameter| be null.
 
-1. Let |context nodes| be an empty list.
+1. Let |context nodes| be an empty [=/list=].
 
-1. If |start nodes parameter| is null, [=list/append=] [=document element=] to
-   |context nodes|. Otherwise, for each |serialized start node| in
-   |start nodes parameter|:
+1. If |start nodes parameter| is null, [=list/append=] the [=document element=]
+   to of |context|'s [=active document=] |context nodes|. Otherwise, for each
+   |serialized start node| in |start nodes parameter|:
 
    1. Let |start node| be the result of [=trying=] to [=deserialize shared reference=] given
       |serialized start node|, |realm| and |session|.
 
-   1. [=list/append=] |start node| to |context nodes|.
+   1. [=list/Append=] |start node| to |context nodes|.
 
-1. If the <code>length</code> property of |context nodes| is 0, append the node 
-   corresponding to the <code>documentElement</code> property of |context|'s
-   [=active document=] to |context nodes|.
+1. Assert [=list/size=] of |context nodes is greater than 0.
 
-1. Let |result nodes| be an empty list.
+1. Let |result nodes| be an empty [=/list=].
 
 1. Let |type| be the value of the <code>type</code> property of |locator|.
 

--- a/index.bs
+++ b/index.bs
@@ -2120,7 +2120,7 @@ To <dfn>await a navigation</dfn> given |context|, |request|, |wait condition|, a
 <pre class="cddl remote-cddl local-cddl">
 browsingContext.Locator = (
    browsingContext.CssLocator /
-   browsingContext.TextLocator /
+   browsingContext.InnerTextLocator /
    browsingContext.XPathLocator
 )
 
@@ -2129,8 +2129,8 @@ browsingContext.CssLocator = {
    value: text
 }
 
-browsingContext.TextLocator {
-   type: "text",
+browsingContext.InnerTextLocator {
+   type: "innerText",
    value: text,
    ? ignoreCase: bool
    ? matchType: "full" / "partial",
@@ -2914,8 +2914,8 @@ without going via the ECMAScript runtime.
 
 </div>
 
-<div algorithm="locate nodes using text">
-To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
+<div algorithm="locate nodes using inner text">
+To <dfn>locate nodes using inner text</dfn> with given |context target|, |context nodes|,
 |selector|, |max depth|, |match type|, |ignore case|, |maximum returned node count|,
 and |session|:
 
@@ -2932,7 +2932,7 @@ and |session|:
 
   1. If |ignore case| is false, let |node text| be |node inner text|. Otherwise,
      let |node text| be the result of executing [=toUppercase=] with |node inner text|
-     according to the Unicode Default Case Conversion algorithm. 
+     according to the Unicode Default Case Conversion algorithm.
 
   1. If |match type| is "full" and |node text| [=is=] |search text| [=list/append=]
      |context node| to |returned nodes|. Otherwise, perform the following steps:
@@ -3053,7 +3053,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. If |locator| [=map/contains=] <code>matchType</code>, let |match type| be 
             |locator|["<code>matchType</code>"]. Otherwise, let |match type| be "full".
 
-         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using inner text=]
             given |current context target|, |context nodes|, |selector|, |max depth|,
             |match type|, |ignore case|, |maximum returned node count| and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -2790,6 +2790,8 @@ list of all nodes matching the specified locators.
          locator: browsingContext.Locator,
          startNodes: [ * script.SharedReference ],
          ? maxNodes: js-uint,
+         ? ownership: script.ResultOwnership,
+         ? serializationOptions: script.SerializationOptions
       }
       </pre>
    </dd>
@@ -2798,7 +2800,7 @@ list of all nodes matching the specified locators.
     <pre class="cddl local-cddl">
         browsingContext.LocateNodesResult = {
             context: browsingContext.BrowsingContext,
-            nodeSharedIds: [ * script.SharedId ]
+            nodes: [ * script.RemoteNodeValue ]
         }
     </pre>
    </dd>
@@ -2852,9 +2854,6 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
       1. Let |node| be the result of calling [=snapshotItem=] with |evaluateResult|
          as this and |index| as the argument.
 
-      1. If |node| is not an element return [=error=] with [=error code=]
-         [=invalid selector=].
-      
       1. Append |node| to |returned nodes|.
       
       1. Increment |index| by 1. 
@@ -2964,26 +2963,21 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |maximum returned nodes| is greater than 0, truncate |result nodes| to the
    first |maximum returned nodes| values.
 
-1. Let |serialization options| be a [=/map=] matching the 
+1. Let |serialization options| be the <code>serializationOptions</code> field of
+   |command parameters| if present, otherwise a [=/map=] matching the 
    <code>script.SerializationOptions</code> production with the fields
    set to their default values.
 
-1. Let |result ownership| be "none".
+1. Let |result ownership| be the value of the <code>ownership</code> field of
+   |command parameters|, if it exits, otherwise "none".
 
-1. Let |serialized result| be the result of [=serialize as a remote value=] with
+1. Let |serialized nodes| be the result of [=serialize as a remote value=] with
    |result nodes|, |serialization options|, |result ownership|, a new map as
    <var ignore>serialization internal map</var>, |realm| and |session|.
 
-1. Let |serialized shared ids| be a new array.
-
-1. For each |serialized result node| in |serialized result|:
-
-   1. Append the value of the <code>sharedId</code> field of |serialized result node|
-      to |serialized shared ids|.
-
 1. Let |result| be a [=/map=] matching the <code>browsingContext.LocateNodesResult</code>
    production, with the <code>context</code> field set to the |context id|
-   and the <code>nodeSharedIds</code> field set |serialized shared ids|.
+   and the <code>nodes</code> field set |serialized nodes|.
 
 1. Return [=success=] with data |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -2823,7 +2823,9 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
      |parse result| and |context target|’s [=active document=] [=root=] using
      [=scoping root=] |context node|.
 
-  1. Append |elements| to |returned nodes|
+  1. For each |element| in |elements|:
+
+    1. Append |element| to |returned nodes|
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -2981,7 +2981,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |match content| be the value of the <code>matchContent</code> field of
             |locator| if present, otherwise "full".
 
-         1. Let |match case| be the value of the <code>match case</code> field of
+         1. Let |match case| be the value of the <code>matchCase</code> field of
             |locator| if present, otherwise true.
 
          1. Let |context nodes| be a result of [=trying=] to [=locate nodes using text=]

--- a/index.bs
+++ b/index.bs
@@ -2135,7 +2135,7 @@ browsingContext.CssLocator = {
    value: text
 }
 
-browsingContext.InnerTextLocator {
+browsingContext.InnerTextLocator = {
    type: "innerText",
    value: text,
    ? ignoreCase: bool
@@ -2143,7 +2143,7 @@ browsingContext.InnerTextLocator {
    ? maxDepth: js-uint,
 }
 
-browsingContext.XPathLocator {
+browsingContext.XPathLocator = {
    type: "xpath",
    value: text
 }

--- a/index.bs
+++ b/index.bs
@@ -2847,7 +2847,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
    1. Let |length| be the result of getting the <code>snapshotLength</code> property
       from |evaluateResult|. If this throws an [=XPathException=] return [=error=]
       with [=error code=] [=invalid selector=], otherwise if this throws any other
-      exception return return [=error=] with [=error code=] [=unknown error=].
+      exception return [=error=] with [=error code=] [=unknown error=].
 
    1. Repeat, while |index| is less than |length|:
 

--- a/index.bs
+++ b/index.bs
@@ -223,6 +223,7 @@ spec: XPATH; urlPrefix: https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html
   type: dfn
     text: evaluate; url: #XPathEvaluator-evaluate
     text: ORDERED_NODE_SNAPSHOT_TYPE; url: #XPathResult-ORDERED-NODE-SNAPSHOT-TYPE
+    text: snapshotItem; url: #XPathResult-snapshotItem
     text: XPathException; url: #XPathException
 </pre>
 
@@ -2849,7 +2850,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
    1. Repeat, while |index| is less than |length|:
 
-      1. Let |node| be the result of calling snapshotItem with evaluateResult
+      1. Let |node| be the result of calling [=snapshotItem=] with |evaluateResult|
          as this and |index| as the argument.
 
       1. If |node| is not an element return [=error=] with [=error code=]

--- a/index.bs
+++ b/index.bs
@@ -2960,35 +2960,33 @@ and |session|:
      let |node text| be the result of [=toUppercase=] with |node inner text|
      according to the [=Unicode Default Case Conversion algorithm=].
 
-  1. If |match type| is "full" and |node text| [=is=] |search text|, [=list/append=]
-     |context node| to |returned nodes|.
+  1. If |search text| is a [=code point substring=] of |node text|, perform the
+     following steps:
      
-  1. Otherwise, perform the following steps:
+    1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
+       <a spec=dom>children</a> of |context node|:
 
-    1. If |search text| is a [=code point substring=] of |node text|, perform the
-       following steps:
+      1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
 
-      1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
-         <a spec=dom>children</a> of |context node|:
+    1. If [=list/size=] of |child nodes| is equal to 0 or |max depth| is equal to 0,
+       perform the following steps:
 
-        1. If |child| implements {{Element}}, [=list/append=] |child| to
-           |child nodes|.
+      1. If |match type| is <code>"full"</code> and |node text| [=is=] |search text|,
+         [=list/append=] |context node| to |returned nodes|.
 
-      1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
-         is equal to 0, [=list/append=] |context node| to |returned nodes|.
-         
-      1. Otherwise, perform the following steps:
+      1. Otherwise, [=list/append=] |context node| to |returned nodes|.
 
-        1. Set |max depth| to |max depth| - 1. 
+    1. Otherwise, perform the following steps:
 
-        1. Let |child node matches| be the result of [=locate nodes using inner text=]
-           with |context target|, |child nodes|, |selector|, |max depth|,
-           |match type|, |ignore case|, |maximum returned node count|, and |session|.
+      1. Set |max depth| to |max depth| - 1. 
 
-        1. If [=list/size=] of |child node matches| is equal to 0 and
-           |match type| is "partial", [=list/append=] |context node| to
-           |returned nodes|. Otherwise, [=list/extend=] |returned nodes|
-           with |child node matches|.
+      1. Let |child node matches| be the result of [=locate nodes using inner text=]
+         with |context target|, |child nodes|, |selector|, |max depth|,
+         |match type|, |ignore case|, |maximum returned node count|, and |session|.
+
+      1. If [=list/size=] of |child nodes matches| is equal to 0 and |match type| is
+         <code>"partial"</code>, append |context node| to |returned nodes|. Otherwise,
+         [=list/extend=] |returned nodes| with |child node matches|.
 
 1. If |maximum returned node count| is not null, [=list/remove=] all entries
    in |returned nodes| with an index greater than or equal to |maximum returned

--- a/index.bs
+++ b/index.bs
@@ -2822,7 +2822,7 @@ list of all nodes matching the specified locator.
       browsingContext.LocateNodesParameters = {
          context: browsingContext.BrowsingContext,
          locator: browsingContext.Locator,
-         ? maxNodes: (js-uint .ge 1),
+         ? maxReturnedNodeCount: (js-uint .ge 1),
          ? ownership: script.ResultOwnership,
          ? serializationOptions: script.SerializationOptions
          ? startNodes: [ + script.SharedReference ],
@@ -2842,7 +2842,7 @@ list of all nodes matching the specified locator.
 
 <div algorithm="locate nodes using CSS">
 To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes|,
-|selector|, |maximum returned nodes|, and <var ignore>session</var>:
+|selector|, |maximum returned node count|, and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty list.
 
@@ -2860,8 +2860,8 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
     1. [=list/append=] |element| to |returned nodes|.
 
-    1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
-       |returned nodes| is greater than or equal to |maximum returned nodes|,
+    1. If |maximum returned node count| is greater than 0 and [=list/size=] of
+       |returned nodes| is greater than or equal to |maximum returned node count|,
        return |returned nodes|.
 
 1. Return |returned nodes|.
@@ -2871,7 +2871,7 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 <div algorithm="locate nodes using XPath">
 
 To <dfn>locate nodes using XPath</dfn> with given |context target|,
-|context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
+|context nodes|, |selector|, |maximum returned node count|, and <var ignore>session</var>:
 
 Note: Owing to the unmaintained state of the XPath specification, this algorithm
 is phrased as if making calls to the XPath DOM APIs. However this is to be understood
@@ -2901,8 +2901,8 @@ without going via the ECMAScript runtime.
 
       1. [=list/append=] |node| to |returned nodes|.
       
-      1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
-         |returned nodes| is greater than or equal to |maximum returned nodes|,
+      1. If |maximum returned node count| is greater than 0 and [=list/size=] of
+         |returned nodes| is greater than or equal to |maximum returned node count|,
          return |returned nodes|.
 
       1. Set |index| to |index| + 1. 
@@ -2913,7 +2913,7 @@ without going via the ECMAScript runtime.
 
 <div algorithm="locate nodes using text">
 To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
-|selector|, |max depth|, |match type|, |ignore case|, |maximum returned nodes|,
+|selector|, |max depth|, |match type|, |ignore case|, |maximum returned node count|,
 and |session|:
 
 1. Let |returned nodes| be an empty list.
@@ -2957,8 +2957,8 @@ and |session|:
         
        1. [=list/append=] |context node| to |returned nodes|.
 
-       1. If |maximum returned nodes| is not null and [=list/size=] of
-          |returned nodes| is greater than or equal to |maximum returned nodes|,
+       1. If |maximum returned node count| is not null and [=list/size=] of
+          |returned nodes| is greater than or equal to |maximum returned node count|,
           return |returned nodes|.
          
        Otherwise, perform the following steps:
@@ -2972,8 +2972,8 @@ and |session|:
        
          1. [=list/append=] |context node| to |returned nodes|.
 
-         1. If |maximum returned nodes| is not null and [=list/size=] of
-            |returned nodes| is greater than or equal to |maximum returned nodes|,
+         1. If |maximum returned node count| is not null and [=list/size=] of
+            |returned nodes| is greater than or equal to |maximum returned node count|,
             return |returned nodes|.
          
          Otherwise, perform the following steps:
@@ -2982,7 +2982,7 @@ and |session|:
 
          1. [=list/extend=] |returned nodes| with the result of [=locate nodes using text=]
             with |context target|, |child nodes|, |selector|, |max depth|,
-            |match type|, |ignore case|, |maximum returned nodes|, and |session|.
+            |match type|, |ignore case|, |maximum returned node count|, and |session|.
 
 1. Return |returned nodes|.
 
@@ -2999,11 +2999,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. If |command parameters| [=map/contains=] "<code>maxNodes</code>", let
-   |maximum returned nodes| be |command parameters|["<code>maxNodes</code>"].
-   Otherwise let |maximum returned nodes| be null.
+1. If |command parameters| [=map/contains=] "<code>maxReturnedNodeCount</code>", let
+   |maximum returned node count| be |command parameters|["<code>maxReturnedNodeCount</code>"].
+   Otherwise let |maximum returned node count| be null.
 
-1. If |maximum returned nodes| is not null, and |maximum returned nodes|
+1. If |maximum returned node count| is not null, and |maximum returned node count|
    is less than 1, return return [=error=] with [=error code=] [=unsupported operation=]. 
 
 1. Let |current context target| be the a [=/map=] matching of the
@@ -3076,9 +3076,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
             given |current context target|, |context nodes|, |selector|, |max depth|,
-            |match type|, |ignore case|, |maximum returned nodes| and |session|.
+            |match type|, |ignore case|, |maximum returned node count| and |session|.
 
-1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned nodes|.
+1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned node count|.
 
 1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",
    let |serialization options| be |command parameters|["<code>serializationOptions</code>"].

--- a/index.bs
+++ b/index.bs
@@ -148,6 +148,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: running execution context; url: running-execution-context
     text: time value; url: sec-time-values-and-time-range
     text: throw completion; url: sec-completion-record-specification-type
+    text: test; url: #sec-regexp.prototype.test
 spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
   type: dfn
     text: rectangle; url: rectangle
@@ -2123,9 +2124,7 @@ browsingContext.CssLocator = {
 
 browsingContext.TextLocator {
    type: "text",
-   value: text,
-   ? matchCase: boolean,
-   ? matchContent: "full" / "partial"
+   value: script.RegExpLocalValue
 }
 
 browsingContext.XPathLocator {
@@ -2868,7 +2867,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 <div algorithm="locate nodes using text">
 To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
-|selector|, |match content|, |match case| and <var ignore>session</var>:
+|regexp| and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty array.
 
@@ -2877,32 +2876,11 @@ To <dfn>locate nodes using text</dfn> with given |context target|, |context node
 
 1. For each |element node| in |element nodes|:
 
-  1. Let |node text| be the <code>innerText</code> property of |element node|
+  1. Let |node text| be the <code>innerText</code> property of |element node|.
 
-  1. In the following list of conditions and associated steps, run the first set 
-     of steps for which the associated condition is true, if any:
+  1. Let |is text match| be the result of calling [=test=] on |regexp| with |node text|.
 
-     <dl>
-
-       <dt>|match content| is "partial" and |match case| is true
-       <dd>
-         1. If |node text| contains the substring |selector|, including case,
-            append |element node| to |returned nodes|.
-
-       <dt>|match content| is "partial" and |match case| is false
-       <dd>
-         1. If |node text| contains the substring |selector|, ignoring case,
-            append |element node| to |returned nodes|.
-
-       <dt>|match content| is "full" and |match case| is true
-       <dd>
-         1. If |node text| is equal to |selector|, including case, append
-            |element node| to |returned nodes|.
-
-       <dt>|match content| is "full" and |match case| is false
-       <dd>
-         1. If |node text| is equal to |selector|, ignoring case, append
-            |element node| to |returned nodes|.
+  1. If |is text match| is true, append |element node to |returned nodes|.
 
 1. Return |returned nodes|.
 
@@ -2964,31 +2942,26 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       <dt>|type| is the string "<code>css</code>"
       <dd>
-         1. Let |selector| be the value of the value property of |locator|.
+         1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using css=]
             given |current context target|, |context nodes|, |selector| and |session|.
 
       <dt>|type| is the string "<code>xpath</code>"
       <dd>
-         1. Let |selector| be the value of the value property of |locator|.
+         1. Let |selector| be the value of the <code>value</value> property of |locator|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using xpath=]
             given |current context target|, |context nodes|, |selector| and |session|.
 
       <dt>|type| is the string "<code>text</code>"
       <dd>
-         1. Let |selector| be the value of the value property of |locator|.
+         1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
-         1. Let |match content| be the value of the <code>matchContent</code> field of
-            |locator| if present, otherwise "full".
-
-         1. Let |match case| be the value of the <code>matchCase</code> field of
-            |locator| if present, otherwise true.
+         1. Let |regexp| be the value of the <code>data</code> property of |selector|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
-            given |current context target|, |context nodes|, |selector|, |match content|,
-            |match case| and |session|.
+            given |current context target|, |context nodes|, |regexp| and |session|.
 
 1. If |maximum returned nodes| is greater than 0, truncate |result nodes| to the
    first |maximum returned nodes| values.

--- a/index.bs
+++ b/index.bs
@@ -223,6 +223,7 @@ spec: SELECTORS4; urlPrefix: https://drafts.csswg.org/selectors-4/
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
     text: root; url: #concept-tree-root
+    text: document element; url: #document-element
 spec: XPATH; urlPrefix: https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html
   type: dfn
     text: evaluate; url: #XPathEvaluator-evaluate
@@ -2816,10 +2817,10 @@ list of all nodes matching the specified locator.
       browsingContext.LocateNodesParameters = {
          context: browsingContext.BrowsingContext,
          locator: browsingContext.Locator,
-         startNodes: [ * script.SharedReference ],
-         ? maxNodes: js-uint,
+         ? maxNodes: (js-uint .ge 1),
          ? ownership: script.ResultOwnership,
          ? serializationOptions: script.SerializationOptions
+         ? startNodes: [ + script.SharedReference ],
       }
       </pre>
    </dd>
@@ -2838,7 +2839,7 @@ list of all nodes matching the specified locator.
 To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes|,
 |selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
-1. Let |returned nodes| be an empty array.
+1. Let |returned nodes| be an empty list.
 
 1. Let |parse result| be the result of [=parse a selector=] given |selector|.
 
@@ -2852,9 +2853,9 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
   1. For each |element| in |elements|:
 
-    1. Append |element| to |returned nodes|.
+    1. [=list/append=] |element| to |returned nodes|.
 
-    1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+    1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
        |returned nodes| is greater than or equal to |maximum returned nodes|,
        return |returned nodes|.
 
@@ -2866,7 +2867,7 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 To <dfn>locate nodes using XPath</dfn> with given |context target|,
 |context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
-1. Let |returned nodes| be an empty array.
+1. Let |returned nodes| be an empty list.
 
 1. For each |context node| of |context nodes|:
 
@@ -2886,9 +2887,9 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
       1. Let |node| be the result of calling [=snapshotItem=] with |evaluateResult|
          as this and |index| as the argument.
 
-      1. Append |node| to |returned nodes|.
+      1. [=list/append=] |node| to |returned nodes|.
       
-      1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+      1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
          |returned nodes| is greater than or equal to |maximum returned nodes|,
          return |returned nodes|.
 
@@ -2902,7 +2903,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 To <dfn>locate nodes using regexp</dfn> with given |context target|, |context nodes|,
 |regexp|, |maximum returned nodes|, and <var ignore>session</var>:
 
-1. Let |returned nodes| be an empty array.
+1. Let |returned nodes| be an empty list.
 
 1. Let |element nodes| be the result of [=locate nodes using CSS=] given |context target|,
    |context nodes|, "*" and <var ignore>session</var>.
@@ -2915,9 +2916,9 @@ To <dfn>locate nodes using regexp</dfn> with given |context target|, |context no
   1. Let |is text match| be the result of calling [=test=] with |regexp| as
      this and |node text| as the argument.
 
-  1. If |is text match| is true, append |element node| to |returned nodes|.
+  1. If |is text match| is true, [=list/append=] |element node| to |returned nodes|.
 
-  1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+  1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
      |returned nodes| is greater than or equal to |maximum returned nodes|,
      return |returned nodes|.
 
@@ -2936,8 +2937,12 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. Let |maximum returned nodes| be the value of the <code>maxNodes</code>
-   field of |command parameters|, if present, or 0 otherwise.
+1. If |command parameters| [=map/contains=] "<code>maxNodes</code>", let
+   |maximum returned nodes| be |command parameters|["<code>maxNodes</code>"|.
+   Otherwise let |maximum returned nodes| be null.
+
+1. If |maximum returned nodes| is not null, and |maximum returned nodes|
+   is less than 1, return return [=error=] with [=error code=] [=unsupported operation=]. 
 
 1. Let |current context target| be the a [=/map=] matching of the
    <code>script.ContextTarget</code> production with the 
@@ -2950,25 +2955,26 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |locator| be the value of the <code>locator</code> field
    of |command parameters|.
 
-1. Let |start nodes parameter| be the value of the <code>startNodes</code> field
-   of |command parameters|.
+1. If |command parameters| [=map/contains=] "<code>startNodes</code>", let
+   |start nodes parameter| be |command parameters|["<code>startNodes</code>"|.
+   Otherwise let |start nodes parameter| be null.
 
-1. Assert: |start nodes parameter| is not null.
+1. Let |context nodes| be an empty list.
 
-1. Let |context nodes| be an empty array.
-
-1. For each |serialized start node| in |start nodes parameter|:
+1. If |start nodes parameter| is null, [=list/append=] [=document element=] to
+   |context nodes|. Otherwise, for each |serialized start node| in
+   |start nodes parameter|:
 
    1. Let |start node| be the result of [=trying=] to [=deserialize shared reference=] given
       |serialized start node|, |realm| and |session|.
 
-   1. Append |start node| to |context nodes|.
+   1. [=list/append=] |start node| to |context nodes|.
 
 1. If the <code>length</code> property of |context nodes| is 0, append the node 
    corresponding to the <code>documentElement</code> property of |context|'s
    [=active document=] to |context nodes|.
 
-1. Let |result nodes| be an empty array.
+1. Let |result nodes| be an empty list.
 
 1. Let |type| be the value of the <code>type</code> property of |locator|.
 
@@ -3003,8 +3009,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |regexp|, |maximum returned
             nodes| and |session|.
 
-1. Assert  |maximum returned nodes| is greater than 0, truncate |result nodes| to the
-   first |maximum returned nodes| values.
+1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned nodes|.
 
 1. Let |serialization options| be the <code>serializationOptions</code> field of
    |command parameters| if present, otherwise a [=/map=] matching the 

--- a/index.bs
+++ b/index.bs
@@ -2973,7 +2973,7 @@ and |session|:
 
          1. [=list/extend=] |returned nodes| with the result of [=locate nodes using text=]
             with |context target|, |child nodes|, |selector|, |max depth|,
-            |match type|, |match case|, |maximum returned nodes|, and |session|.
+            |match type|, |ignore case|, |maximum returned nodes|, and |session|.
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -2862,8 +2862,8 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 </div>
 
-<div algorithm="locate nodes using text">
-To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
+<div algorithm="locate nodes using regexp">
+To <dfn>locate nodes using regexp</dfn> with given |context target|, |context nodes|,
 |regexp| and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty array.
@@ -2958,7 +2958,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. Let |regexp| be the value of the <code>data</code> property of |selector|.
 
-         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using regexp=]
             given |current context target|, |context nodes|, |regexp| and |session|.
 
 1. If |maximum returned nodes| is greater than 0, truncate |result nodes| to the

--- a/index.bs
+++ b/index.bs
@@ -2938,7 +2938,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Assert: |context| is not null.
 
 1. If |command parameters| [=map/contains=] "<code>maxNodes</code>", let
-   |maximum returned nodes| be |command parameters|["<code>maxNodes</code>"|.
+   |maximum returned nodes| be |command parameters|["<code>maxNodes</code>"].
    Otherwise let |maximum returned nodes| be null.
 
 1. If |maximum returned nodes| is not null, and |maximum returned nodes|

--- a/index.bs
+++ b/index.bs
@@ -2837,7 +2837,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 1. For each |context node| of |context nodes|:
 
    1. Let |evaluateResult| be the result of calling [=evaluate=] on |context target|'s
-      [=active document], with arguments |selector|, |context node|, null,
+      [=active document=], with arguments |selector|, |context node|, null,
       [=ORDERED_NODE_SNAPSHOT_TYPE=], and null.
 
    1. Let |index| be 0.

--- a/index.bs
+++ b/index.bs
@@ -2943,7 +2943,7 @@ and |session|:
          1. If |ignore case| is false and |selector| is a [=code point substring=]
             of |node text| set |contains text| to true.
 
-         1. If |ignore case| is false and |selector| is a [=code point substring=]
+         1. If |ignore case| is true and |selector| is a [=code point substring=]
             of |node text|, ignoring case, set |contains text| to true.
 
          1. If |contains text| is true, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -2918,56 +2918,45 @@ and |session|:
 
 1. Let |returned nodes| be an empty [=/list=].
 
+1. If |ignore case| is false let |search text| be |selector|. Otherwise,
+   let |search text| be the result of executing toUppercase with |selector|
+   according to the Unicode Default Case Conversion algorithm.
+
 1. For each |context node| in |context nodes|:
 
-  1. Let |node text| be the result of calling the [=innerText getter steps=] with
+  1. Let |node inner text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
 
-  1. In the following list of conditions and associated steps, run the first set 
-     of steps for which the associated condition is true, if any:
+  1. If |ignore case| is false, let |node text| be |node inner text|. Otherwise,
+     let |node text| be the result of executing toUppercase with |node inner text|
+     according to the Unicode Default Case Conversion algorithm. 
 
-     <dl>
+  1. If |match type| is "full" and |node text| [=is=] |search text| [=list/append=]
+     |context node| to |returned nodes|. Otherwise, perform the following steps:
 
-       <dt>|match type| is "full" and |ignore case| is false
-       <dd>
-         1. If |node text| [=is=] |selector|, [=list/append=]
-            |context node| to |returned nodes|.
+    1. If |search text| is a [=code point substring=] of |node text|, perform the
+       following steps:
 
-       <dt>|match type| is "full" and |ignore case| is true
-       <dd>
-         1. If |node text| [=is=] |selector|, ignoring case,
-            [=list/append=] |context node| to |returned nodes|.
+      1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
+         <a spec=dom>children</a> of |context node|:
 
-       <dt>Otherwise
-       <dd>
-         1. If |ignore case| is false and |selector| is a [=code point substring=]
-            of |node text| set |contains text| to true.
+        1. If |child| implements {{Element}}, [=list/append=] |child| to
+           |child nodes|.
 
-         1. If |ignore case| is true and |selector| is a [=code point substring=]
-            of |node text|, ignoring case, set |contains text| to true.
+      1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
+         is equal to 0 [=list/append=] |context node| to |returned nodes|.
+         Otherwise perform the following steps:
 
-         1. If |contains text| is true, perform the following steps:
+        1. Set |max depth| to |max depth| - 1. 
 
-           1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
-              <a spec=dom>children</a> of |context node|:
+        1. Let |child node matches| be the result of [=locate nodes using text=]
+           with |context target|, |child nodes|, |selector|, |max depth|,
+           |match type|, |ignore case|, |maximum returned node count|, and |session|.
 
-             1. If |child| implements {{Element}}, [=list/append=] |child| to
-                |child nodes|.
-
-           1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
-              is equal to 0 [=list/append=] |context node| to |returned nodes|.
-              Otherwise perform the following steps:
-
-             1. Set |max depth| to |max depth| - 1. 
-
-             1. Let |child node matches| be the result of [=locate nodes using text=]
-                with |context target|, |child nodes|, |selector|, |max depth|,
-                |match type|, |ignore case|, |maximum returned node count|, and |session|.
-
-             1. If [=list/size=] of |child node matches| is equal to 0 and
-                |match type| is "partial" [=list/append=] |context node| to
-                |returned nodes|. Otherwise, [=list/extend=] |returned nodes|
-                with |child node matches|.
+        1. If [=list/size=] of |child node matches| is equal to 0 and
+           |match type| is "partial" [=list/append=] |context node| to
+           |returned nodes|. Otherwise, [=list/extend=] |returned nodes|
+           with |child node matches|.
 
 1. If |maximum returned node count| is not null [=list/remove=] all entries
    in |returned nodes| with an index greater than or equal to |maximum returned

--- a/index.bs
+++ b/index.bs
@@ -2964,14 +2964,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
       <dd>
          1. Let |selector| be the value of the value property of |locator|.
 
-         1. Let |context nodes| be a result of [=trying=] to [=locate nodes using css=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using css=]
             given |current context target|, |context nodes|, |selector| and |session|.
 
       <dt>|type| is the string "<code>xpath</code>"
       <dd>
          1. Let |selector| be the value of the value property of |locator|.
 
-         1. Let |context nodes| be a result of [=trying=] to [=locate nodes using xpath=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using xpath=]
             given |current context target|, |context nodes|, |selector| and |session|.
 
       <dt>|type| is the string "<code>text</code>"
@@ -2984,7 +2984,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |match case| be the value of the <code>matchCase</code> field of
             |locator| if present, otherwise true.
 
-         1. Let |context nodes| be a result of [=trying=] to [=locate nodes using text=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
             given |current context target|, |context nodes|, |selector|, |match content|,
             |match case| and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -232,6 +232,9 @@ spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: DOMException; url: #idl-DOMException
     text: SyntaxError; url:#syntaxerror
+spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
+  type: dfn
+    text: toUppercase; url: ch03.pdf#G34078
 </pre>
 
 <pre class="biblio">
@@ -2919,8 +2922,8 @@ and |session|:
 1. Let |returned nodes| be an empty [=/list=].
 
 1. If |ignore case| is false let |search text| be |selector|. Otherwise,
-   let |search text| be the result of executing toUppercase with |selector|
-   according to the Unicode Default Case Conversion algorithm.
+   let |search text| be the result of executing <code>toUppercase</code>
+   with |selector| according to the Unicode Default Case Conversion algorithm.
 
 1. For each |context node| in |context nodes|:
 
@@ -2928,7 +2931,7 @@ and |session|:
      |context node| as the [=this=] value.
 
   1. If |ignore case| is false, let |node text| be |node inner text|. Otherwise,
-     let |node text| be the result of executing toUppercase with |node inner text|
+     let |node text| be the result of executing [=toUppercase=] with |node inner text|
      according to the Unicode Default Case Conversion algorithm. 
 
   1. If |match type| is "full" and |node text| [=is=] |search text| [=list/append=]

--- a/index.bs
+++ b/index.bs
@@ -2774,7 +2774,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 #### The browsingContext.locateNodes Command ####  {#command-browsingContext-locateNodes}
 
 The <dfn export for=commands>browsingContext.locateNodes</dfn> command returns a
-list of all nodes matching the specified locators.
+list of all nodes matching the specified locator.
 
 <dl>
    <dt>Command Type</dt>
@@ -2808,15 +2808,15 @@ list of all nodes matching the specified locators.
 
 <div algorithm="locate nodes using CSS">
 To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes|,
-|selector| and <var ignore>session</var>:
+|selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty array.
 
+1. Let |parse result| be the result of [=parse a selector=] given |selector|.
+
+1. If |parse result| is failure, return [=error=] with [=error code=] [=invalid selector=].
+
 1. For each |context node| of |context nodes|:
-
-  1. Let |parse result| be the result of [=parse a selector=] given |selector|.
-
-  1. If |parse result| is failure, return [=error=] with [=error code=] [=invalid selector=].
 
   1. Let |elements| be the result of [=match a selector against a tree=] with 
      |parse result| and |context target|’s [=active document=] [=root=] using
@@ -2824,7 +2824,11 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
   1. For each |element| in |elements|:
 
-    1. Append |element| to |returned nodes|
+    1. Append |element| to |returned nodes|.
+
+    1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+       |returned nodes| is greater than or equal to |maximum returned nodes|,
+       return |returned nodes|.
 
 1. Return |returned nodes|.
 
@@ -2832,7 +2836,7 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
 <div algorithm="locate nodes using XPath">
 To <dfn>locate nodes using XPath</dfn> with given |context target|,
-|context nodes|, |selector| and <var ignore>session</var>:
+|context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty array.
 
@@ -2856,6 +2860,10 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
       1. Append |node| to |returned nodes|.
       
+      1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+         |returned nodes| is greater than or equal to |maximum returned nodes|,
+         return |returned nodes|.
+
       1. Increment |index| by 1. 
 
 1. Return |returned nodes|
@@ -2864,7 +2872,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 <div algorithm="locate nodes using regexp">
 To <dfn>locate nodes using regexp</dfn> with given |context target|, |context nodes|,
-|regexp| and <var ignore>session</var>:
+|regexp|, |maximum returned nodes|, and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty array.
 
@@ -2879,6 +2887,10 @@ To <dfn>locate nodes using regexp</dfn> with given |context target|, |context no
      this and |node text| as the argument.
 
   1. If |is text match| is true, append |element node| to |returned nodes|.
+
+  1. If |maximum returned nodes| is greater than 0 and <code>length</code> of
+     |returned nodes| is greater than or equal to |maximum returned nodes|,
+     return |returned nodes|.
 
 1. Return |returned nodes|.
 
@@ -2943,14 +2955,16 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using css=]
-            given |current context target|, |context nodes|, |selector| and |session|.
+            given |current context target|, |context nodes|, |selector|, |maximum returned
+            nodes| and |session|.
 
       <dt>|type| is the string "<code>xpath</code>"
       <dd>
          1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using xpath=]
-            given |current context target|, |context nodes|, |selector| and |session|.
+            given |current context target|, |context nodes|, |selector|, |maximum returned
+            nodes| and |session|.
 
       <dt>|type| is the string "<code>text</code>"
       <dd>
@@ -2959,7 +2973,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |regexp| be the value of the <code>data</code> property of |selector|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using regexp=]
-            given |current context target|, |context nodes|, |regexp| and |session|.
+            given |current context target|, |context nodes|, |regexp|, |maximum returned
+            nodes| and |session|.
 
 1. If |maximum returned nodes| is greater than 0, truncate |result nodes| to the
    first |maximum returned nodes| values.

--- a/index.bs
+++ b/index.bs
@@ -63,6 +63,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: input cancel list; url: dfn-input-cancel-list
     text: intermediary node; url: dfn-intermediary-node
     text: invalid argument; url: dfn-invalid-argument
+    text: invalid selector; url: dfn-invalid-selector
     text: invalid session id; url: dfn-invalid-session-id
     text: is element origin; url: dfn-is-element-origin
     text: local end; url: dfn-local-ends

--- a/index.bs
+++ b/index.bs
@@ -2921,9 +2921,9 @@ and |session|:
 
 1. Let |returned nodes| be an empty [=/list=].
 
-1. If |ignore case| is false let |search text| be |selector|. Otherwise,
-   let |search text| be the result of executing <code>toUppercase</code>
-   with |selector| according to the Unicode Default Case Conversion algorithm.
+1. If |ignore case| is false let |search text| be |selector|. Otherwise, let
+   |search text| be the result of executing [=toUppercase=] with |selector|
+   according to the Unicode Default Case Conversion algorithm.
 
 1. For each |context node| in |context nodes|:
 

--- a/index.bs
+++ b/index.bs
@@ -2930,20 +2930,20 @@ and |session|:
 
        <dt>|match type| is "full" and |ignore case| is false
        <dd>
-         1. If |node text| [=string/string-is] |selector|, [=list/append=]
+         1. If |node text| [=strings/string-is] |selector|, [=list/append=]
             |context node| to |returned nodes|.
 
        <dt>|match type| is "full" and |ignore case| is true
        <dd>
-         1. If |node text| [=string/string-is] |selector|, ignoring case,
+         1. If |node text| [=strings/string-is] |selector|, ignoring case,
             [=list/append=] |context node| to |returned nodes|.
 
        <dt>Otherwise
        <dd>
-         1. If |ignore case| is false and |selector| is a [=string/code-point-substring=]
+         1. If |ignore case| is false and |selector| is a [=strings/code-point-substring=]
             of |node text| set |contains text| to true.
 
-         1. If |ignore case| is false and |selector| is a [=string/code-point-substring=]
+         1. If |ignore case| is false and |selector| is a [=strings/code-point-substring=]
             of |node text|, ignoring case, set |contains text| to true.
 
          1. If |contains text| is true, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -3081,7 +3081,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |selector|, |max depth|,
             |match type|, |ignore case|, |maximum returned node count| and |session|.
 
-1. Assert |maximum returned node count| is null or [=list/size=] of |result nodes| is less
+1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.
 
 1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",

--- a/index.bs
+++ b/index.bs
@@ -2852,8 +2852,9 @@ list of all nodes matching the specified locator.
          locator: browsingContext.Locator,
          ? maxNodeCount: (js-uint .ge 1),
          ? ownership: script.ResultOwnership,
-         ? serializationOptions: script.SerializationOptions
-         ? startNodes: [ + script.SharedReference ],
+         ? sandbox: text,
+         ? serializationOptions: script.SerializationOptions,
+         ? startNodes: [ + script.SharedReference ]
       }
       </pre>
    </dd>
@@ -3007,14 +3008,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. If |command parameters| [=map/contains=] "<code>maxNodeCount</code>", let
-   |maximum returned node count| be |command parameters|["<code>maxNodeCount</code>"].
-   Otherwise, let |maximum returned node count| be null.
+1. If |command parameters| [=map/contains=] "<code>sandbox</code>", let
+   |sandbox| be |command parameters|["<code>sandbox</code>"]. Otherwise,
+   let |sandbox| be null.
 
 1. Let |current context target| be the a [=/map=] matching of the
    <code>script.ContextTarget</code> production with the 
    <code>context</code> field set to the [=browsing context id=]
-   of |context|.
+   of |context| and the <code>sandbox</code> field set to |sandbox|.
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given |current context target|.
@@ -3024,6 +3025,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. If |command parameters| [=map/contains=] "<code>startNodes</code>", let
    |start nodes parameter| be |command parameters|["<code>startNodes</code>"].
    Otherwise let |start nodes parameter| be null.
+
+1. If |command parameters| [=map/contains=] "<code>maxNodeCount</code>", let
+   |maximum returned node count| be |command parameters|["<code>maxNodeCount</code>"].
+   Otherwise, let |maximum returned node count| be null.
 
 1. Let |context nodes| be an empty [=/list=].
 

--- a/index.bs
+++ b/index.bs
@@ -2863,7 +2863,6 @@ list of all nodes matching the specified locator.
    <dd>
     <pre class="cddl local-cddl">
         browsingContext.LocateNodesResult = {
-            context: browsingContext.BrowsingContext,
             nodes: [ * script.NodeRemoteValue ]
         }
     </pre>
@@ -3103,8 +3102,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    <var ignore>serialization internal map</var>, |realm| and |session|.
 
 1. Let |result| be a [=/map=] matching the <code>browsingContext.LocateNodesResult</code>
-   production, with the <code>context</code> field set to the |context id|
-   and the <code>nodes</code> field set |serialized nodes|.
+   production, with the <code>nodes</code> field set |serialized nodes|.
 
 1. Return [=success=] with data |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -2800,7 +2800,7 @@ list of all nodes matching the specified locators.
     <pre class="cddl local-cddl">
         browsingContext.LocateNodesResult = {
             context: browsingContext.BrowsingContext,
-            nodes: [ * script. NodeRemoteValue ]
+            nodes: [ * script.NodeRemoteValue ]
         }
     </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -2888,8 +2888,8 @@ without going via the ECMAScript runtime.
    1. Let |evaluate result| be the result of calling [=evaluate=] on |context target|'s
       [=active document=], with arguments |selector|, |context node|, null,
       [=ORDERED_NODE_SNAPSHOT_TYPE=], and null. If this throws a "[=SyntaxError=]"
-      [=DOMException=] return [=error=] with [=error code=] [=invalid selector=],
-      otherwise if this throws any other exception return [=error=] with [=error code=]
+      [=DOMException=], return [=error=] with [=error code=] [=invalid selector=];
+      otherwise, if this throws any other exception return [=error=] with [=error code=]
       [=unknown error=].
 
    1. Let |index| be 0.
@@ -2921,7 +2921,7 @@ and |session|:
 
 1. Let |returned nodes| be an empty [=/list=].
 
-1. If |ignore case| is false let |search text| be |selector|. Otherwise, let
+1. If |ignore case| is false, let |search text| be |selector|. Otherwise, let
    |search text| be the result of executing [=toUppercase=] with |selector|
    according to the Unicode Default Case Conversion algorithm.
 
@@ -2934,7 +2934,7 @@ and |session|:
      let |node text| be the result of executing [=toUppercase=] with |node inner text|
      according to the Unicode Default Case Conversion algorithm.
 
-  1. If |match type| is "full" and |node text| [=is=] |search text| [=list/append=]
+  1. If |match type| is "full" and |node text| [=is=] |search text|, [=list/append=]
      |context node| to |returned nodes|. Otherwise, perform the following steps:
 
     1. If |search text| is a [=code point substring=] of |node text|, perform the
@@ -2947,8 +2947,8 @@ and |session|:
            |child nodes|.
 
       1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
-         is equal to 0 [=list/append=] |context node| to |returned nodes|.
-         Otherwise perform the following steps:
+         is equal to 0, [=list/append=] |context node| to |returned nodes|.
+         Otherwise, perform the following steps:
 
         1. Set |max depth| to |max depth| - 1. 
 
@@ -2957,11 +2957,11 @@ and |session|:
            |match type|, |ignore case|, |maximum returned node count|, and |session|.
 
         1. If [=list/size=] of |child node matches| is equal to 0 and
-           |match type| is "partial" [=list/append=] |context node| to
+           |match type| is "partial", [=list/append=] |context node| to
            |returned nodes|. Otherwise, [=list/extend=] |returned nodes|
            with |child node matches|.
 
-1. If |maximum returned node count| is not null [=list/remove=] all entries
+1. If |maximum returned node count| is not null, [=list/remove=] all entries
    in |returned nodes| with an index greater than or equal to |maximum returned
    node count|.
 
@@ -2981,9 +2981,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>maxReturnedNodeCount</code>", let
    |maximum returned node count| be |command parameters|["<code>maxReturnedNodeCount</code>"].
-   Otherwise let |maximum returned node count| be null.
+   Otherwise, let |maximum returned node count| be null.
 
-1. If |maximum returned node count| is not null, and |maximum returned node count|
+1. If |maximum returned node count| is not null and |maximum returned node count|
    is less than 1, return [=error=] with [=error code=] [=unsupported operation=]. 
 
 1. Let |current context target| be the a [=/map=] matching of the
@@ -3059,13 +3059,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",
    let |serialization options| be |command parameters|["<code>serializationOptions</code>"].
-   Otherwise let |serialization options| be a [=/map=] matching the 
+   Otherwise, let |serialization options| be a [=/map=] matching the 
    <code>script.SerializationOptions</code> production with the fields
    set to their default values.
 
 1. If |command parameters| [=map/contains=] "<code>ownership</code>",
    let |result ownership| be |command parameters|["<code>ownership</code>"].
-   Otherwise let |result ownership| be "none".
+   Otherwise, let |result ownership| be "none".
 
 1. Let |serialized nodes| be the result of [=serialize as a remote value=] with
    |result nodes|, |serialization options|, |result ownership|, a new map as

--- a/index.bs
+++ b/index.bs
@@ -3043,8 +3043,6 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert [=list/size=] of |context nodes| is greater than 0.
 
-1. Let |result nodes| be an empty [=/list=].
-
 1. Let |type| be |locator|["<code>type</code>"].
 
 1. In the following list of conditions and associated steps, run the first set 

--- a/index.bs
+++ b/index.bs
@@ -2994,8 +2994,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given |current context target|.
 
-1. Let |locator| be the value of the <code>locator</code> field
-   of |command parameters|.
+1. Let |locator| be |command parameters|["<code>locator</code>"].
 
 1. If |command parameters| [=map/contains=] "<code>startNodes</code>", let
    |start nodes parameter| be |command parameters|["<code>startNodes</code>"].

--- a/index.bs
+++ b/index.bs
@@ -2946,6 +2946,9 @@ To <dfn>locate nodes using inner text</dfn> with given |context target|, |contex
 |selector|, |max depth|, |match type|, |ignore case|, |maximum returned node count|,
 and |session|:
 
+1. If |selector| is the empty string, return [=error=] with [=error code=]
+   [=invalid selector=].
+
 1. Let |returned nodes| be an empty [=/list=].
 
 1. If |ignore case| is false, let |search text| be |selector|. Otherwise, let

--- a/index.bs
+++ b/index.bs
@@ -239,6 +239,7 @@ spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
     text: SyntaxError; url:#syntaxerror
 spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
+    text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
 </pre>
 
@@ -2849,7 +2850,7 @@ list of all nodes matching the specified locator.
       browsingContext.LocateNodesParameters = {
          context: browsingContext.BrowsingContext,
          locator: browsingContext.Locator,
-         ? maxReturnedNodeCount: (js-uint .ge 1),
+         ? maxNodeCount: (js-uint .ge 1),
          ? ownership: script.ResultOwnership,
          ? serializationOptions: script.SerializationOptions
          ? startNodes: [ + script.SharedReference ],
@@ -2887,8 +2888,8 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
     1. [=list/Append=] |element| to |returned nodes|.
 
-    1. If |maximum returned node count| is greater than 0 and [=list/size=] of
-       |returned nodes| is greater than or equal to |maximum returned node count|,
+    1. If |maximum returned node count| is not null and [=list/size=] of
+       |returned nodes| is equal to |maximum returned node count|,
        return |returned nodes|.
 
 1. Return |returned nodes|.
@@ -2928,8 +2929,8 @@ without going via the ECMAScript runtime.
 
       1. [=list/Append=] |node| to |returned nodes|.
       
-      1. If |maximum returned node count| is greater than 0 and [=list/size=] of
-         |returned nodes| is greater than or equal to |maximum returned node count|,
+      1. If |maximum returned node count| not null and [=list/size=] of
+         |returned nodes| is equal to |maximum returned node count|,
          return |returned nodes|.
 
       1. Set |index| to |index| + 1. 
@@ -2946,8 +2947,8 @@ and |session|:
 1. Let |returned nodes| be an empty [=/list=].
 
 1. If |ignore case| is false, let |search text| be |selector|. Otherwise, let
-   |search text| be the result of executing [=toUppercase=] with |selector|
-   according to the Unicode Default Case Conversion algorithm.
+   |search text| be the result of [=toUppercase=] with |selector| according
+   to the [=Unicode Default Case Conversion algorithm=].
 
 1. For each |context node| in |context nodes|:
 
@@ -2955,11 +2956,13 @@ and |session|:
      |context node| as the [=this=] value.
 
   1. If |ignore case| is false, let |node text| be |node inner text|. Otherwise,
-     let |node text| be the result of executing [=toUppercase=] with |node inner text|
-     according to the Unicode Default Case Conversion algorithm.
+     let |node text| be the result of [=toUppercase=] with |node inner text|
+     according to the [=Unicode Default Case Conversion algorithm=].
 
   1. If |match type| is "full" and |node text| [=is=] |search text|, [=list/append=]
-     |context node| to |returned nodes|. Otherwise, perform the following steps:
+     |context node| to |returned nodes|.
+     
+  1. Otherwise, perform the following steps:
 
     1. If |search text| is a [=code point substring=] of |node text|, perform the
        following steps:
@@ -2972,7 +2975,8 @@ and |session|:
 
       1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
          is equal to 0, [=list/append=] |context node| to |returned nodes|.
-         Otherwise, perform the following steps:
+         
+      1. Otherwise, perform the following steps:
 
         1. Set |max depth| to |max depth| - 1. 
 
@@ -3003,12 +3007,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Assert: |context| is not null.
 
-1. If |command parameters| [=map/contains=] "<code>maxReturnedNodeCount</code>", let
-   |maximum returned node count| be |command parameters|["<code>maxReturnedNodeCount</code>"].
+1. If |command parameters| [=map/contains=] "<code>maxNodeCount</code>", let
+   |maximum returned node count| be |command parameters|["<code>maxNodeCount</code>"].
    Otherwise, let |maximum returned node count| be null.
-
-1. If |maximum returned node count| is not null and |maximum returned node count|
-   is less than 1, return [=error=] with [=error code=] [=unsupported operation=]. 
 
 1. Let |current context target| be the a [=/map=] matching of the
    <code>script.ContextTarget</code> production with the 
@@ -3042,7 +3043,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |type| be |locator|["<code>type</code>"].
 
 1. In the following list of conditions and associated steps, run the first set 
-   of steps for which the associated condition is true, if any:
+   of steps for which the associated condition is true:
 
    <dl>
 
@@ -3079,7 +3080,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |selector|, |max depth|,
             |match type|, |ignore case|, |maximum returned node count| and |session|.
 
-1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned node count|.
+1. Assert |maximum returned node count| is null or [=list/size=] of |result nodes| is less
+   than or equal to |maximum returned node count|.
 
 1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",
    let |serialization options| be |command parameters|["<code>serializationOptions</code>"].

--- a/index.bs
+++ b/index.bs
@@ -2936,7 +2936,7 @@ and |session|:
        <dt>|match type| is "full" and |ignore case| is true
        <dd>
          1. If |node text| is equal to |selector|, ignoring case,
-            [=list/append] |context node| to |returned nodes|.
+            [=list/append=] |context node| to |returned nodes|.
 
        <dt>Otherwise
        <dd>
@@ -2955,7 +2955,7 @@ and |session|:
                 |child nodes|.
 
            1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
-              is equal to 0 [=list/append] |context node| to |returned nodes|.
+              is equal to 0 [=list/append=] |context node| to |returned nodes|.
               Otherwise perform the following steps:
 
              1. Set |max depth| to |max depth| - 1. 

--- a/index.bs
+++ b/index.bs
@@ -2800,7 +2800,7 @@ list of all nodes matching the specified locators.
     <pre class="cddl local-cddl">
         browsingContext.LocateNodesResult = {
             context: browsingContext.BrowsingContext,
-            nodes: [ * script.RemoteNodeValue ]
+            nodes: [ * script. NodeRemoteValue ]
         }
     </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -2984,7 +2984,7 @@ and |session|:
          with |context target|, |child nodes|, |selector|, |max depth|,
          |match type|, |ignore case|, |maximum returned node count|, and |session|.
 
-      1. If [=list/size=] of |child nodes matches| is equal to 0 and |match type| is
+      1. If [=list/size=] of |child node matches| is equal to 0 and |match type| is
          <code>"partial"</code>, append |context node| to |returned nodes|. Otherwise,
          [=list/extend=] |returned nodes| with |child node matches|.
 

--- a/index.bs
+++ b/index.bs
@@ -2930,21 +2930,21 @@ and |session|:
 
        <dt>|match type| is "full" and |ignore case| is false
        <dd>
-         1. If |node text| is equal to |selector|, including case,
-           [=list/append=] |context node| to |returned nodes|.
+         1. If |node text| [=string/string-is] |selector|, [=list/append=]
+            |context node| to |returned nodes|.
 
        <dt>|match type| is "full" and |ignore case| is true
        <dd>
-         1. If |node text| is equal to |selector|, ignoring case,
+         1. If |node text| [=string/string-is] |selector|, ignoring case,
             [=list/append=] |context node| to |returned nodes|.
 
        <dt>Otherwise
        <dd>
-         1. If |node text| contains the substring |selector|, including case,
-            set |contains text| to true.
+         1. If |ignore case| is false and |selector| is a [=string/code-point-substring=]
+            of |node text| set |contains text| to true.
 
-         1. If |node text| contains the substring |selector|, ignoring case,
-            set |contains text| to true.
+         1. If |ignore case| is false and |selector| is a [=string/code-point-substring=]
+            of |node text|, ignoring case, set |contains text| to true.
 
          1. If |contains text| is true, perform the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -3013,7 +3013,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. [=list/Append=] |start node| to |context nodes|.
 
-1. Assert [=list/size=] of |context nodes is greater than 0.
+1. Assert [=list/size=] of |context nodes| is greater than 0.
 
 1. Let |result nodes| be an empty [=/list=].
 

--- a/index.bs
+++ b/index.bs
@@ -2985,7 +2985,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    Otherwise let |maximum returned node count| be null.
 
 1. If |maximum returned node count| is not null, and |maximum returned node count|
-   is less than 1, return return [=error=] with [=error code=] [=unsupported operation=]. 
+   is less than 1, return [=error=] with [=error code=] [=unsupported operation=]. 
 
 1. Let |current context target| be the a [=/map=] matching of the
    <code>script.ContextTarget</code> production with the 

--- a/index.bs
+++ b/index.bs
@@ -2904,7 +2904,7 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 <div algorithm="locate nodes using text">
 To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
-|selector|, |max depth|, |match type|, |match case|, |maximum returned nodes|,
+|selector|, |max depth|, |match type|, |ignore case|, |maximum returned nodes|,
 and |session|:
 
 1. Let |returned nodes| be an empty list.
@@ -2921,22 +2921,22 @@ and |session|:
 
      <dl>
 
-       <dt>|match type| is "partial" and |match case| is true
+       <dt>|match type| is "partial" and |ignore case| is false
        <dd>
          1. If |node text| contains the substring |selector|, including case,
             set |is match| to true.
 
-       <dt>|match type| is "partial" and |match case| is false
+       <dt>|match type| is "partial" and |ignore case| is true
        <dd>
          1. If |node text| contains the substring |selector|, ignoring case,
             set |is match| to true.
 
-       <dt>|match type| is "full" and |match case| is true
+       <dt>|match type| is "full" and |ignore case| is false
        <dd>
          1. If |node text| is equal to |selector|, including case, 
             set |is match| to true.
 
-       <dt>|match type| is "full" and |match case| is false
+       <dt>|match type| is "full" and |ignore case| is true
        <dd>
          1. If |node text| is equal to |selector|, ignoring case,
             set |is match| to true.
@@ -3056,11 +3056,18 @@ The [=remote end steps=] with |session| and |command parameters| are:
       <dd>
          1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
-         1. Let |regexp| be the value of the <code>data</code> property of |selector|.
+         1. If |locator| [=map/contains=] <code>maxDepth</code>, let |max depth| be 
+            |locator|["<code>maxDepth</code>"]. Otherwise, let |max depth| be null.
+
+         1. If |locator| [=map/contains=] <code>ignoreCase</code>, let |ignore case| be 
+            |locator|["<code>ignoreCase</code>"]. Otherwise, let |ignore case| be false.
+
+         1. If |locator| [=map/contains=] <code>matchType</code>, let |match type| be 
+            |locator|["<code>matchType</code>"]. Otherwise, let |match type| be "full".
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
-            given |current context target|, |context nodes|, |regexp|, |maximum returned
-            nodes| and |session|.
+            given |current context target|, |context nodes|, |selector|, |max depth|,
+            |match type|, |ignore case|, |maximum returned nodes| and |session|.
 
 1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -224,12 +224,13 @@ spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
     text: root; url: #concept-tree-root
     text: document element; url: #document-element
-spec: XPATH; urlPrefix: https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html
+    text: evaluate; url: #dom-xpathevaluatorbase-evaluate
+    text: ORDERED_NODE_SNAPSHOT_TYPE; url: #dom-xpathresult-ordered_node_snapshot_type
+    text: snapshotItem; url: #dom-xpathresult-snapshotitem
+spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
-    text: evaluate; url: #XPathEvaluator-evaluate
-    text: ORDERED_NODE_SNAPSHOT_TYPE; url: #XPathResult-ORDERED-NODE-SNAPSHOT-TYPE
-    text: snapshotItem; url: #XPathResult-snapshotItem
-    text: XPathException; url: #XPathException
+    text: DOMException; url: #idl-DOMException
+    text: SyntaxError; url:#syntaxerror
 </pre>
 
 <pre class="biblio">
@@ -2867,6 +2868,12 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 </div>
 
 <div algorithm="locate nodes using XPath">
+
+Note: Owing to the unmaintained state of the XPath specification, this algorithm
+is phrased as if making calls to the XPath DOM APIs. However this is to be understood
+as equivalent to spec-internal calls directly accessing the underlying algorithms,
+without going via the ECMAScript runtime.
+
 To <dfn>locate nodes using XPath</dfn> with given |context target|,
 |context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
@@ -2874,20 +2881,21 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 1. For each |context node| of |context nodes|:
 
-   1. Let |evaluateResult| be the result of calling [=evaluate=] on |context target|'s
+   1. Let |evaluate result| be the result of calling [=evaluate=] on |context target|'s
       [=active document=], with arguments |selector|, |context node|, null,
-      [=ORDERED_NODE_SNAPSHOT_TYPE=], and null. If this throws an [=XPathException=]
-      return [=error=] with [=error code=] [=invalid selector=], otherwise if this
-      throws any other exception return [=error=] with [=error code=] [=unknown error=].
+      [=ORDERED_NODE_SNAPSHOT_TYPE=], and null. If this throws a "[=SyntaxError=]"
+      [=DOMException=] return [=error=] with [=error code=] [=invalid selector=],
+      otherwise if this throws any other exception return [=error=] with [=error code=]
+      [=unknown error=].
 
    1. Let |index| be 0.
 
    1. Let |length| be the result of getting the <code>snapshotLength</code> property
-      from |evaluateResult|.
+      from |evaluate result|.
 
    1. Repeat, while |index| is less than |length|:
 
-      1. Let |node| be the result of calling [=snapshotItem=] with |evaluateResult|
+      1. Let |node| be the result of calling [=snapshotItem=] with |evaluate result|
          as this and |index| as the argument.
 
       1. [=list/append=] |node| to |returned nodes|.

--- a/index.bs
+++ b/index.bs
@@ -2869,13 +2869,13 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
 <div algorithm="locate nodes using XPath">
 
+To <dfn>locate nodes using XPath</dfn> with given |context target|,
+|context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
+
 Note: Owing to the unmaintained state of the XPath specification, this algorithm
 is phrased as if making calls to the XPath DOM APIs. However this is to be understood
 as equivalent to spec-internal calls directly accessing the underlying algorithms,
 without going via the ECMAScript runtime.
-
-To <dfn>locate nodes using XPath</dfn> with given |context target|,
-|context nodes|, |selector|, |maximum returned nodes|, and <var ignore>session</var>:
 
 1. Let |returned nodes| be an empty list.
 

--- a/index.bs
+++ b/index.bs
@@ -2843,9 +2843,9 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
    1. Let |index| be 0.
 
-   1. Let |length| be the result of getting the property "snapshotLength" from
-      |evaluateResult|. If this throws an [=XPathException=] return [=error=] with
-      [=error code=] [=invalid selector=], otherwise if this throws any other
+   1. Let |length| be the result of getting the <code>snapshotLength</code> property
+      from |evaluateResult|. If this throws an [=XPathException=] return [=error=]
+      with [=error code=] [=invalid selector=], otherwise if this throws any other
       exception return return [=error=] with [=error code=] [=unknown error=].
 
    1. Repeat, while |index| is less than |length|:

--- a/index.bs
+++ b/index.bs
@@ -2126,7 +2126,10 @@ browsingContext.CssLocator = {
 
 browsingContext.TextLocator {
    type: "text",
-   value: script.RegExpLocalValue
+   value: text,
+   ? ignoreCase: bool
+   ? matchType: "full" / "partial",
+   ? maxDepth: js-uint,
 }
 
 browsingContext.XPathLocator {
@@ -2899,28 +2902,80 @@ To <dfn>locate nodes using XPath</dfn> with given |context target|,
 
 </div>
 
-<div algorithm="locate nodes using regexp">
-To <dfn>locate nodes using regexp</dfn> with given |context target|, |context nodes|,
-|regexp|, |maximum returned nodes|, and <var ignore>session</var>:
+<div algorithm="locate nodes using text">
+To <dfn>locate nodes using text</dfn> with given |context target|, |context nodes|,
+|selector|, |max depth|, |match type|, |match case|, |maximum returned nodes|,
+and |session|:
 
 1. Let |returned nodes| be an empty list.
 
-1. Let |element nodes| be the result of [=locate nodes using CSS=] given |context target|,
-   |context nodes|, "*" and <var ignore>session</var>.
+1. For each |context node| in |context nodes|:
 
-1. For each |element node| in |element nodes|:
+  1. Let |iterative returned nodes| be an empty list.
 
   1. Let |node text| be the result of calling the [=innerText getter steps=] with
-     |element node| as the [=this=] value.
+     |context node| as the [=this=] value.
 
-  1. Let |is text match| be the result of calling [=test=] with |regexp| as
-     this and |node text| as the argument.
+  1. Let |is match| be false.
 
-  1. If |is text match| is true, [=list/append=] |element node| to |returned nodes|.
+  1. In the following list of conditions and associated steps, run the first set 
+     of steps for which the associated condition is true, if any:
 
-  1. If |maximum returned nodes| is greater than 0 and [=list/size=] of
-     |returned nodes| is greater than or equal to |maximum returned nodes|,
-     return |returned nodes|.
+     <dl>
+
+       <dt>|match type| is "partial" and |match case| is true
+       <dd>
+         1. If |node text| contains the substring |selector|, including case,
+            set |is match| to true.
+
+       <dt>|match type| is "partial" and |match case| is false
+       <dd>
+         1. If |node text| contains the substring |selector|, ignoring case,
+            set |is match| to true.
+
+       <dt>|match type| is "full" and |match case| is true
+       <dd>
+         1. If |node text| is equal to |selector|, including case, 
+            set |is match| to true.
+
+       <dt>|match type| is "full" and |match case| is false
+       <dd>
+         1. If |node text| is equal to |selector|, ignoring case,
+            set |is match| to true.
+
+   1. If |is match| is true, perform the following steps:
+
+     1. If |max depth| is not null and |max depth| is equal to 0, perform the
+        following steps:
+        
+       1. [=list/append=] |context node| to |returned nodes|.
+
+       1. If |maximum returned nodes| is not null and [=list/size=] of
+          |returned nodes| is greater than or equal to |maximum returned nodes|,
+          return |returned nodes|.
+         
+         Otherwise, perform the following steps:
+
+       1. Let |child nodes| be an empty list and, for each node |child| in the
+          <a spec=dom>children</a> of |context node|:
+
+         1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
+
+       1. If [=list/size=] of |child nodes| is equal to 0, perform the following steps:
+       
+         1. [=list/append=] |context node| to |returned nodes|.
+
+         1. If |maximum returned nodes| is not null and [=list/size=] of
+            |returned nodes| is greater than or equal to |maximum returned nodes|,
+            return |returned nodes|.
+         
+         Otherwise, perform the following steps:
+
+         1. Set |max depth| to |max depth| - 1 if |max depth| is not null.
+
+         1. [=list/extend=] |returned nodes| with the result of [=locate nodes using text=]
+            with |context target|, |child nodes|, |selector|, |max depth|,
+            |match type|, |match case|, |maximum returned nodes|, and |session|.
 
 1. Return |returned nodes|.
 
@@ -3005,7 +3060,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. Let |regexp| be the value of the <code>data</code> property of |selector|.
 
-         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using regexp=]
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using text=]
             given |current context target|, |context nodes|, |regexp|, |maximum returned
             nodes| and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -2947,7 +2947,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       <dt>|type| is the string "<code>xpath</code>"
       <dd>
-         1. Let |selector| be the value of the <code>value</value> property of |locator|.
+         1. Let |selector| be the value of the <code>value</code> property of |locator|.
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using xpath=]
             given |current context target|, |context nodes|, |selector| and |session|.

--- a/index.bs
+++ b/index.bs
@@ -2911,8 +2911,6 @@ and |session|:
 
 1. For each |context node| in |context nodes|:
 
-  1. Let |iterative returned nodes| be an empty list.
-
   1. Let |node text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
 

--- a/index.bs
+++ b/index.bs
@@ -3098,8 +3098,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
    Otherwise, let |result ownership| be "none".
 
 1. Let |serialized nodes| be the result of [=serialize as a remote value=] with
-   |result nodes|, |serialization options|, |result ownership|, a new map as
-   <var ignore>serialization internal map</var>, |realm| and |session|.
+   |result nodes|, |serialization options|, |result ownership|, a new [=/map=]
+   as serialization internal map, |realm| and |session|.
 
 1. Let |result| be a [=/map=] matching the <code>browsingContext.LocateNodesResult</code>
    production, with the <code>nodes</code> field set |serialized nodes|.

--- a/index.bs
+++ b/index.bs
@@ -2877,7 +2877,7 @@ To <dfn>locate nodes using text</dfn> with given |context target|, |context node
 
   1. Let |is text match| be the result of calling [=test=] on |regexp| with |node text|.
 
-  1. If |is text match| is true, append |element node to |returned nodes|.
+  1. If |is text match| is true, append |element node| to |returned nodes|.
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -3040,7 +3040,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |selector|, |maximum returned
             nodes| and |session|.
 
-      <dt>|type| is the string "<code>text</code>"
+      <dt>|type| is the string "<code>innerText</code>"
       <dd>
          1. Let |selector| be the value of the <code>value</code> property of |locator|.
 

--- a/index.bs
+++ b/index.bs
@@ -2972,8 +2972,7 @@ and |session|:
 <div algorithm="remote end steps for browsingContext.locateNodes">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let |context id| be the value of the <code>context</code> field of
-   |command parameters|.
+1. Let |context id| be |command parameters|["<code>context</code>"].
 
 1. Let |context| be the result of [=trying=] to [=get a browsing context=]
    with |context id|.

--- a/index.bs
+++ b/index.bs
@@ -2906,7 +2906,7 @@ without going via the ECMAScript runtime.
 
       1. Set |index| to |index| + 1. 
 
-1. Return |returned nodes|
+1. Return |returned nodes|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2923,66 +2923,55 @@ and |session|:
   1. Let |node text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
 
-  1. Let |is match| be false.
-
   1. In the following list of conditions and associated steps, run the first set 
      of steps for which the associated condition is true, if any:
 
      <dl>
 
-       <dt>|match type| is "partial" and |ignore case| is false
-       <dd>
-         1. If |node text| contains the substring |selector|, including case,
-            set |is match| to true.
-
-       <dt>|match type| is "partial" and |ignore case| is true
-       <dd>
-         1. If |node text| contains the substring |selector|, ignoring case,
-            set |is match| to true.
-
        <dt>|match type| is "full" and |ignore case| is false
        <dd>
-         1. If |node text| is equal to |selector|, including case, 
-            set |is match| to true.
+         1. If |node text| is equal to |selector|, including case,
+           [=list/append=] |context node| to |returned nodes|.
 
        <dt>|match type| is "full" and |ignore case| is true
        <dd>
          1. If |node text| is equal to |selector|, ignoring case,
-            set |is match| to true.
+            [=list/append] |context node| to |returned nodes|.
 
-   1. If |is match| is true, perform the following steps:
+       <dt>Otherwise
+       <dd>
+         1. If |node text| contains the substring |selector|, including case,
+            set |contains text| to true.
 
-     1. If |max depth| is not null and |max depth| is equal to 0, perform the
-        following steps:
-        
-       1. [=list/append=] |context node| to |returned nodes|.
+         1. If |node text| contains the substring |selector|, ignoring case,
+            set |contains text| to true.
 
-       1. If |maximum returned node count| is not null and [=list/size=] of
-          |returned nodes| is greater than or equal to |maximum returned node count|,
-          return |returned nodes|.
-         
-       Otherwise, perform the following steps:
+         1. If |contains text| is true, perform the following steps:
 
-       1. Let |child nodes| be an empty list and, for each node |child| in the
-          <a spec=dom>children</a> of |context node|:
+           1. Let |child nodes| be an empty list and, for each node |child| in the
+              <a spec=dom>children</a> of |context node|:
 
-         1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
+             1. If |child| implements {{Element}}, [=list/append=] |child| to
+                |child nodes|.
 
-       1. If [=list/size=] of |child nodes| is equal to 0, perform the following steps:
-       
-         1. [=list/append=] |context node| to |returned nodes|.
+           1. If [=list/size=] of |child nodes| is equal to 0 or |max depth|
+              is equal to 0 [=list/append] |context node| to |returned nodes|.
+              Otherwise perform the following steps:
 
-         1. If |maximum returned node count| is not null and [=list/size=] of
-            |returned nodes| is greater than or equal to |maximum returned node count|,
-            return |returned nodes|.
-         
-         Otherwise, perform the following steps:
+             1. Set |max depth| to |max depth| - 1. 
 
-         1. Set |max depth| to |max depth| - 1 if |max depth| is not null.
+             1. Let |child node matches| be the result of [=locate nodes using text=]
+                with |context target|, |child nodes|, |selector|, |max depth|,
+                |match type|, |ignore case|, |maximum returned node count|, and |session|.
 
-         1. [=list/extend=] |returned nodes| with the result of [=locate nodes using text=]
-            with |context target|, |child nodes|, |selector|, |max depth|,
-            |match type|, |ignore case|, |maximum returned node count|, and |session|.
+             1. If [=list/size=] of |child node matches| is equal to 0 and
+                |match type| is "partial" [=list/append=] |context node| to
+                |returned nodes|. Otherwise, [=list/extend=] |returned nodes|
+                with |child node matches|.
+
+1. If |maximum returned node count| is not null [=list/remove=] all entries
+   in |returned nodes| with an index greater than or equal to |maximum returned
+   node count|.
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -2956,7 +2956,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    of |command parameters|.
 
 1. If |command parameters| [=map/contains=] "<code>startNodes</code>", let
-   |start nodes parameter| be |command parameters|["<code>startNodes</code>"|.
+   |start nodes parameter| be |command parameters|["<code>startNodes</code>"].
    Otherwise let |start nodes parameter| be null.
 
 1. Let |context nodes| be an empty list.
@@ -3012,13 +3012,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Assert [=list/size=] of |result nodes| is less than or equal to |maximum returned nodes|.
 
 1. If |command parameters| [=map/contains=] "<code>serializationOptions</code>",
-   let |serialization options| be |command parameters|["<code>serializationOptions</code>"|.
+   let |serialization options| be |command parameters|["<code>serializationOptions</code>"].
    Otherwise let |serialization options| be a [=/map=] matching the 
    <code>script.SerializationOptions</code> production with the fields
    set to their default values.
 
 1. If |command parameters| [=map/contains=] "<code>ownership</code>",
-   let |result ownership| be |command parameters|["<code>ownership</code>"|.
+   let |result ownership| be |command parameters|["<code>ownership</code>"].
    Otherwise let |result ownership| be "none".
 
 1. Let |serialized nodes| be the result of [=serialize as a remote value=] with

--- a/index.bs
+++ b/index.bs
@@ -3003,7 +3003,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |context nodes| be an empty [=/list=].
 
 1. If |start nodes parameter| is null, [=list/append=] the [=document element=]
-   to of |context|'s [=active document=] |context nodes|. Otherwise, for each
+   of |context|'s [=active document=] to |context nodes|. Otherwise, for each
    |serialized start node| in |start nodes parameter|:
 
    1. Let |start node| be the result of [=trying=] to [=deserialize shared reference=] given
@@ -3015,7 +3015,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |result nodes| be an empty [=/list=].
 
-1. Let |type| be the value of the <code>type</code> property of |locator|.
+1. Let |type| be |locator|["<code>type</code>"].
 
 1. In the following list of conditions and associated steps, run the first set 
    of steps for which the associated condition is true, if any:
@@ -3024,7 +3024,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       <dt>|type| is the string "<code>css</code>"
       <dd>
-         1. Let |selector| be the value of the <code>value</code> property of |locator|.
+         1. Let |selector| be |locator|["<code>value</code>"].
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using css=]
             given |current context target|, |context nodes|, |selector|, |maximum returned
@@ -3032,7 +3032,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       <dt>|type| is the string "<code>xpath</code>"
       <dd>
-         1. Let |selector| be the value of the <code>value</code> property of |locator|.
+         1. Let |selector| be |locator|["<code>value</code>"].
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using xpath=]
             given |current context target|, |context nodes|, |selector|, |maximum returned
@@ -3040,7 +3040,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       <dt>|type| is the string "<code>innerText</code>"
       <dd>
-         1. Let |selector| be the value of the <code>value</code> property of |locator|.
+         1. Let |selector| be |locator|["<code>value</code>"].
 
          1. If |locator| [=map/contains=] <code>maxDepth</code>, let |max depth| be 
             |locator|["<code>maxDepth</code>"]. Otherwise, let |max depth| be null.

--- a/index.bs
+++ b/index.bs
@@ -2952,7 +2952,7 @@ and |session|:
 
         1. Set |max depth| to |max depth| - 1. 
 
-        1. Let |child node matches| be the result of [=locate nodes using text=]
+        1. Let |child node matches| be the result of [=locate nodes using inner text=]
            with |context target|, |child nodes|, |selector|, |max depth|,
            |match type|, |ignore case|, |maximum returned node count|, and |session|.
 

--- a/index.bs
+++ b/index.bs
@@ -2931,7 +2931,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |result nodes| be an empty array.
 
-1. Let |type| be the value of the type property of |locator|.
+1. Let |type| be the value of the <code>type</code> property of |locator|.
 
 1. In the following list of conditions and associated steps, run the first set 
    of steps for which the associated condition is true, if any:


### PR DESCRIPTION
Fixes #150.

This PR implements the `browsingContext.locateNodes` command, which allows the user to locate nodes in the DOM using means other than returning them via JavaScript. This also allows for future expansion of location strategies should they become available.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/547.html" title="Last updated on Nov 2, 2023, 1:37 PM UTC (ae9938d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/547/a3a09be...ae9938d.html" title="Last updated on Nov 2, 2023, 1:37 PM UTC (ae9938d)">Diff</a>