### PR TITLE
Extend browsingContext.setViewport with devicePixelRatio

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -211,12 +211,11 @@ spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
     text: absolute lengths; url: #absolute-lengths
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
+    text: viewport; url: #visual-viewport
     text: visual viewport; url: #visual-viewport
-<<<<<<< HEAD
     text: layout viewport; url: #layout-viewport
-=======
     text: device pixel ratio; url: #dom-window-devicepixelratio
->>>>>>> f7948c0 (WIP dpr)
+    text: CSS pixel; url: #dom-window-devicepixelratio
 </pre>
 
 <pre class="biblio">
@@ -3074,6 +3073,10 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
 
+1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
+
+1. If |device pixel ratio parameter| is not null and the implementation is not able to change the size of the [=CSS Pixel=] in |context|'s [=viewport=] for any reason, return [=error=] with [=error code=] [=unsupported operation=].
+
 1. If |viewport parameter| is not null:
     1. Let |width| be the |viewport parameter|["<code>width</code>"]
     1. Let |height| be the |viewport parameter|["<code>height</code>"]
@@ -3081,15 +3084,14 @@ The [=remote end steps=] with |command parameters| are:
     1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
     1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
-1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
+
 1. If |device pixel ratio parameter| is not null:
-  1. If the implementation is not able to set |device pixel ratio parameter| for |context| for any reasonm return [=error=] with [=error code=] [=unsupported operation=].
-  1. Override the [=device pixel ratio=] algorithm with the algorithm returning |device pixel ratio parameter| for |context|.
-  1. Perform implementation-specific steps to apply [=device pixel ratio=] to the page rendering for |context|.
+  1. Change the size of the [=CSS Pixel=] in |context|'s [=viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.
 1. Else:
-  1. Restore the [=device pixel ratio=] algorithm for |context|.
-  1. Perform implementation-specific steps to apply [=device pixel ratio=] to the page rendering for |context|.
+  1. Set the size of the [=CSS Pixel=] in |context|'s [=viewport=] to the implementation defined default.
+
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
+
 1. Return [=success=] with data null.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -3081,11 +3081,9 @@ The [=remote end steps=] with |command parameters| are:
    with [=error code=] [=unsupported operation=]
 
 1. If |viewport parameter| is not null:
-    1. Let |width| be the |viewport parameter|["<code>width</code>"]
-    1. Let |height| be the |viewport parameter|["<code>height</code>"]
-    1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
+    1. Set the [=layout viewport=] of the |context| to be |viewport|["width"] CSS pixels wide and |viewport|["height"] CSS pixels high.
 1. Otherwise:
-    1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
+    1. Set the [=layout viewport=] of the |context| to the implementation defined default.
 
 1. If |device pixel ratio parameter| is not null:
   1. Change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.

--- a/index.bs
+++ b/index.bs
@@ -3044,7 +3044,7 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command  specific
       browsingContext.SetViewportParameters = {
         context: browsingContext.BrowsingContext,
         viewport: browsingContext.Viewport / null,
-        devicePixelRatio: float / null,
+        devicePixelRatio: (float .gt 0.0) / null,
       }
 
       browsingContext.Viewport = {

--- a/index.bs
+++ b/index.bs
@@ -3073,19 +3073,23 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
 
-1. If |device pixel ratio parameter| is not null and the implementation is not able to change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] for any reason, return [=error=] with [=error code=] [=unsupported operation=].
+1. If |viewport| is not null, and the implementation is unable to set the width and height dimensions
+   of the [=layout viewport=] to |viewport|["width"] and |viewport|["height"], respectively, or if 
+   |device pixel ratio| is not null and the implementation is unable to set the size of the CSS pixel 
+   of the [=layout viewport=] to |device pixel ratio| device pixels, or if the implementation is unable
+   to adjust the [=layout viewport=] parameters for any other reason, return [=error=] 
+   with [=error code=] [=unsupported operation=]
 
 1. If |viewport parameter| is not null:
     1. Let |width| be the |viewport parameter|["<code>width</code>"]
     1. Let |height| be the |viewport parameter|["<code>height</code>"]
-    1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
-1. Else:
+1. Otherwise:
     1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
 
 1. If |device pixel ratio parameter| is not null:
   1. Change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.
-1. Else:
+1. Otherwise:
   1. Set the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] to the implementation defined default.
 
 1. Run the [[cssom-view-1#resizing-viewports]] steps.

--- a/index.bs
+++ b/index.bs
@@ -214,7 +214,6 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
     text: viewport; url: #visual-viewport
     text: visual viewport; url: #visual-viewport
     text: layout viewport; url: #layout-viewport
-    text: device pixel ratio; url: #dom-window-devicepixelratio
     text: CSS pixel; url: #dom-window-devicepixelratio
 </pre>
 
@@ -3083,7 +3082,7 @@ The [=remote end steps=] with |command parameters| are:
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
-    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
+    1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
 
 1. If |device pixel ratio parameter| is not null:
   1. Change the size of the [=CSS Pixel=] in |context|'s [=viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.

--- a/index.bs
+++ b/index.bs
@@ -211,7 +211,6 @@ spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
     text: absolute lengths; url: #absolute-lengths
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
-    text: viewport; url: #visual-viewport
     text: visual viewport; url: #visual-viewport
     text: layout viewport; url: #layout-viewport
     text: CSS pixel; url: #dom-window-devicepixelratio
@@ -3074,7 +3073,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
 
-1. If |device pixel ratio parameter| is not null and the implementation is not able to change the size of the [=CSS Pixel=] in |context|'s [=viewport=] for any reason, return [=error=] with [=error code=] [=unsupported operation=].
+1. If |device pixel ratio parameter| is not null and the implementation is not able to change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] for any reason, return [=error=] with [=error code=] [=unsupported operation=].
 
 1. If |viewport parameter| is not null:
     1. Let |width| be the |viewport parameter|["<code>width</code>"]
@@ -3085,9 +3084,9 @@ The [=remote end steps=] with |command parameters| are:
     1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
 
 1. If |device pixel ratio parameter| is not null:
-  1. Change the size of the [=CSS Pixel=] in |context|'s [=viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.
+  1. Change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.
 1. Else:
-  1. Set the size of the [=CSS Pixel=] in |context|'s [=viewport=] to the implementation defined default.
+  1. Set the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] to the implementation defined default.
 
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
 

--- a/index.bs
+++ b/index.bs
@@ -3069,9 +3069,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. If |context| is not a [=top-level browsing context=], return [=error=] with [=error code=] [=invalid argument=].
 
-1. Let |viewport parameter| be the |command parameters|["<code>viewport</code>"] field.
+1. Let |viewport| be the |command parameters|["<code>viewport</code>"] field.
 
-1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
+1. Let |device pixel ratio| be the |command parameters|["<code>devicePixelRatio</code>"] field.
 
 1. If |viewport| is not null, and the implementation is unable to set the width and height dimensions
    of the [=layout viewport=] to |viewport|["width"] and |viewport|["height"], respectively, or if 
@@ -3080,13 +3080,13 @@ The [=remote end steps=] with |command parameters| are:
    to adjust the [=layout viewport=] parameters for any other reason, return [=error=] 
    with [=error code=] [=unsupported operation=]
 
-1. If |viewport parameter| is not null:
+1. If |viewport| is not null:
     1. Set the [=layout viewport=] of the |context| to be |viewport|["width"] CSS pixels wide and |viewport|["height"] CSS pixels high.
 1. Otherwise:
     1. Set the [=layout viewport=] of the |context| to the implementation defined default.
 
-1. If |device pixel ratio parameter| is not null:
-  1. Change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] such that it corresponds to |device pixel ratio parameter| device pixels.
+1. If |device pixel ratio| is not null:
+  1. Change the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] such that it corresponds to |device pixel ratio| device pixels.
 1. Otherwise:
   1. Set the size of the [=CSS Pixel=] in |context|'s [=layout viewport=] to the implementation defined default.
 

--- a/index.bs
+++ b/index.bs
@@ -212,7 +212,11 @@ spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
     text: visual viewport; url: #visual-viewport
+<<<<<<< HEAD
     text: layout viewport; url: #layout-viewport
+=======
+    text: device pixel ratio; url: #dom-window-devicepixelratio
+>>>>>>> f7948c0 (WIP dpr)
 </pre>
 
 <pre class="biblio">
@@ -3041,6 +3045,7 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command  specific
       browsingContext.SetViewportParameters = {
         context: browsingContext.BrowsingContext,
         viewport: browsingContext.Viewport / null,
+        devicePixelRatio: float / null,
       }
 
       browsingContext.Viewport = {
@@ -3075,7 +3080,15 @@ The [=remote end steps=] with |command parameters| are:
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
-    1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
+    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
+1. Let |device pixel ratio parameter| be the |command parameters|["<code>devicePixelRatio</code>"] field.
+1. If |device pixel ratio parameter| is not null:
+  1. If the implementation is not able to set |device pixel ratio parameter| for |context| for any reasonm return [=error=] with [=error code=] [=unsupported operation=].
+  1. Override the [=device pixel ratio=] algorithm with the algorithm returning |device pixel ratio parameter| for |context|.
+  1. Perform implementation-specific steps to apply [=device pixel ratio=] to the page rendering for |context|.
+1. Else:
+  1. Restore the [=device pixel ratio=] algorithm for |context|.
+  1. Perform implementation-specific steps to apply [=device pixel ratio=] to the page rendering for |context|.
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -3078,7 +3078,7 @@ The [=remote end steps=] with |command parameters| are:
    |device pixel ratio| is not null and the implementation is unable to set the size of the CSS pixel 
    of the [=layout viewport=] to |device pixel ratio| device pixels, or if the implementation is unable
    to adjust the [=layout viewport=] parameters for any other reason, return [=error=] 
-   with [=error code=] [=unsupported operation=]
+   with [=error code=] [=unsupported operation=].
 
 1. If |viewport| is not null:
     1. Set the [=layout viewport=] of the |context| to be |viewport|["width"] CSS pixels wide and |viewport|["height"] CSS pixels high.


### PR DESCRIPTION
Closes #529


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/557.html" title="Last updated on Oct 9, 2023, 6:13 AM UTC (5563672)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/557/d8df062...5563672.html" title="Last updated on Oct 9, 2023, 6:13 AM UTC (5563672)">Diff</a>