### PR TITLE
Remove ranges from `AngleProperties` and `TiltProperties`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8852,15 +8852,13 @@ specified sequence of user input actions.
       )
 
       input.AngleProperties = (
-        ; 0 .. Math.PI / 2
-        ? altitudeAngle: (0.0..1.5707963267948966) .default 0.0,
-        ; 0 .. 2 * Math.PI
-        ? azimuthAngle: (0.0..6.283185307179586) .default 0.0,
+         ? altitudeAngle: float .default 0.0,
+         ? azimuthAngle: float .default 0.0,
       )
 
       input.TiltProperties = (
-        ? tiltX: (-90..90) .default 0,
-        ? tiltY: (-90..90) .default 0,
+         ? tiltX: js-int .default 0,
+         ? tiltY: js-int .default 0,
       )
 
       input.Origin = "viewport" / "pointer" / input.ElementOrigin


### PR DESCRIPTION
Although the ranges for `AngleProperties` and `TiltProperties` are correct, adding them to the schema creates the incorrect type.

More specifically, for a given value, the type union will match the value _if the value matches any of the productions in the union_. In particular, if the value is `{tiltX: 91}`, value will not match `TiltProperties`, but it _will_ match `AngleProperties`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/559.html" title="Last updated on Sep 26, 2023, 1:58 PM UTC (6f8467a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/559/7a9b69c...6f8467a.html" title="Last updated on Sep 26, 2023, 1:58 PM UTC (6f8467a)">Diff</a>