### PR TITLE
Use range instead of `float` for angle values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8846,8 +8846,10 @@ specified sequence of user input actions.
       )
 
       input.AngleProperties = (
-        ? altitudeAngle: float .default 0.0,
-        ? azimuthAngle: float .default 0.0,
+        ; 0 .. Math.PI / 2
+        ? altitudeAngle: (0.0..1.5707963267948966) .default 0.0,
+        ; 0 .. 2 * Math.PI
+        ? azimuthAngle: (0.0..6.283185307179586) .default 0.0,
       )
 
       input.TiltProperties = (


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/555.html" title="Last updated on Sep 25, 2023, 1:28 PM UTC (64501e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/555/4361bea...64501e6.html" title="Last updated on Sep 25, 2023, 1:28 PM UTC (64501e6)">Diff</a>