### PR TITLE
Make context/navigable id per session.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1808,7 +1808,7 @@ events relating to [=navigables=].
 
 Note: For historic reasons this module is called <code>browsingContext</code>
 rather than <code>navigable</code>, and the protocol uses the term
-<code>context</code> to refer to navigables, particuarly as a field in command
+<code>context</code> to refer to navigables, particularly as a field in command
 and response parameters.
 
 Issue: Update the spec to use [=navigable=] consistently and remove


### PR DESCRIPTION
Also make it clear that context ids actually relate to navigables, not browsing contexts. This part is a temporary workaround while the rest of the spec continues to pass in browsing contexts rather than navigables.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/565.html" title="Last updated on Oct 2, 2023, 1:06 PM UTC (e9e85fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/565/0b128ab...e9e85fe.html" title="Last updated on Oct 2, 2023, 1:06 PM UTC (e9e85fe)">Diff</a>