### PR TITLE
Update references to the layout viewport in browsingContext.setViewport

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -211,6 +211,7 @@ spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
     text: visual viewport; url: #visual-viewport
+    text: layout viewport; url: #layout-viewport
 </pre>
 
 <pre class="biblio">
@@ -3046,9 +3047,9 @@ The [=remote end steps=] with |command parameters| are:
     1. Let |width| be the |viewport parameter|["<code>width</code>"]
     1. Let |height| be the |viewport parameter|["<code>height</code>"]
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
-    1. Set the layout [[css2#viewport]] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
+    1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
-    1. Set the layout [[css2#viewport]] of |context| to the implementation-defined default layout viewport for |context|.
+    1. Set the |context| [=layout viewport=] to the implementation-defined default value.
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -3049,7 +3049,7 @@ The [=remote end steps=] with |command parameters| are:
     1. If the |width| or |height| is outside of the implementation-specific or runtime constraints, return an [=error=] with the [=error code=] [=unsupported operation=].
     1. Set the [=layout viewport=] of the |context| to be |width| CSS pixels wide and |height| CSS pixels high.
 1. Else:
-    1. Set the |context| [=layout viewport=] to the implementation-defined default value.
+    1. Set the [=layout viewport=] of the |context| to the implementation-defined default value.
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
 1. Return [=success=] with data null.
 


### PR DESCRIPTION
I noticed that the link to the definition of the layout viewport is not the best and, perhaps, the spec text in cssom-view spec was updated as well so now it's possible to link to the layout viewport definition. Also, tried to simplify the test.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/566.html" title="Last updated on Oct 5, 2023, 8:28 AM UTC (ac95b99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/566/5a6087e...ac95b99.html" title="Last updated on Oct 5, 2023, 8:28 AM UTC (ac95b99)">Diff</a>