### PR TITLE
Remove type union for tilt and angle properties

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8892,17 +8892,10 @@ specified sequence of user input actions.
         ? pressure: float .default 0.0,
         ? tangentialPressure: float .default 0.0,
         ? twist: (0..359) .default 0,
-        (input.TiltProperties // input.AngleProperties)
-      )
-
-      input.AngleProperties = (
-         ? altitudeAngle: float .default 0.0,
-         ? azimuthAngle: float .default 0.0,
-      )
-
-      input.TiltProperties = (
-         ? tiltX: js-int .default 0,
-         ? tiltY: js-int .default 0,
+        ; 0 .. Math.PI / 2
+        ? altitudeAngle: (0.0..1.5707963267948966) .default 0.0,
+        ; 0 .. 2 * Math.PI
+        ? azimuthAngle: (0.0..6.283185307179586) .default 0.0,
       )
 
       input.Origin = "viewport" / "pointer" / input.ElementOrigin


### PR DESCRIPTION
### 3rd Attempt...

`{azimuthAngle:0}` matches `TiltProperties` because it only validates whether `tiltX` and `tiltY` exist and defaults them otherwise. This implies `AngleProperties` is not matched.

This PR implements the TiltProperties and AngleProperties verbatim, according to the Webdriver spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/562.html" title="Last updated on Oct 4, 2023, 1:05 PM UTC (32669aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/562/0b128ab...32669aa.html" title="Last updated on Oct 4, 2023, 1:05 PM UTC (32669aa)">Diff</a>