### PR TITLE
Remove `data` link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4980,7 +4980,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. [=Resume=] with "<code>continue request</code>", |request id|, and (null,
    "<code>incomplete</code>").
 
-1. Return [=success=] with [=data=] null.
+1. Return [=success=] with data null.
 
 </div>
 
@@ -5115,7 +5115,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. [=Resume=] with "<code>continue request</code>", |request id|, and
    (|response|, "<code>incomplete</code>").
 
-1. Return [=success=] with [=data=] null.
+1. Return [=success=] with data null.
 
 </div>
 
@@ -5190,7 +5190,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. [=Resume=] with "<code>continue request</code>", |request id|, and
    (|response|, "<code>incomplete</code>").
 
-1. Return [=success=] with [=data=] null.
+1. Return [=success=] with data null.
 
 </div>
 
@@ -5302,7 +5302,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. [=Resume=] with "<code>continue request</code>", |request id|, and
    (|response|,"<code>complete</code>").
 
-1. Return [=success=] with [=data=] null.
+1. Return [=success=] with data null.
 
 </div>
 


### PR DESCRIPTION
This is causing failing tests. It doesn't link to anywhere valid with context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/563.html" title="Last updated on Sep 29, 2023, 10:33 AM UTC (e3de66a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/563/a738ba0...e3de66a.html" title="Last updated on Sep 29, 2023, 10:33 AM UTC (e3de66a)">Diff</a>