### PR TITLE
Support user contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2025,11 +2025,12 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a [
 
 The [=remote end steps=] are:
 
-1. Let |user context| be the result of performing implementation defined steps to create an [=empty user context=].
+1. Let |user context| be the result of performing implementation-defined steps
+   to create an [=empty user context=].
 
 1. Let |result| be a [=/map=] matching the
-   <code>browser.createUserContextResult</code> production with the <code>userContext</code>
-   field set to |user context|'s [=user context id=].
+   <code>browser.createUserContextResult</code> production with the
+   <code>userContext</code> field set to |user context|'s [=user context id=].
 
 1. Return [=success=] with data |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -1951,6 +1951,10 @@ BrowserCommand = (
 
 <!-- Nothing yet -->
 <pre class="cddl local-cddl">
+BrowserResult = (
+   browser.CreateUserContextResult /
+   browser.GetUserContextsResult
+)
 </pre>
 
 

--- a/index.bs
+++ b/index.bs
@@ -1294,20 +1294,20 @@ Issue: Define how this works.
 # User Contexts # {#user-contexts}
 
 A <dfn>user context</dfn> represents a collection of top-level navigables within
-a [=remote end=]. Each top-level navigable belongs to exactly one [=user
-context=], and child navigables belong to the same [=user context=] as their
-parent. A [=user context=] without navigables belonging to it is an <dfn>empty
-user context</dfn>.
+a [=remote end=]. User contexts have a <dfn>user context id</dfn>, which is a
+string set upon the user context creation. The [=default user context=]'s [=user
+context id|id=] is <code>"default"</code>. A [=remote end=] always contains at
+least one [=user context=] referred as the <dfn>default user context</dfn>.
 
-A [=remote end=] always contains at least one [=user context=] referred as the
-<dfn>default user context</dfn>.
+Each top-level navigable belongs to exactly one [=user context=], and child
+navigables belong to the same [=user context=] as their parent. Each navigable's
+[=user context=] is the [=user context=] the navigables belongs to.
+
+A [=user context=] without navigables belonging to it is an <dfn>empty
+user context</dfn>.
 
 Each [=user context=] represents an additional [=storage key=], so that no
 storage state is shared between different [=user context|user contexts=].
-
-A [=user context=] other than the [=default user context=] has a <dfn>user
-context id</dfn>, which is a string set upon context creation. The [=default
-user context=] does not have a [=user context id=].
 
 Note: The infra spec uses the term "user agent" to refer to the same concept as
 [=user context|user contexts=]. However, this is not compatible with usage of
@@ -2025,8 +2025,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 The [=remote end steps=] are:
 
-1. Let |user context| be the result of performing implementation-defined steps
-   to create an [=empty user context=].
+1. Let |user context| be a new [=empty user context=].
 
 1. Let |result| be a [=/map=] matching the
    <code>browser.createUserContextResult</code> production with the
@@ -2069,14 +2068,14 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |user context| be |command  parameters|["<code>userContext</code>"].
 
 1. If the [=user context=] with the [=user context id=] equal to |user context|
-   does not exist in the user agent, return [=error=] with [=error code=]
+   does not exist in the [=remote end=], return [=error=] with [=error code=]
    [=invalid argument=]
 
-1. [=Close=] any [=top-level browsing contexts=] that belong to the |user
-   context| without [=prompting to unload=].
+1. [=Close=] any [=top-level browsing contexts=] whose [=user context=]'s [=user
+   context id=] is |user context| without [=prompting to unload=].
 
-1. Perform implementation-defined steps to remove |user context| from the user
-   agent.
+1. Perform implementation-defined steps to remove |user context| from the
+   [=remote end=].
 
 1. Return [=success=] with data null.
 
@@ -2110,15 +2109,15 @@ The <dfn export for=commands>browser.getUserContexts</dfn> command returns a lis
 
 The [=remote end steps=] are:
 
-1. Let |user contexts| be the result of performing implementation defined steps
-   to get [=user contexts=] from the user agent.
+1. Let |user contexts| be the [=user contexts=] within the [=remote end=].
 
 1. Let |user context info list| be an empty [=/list=].
 
 1. For each |user context| in |user contexts|:
 
   1. Let |info| be a [=/map=] matching the <code>browser.UserContextInfo</code>
-     production with the <code>userContext</code> field set to |user context|'s [=user context id=].
+     production with the <code>userContext</code> field set to |user context|'s
+     [=user context id|id=].
 
   1. Append |info| to |user context info list|.
 
@@ -2312,10 +2311,6 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. Let |user context| be null if |context| belongs to the [=default user
-   context=] or the [=user context id=] of the [=user context=] which the |context|
-   belongs to otherwise.
-
 1. Let |child infos| be null.
 
 1. If |max depth| is null, or |max depth| is greater than 0:
@@ -2337,8 +2332,9 @@ To <dfn>get the browsing context info</dfn> given |context|,
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
    if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, the <code>userContext</code> field set to |user context| if it’s not null, or omitted otherwise,
-   and the <code>children</code> field set to |child infos|.
+   field set to |url|, the <code>userContext</code> field set to |context|'s
+   [=user context id=], and the <code>children</code> field set to |child
+   infos|.
 
 1. Return |context info|.
 

--- a/index.bs
+++ b/index.bs
@@ -1889,10 +1889,10 @@ managing the remote end browser process.
 
 <pre class="cddl remote-cddl">
 BrowserCommand = (
-  browser.Close,
-  browser.CreateUserContext,
-  browser.RemoveUserContext,
-  browser.GetUserContexts,
+  browser.Close //
+  browser.CreateUserContext //
+  browser.RemoveUserContext //
+  browser.GetUserContexts
 )
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1301,27 +1301,61 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn>user context</dfn> represents a collection of top-level navigables within
-a [=remote end=]. User contexts have a <dfn>user context id</dfn>, which is a
-string set upon the user context creation. The [=default user context=]'s [=user
-context id|id=] is <code>"default"</code>. A [=remote end=] always contains one
-[=user context=] referred as the <dfn>default user context</dfn>.
+A <dfn>user context</dfn> represents a collection of zero or more
+[=/top-level traversables=] within a [=remote end=]. Each [=user context=] has
+an associated [=storage partition=], so that [=remote end=] data is not shared
+between different [=user contexts=].
 
-Each top-level navigable belongs to exactly one [=user context=], and child
-navigables belong to the same [=user context=] as their parent. Each navigable's
-[=user context=] is the [=user context=] the navigables belongs to.
-
-A [=user context=] without navigables belonging to it is an <dfn>empty
-user context</dfn>.
-
-Each [=user context=] represents an additional [=storage key=], so that no
-storage state is shared between different [=user context|user contexts=].
+Issue: Unclear that this is the best way to formally define the concept of a
+user context or the interaction with storage.
 
 Note: The infra spec uses the term "user agent" to refer to the same concept as
 [=user context|user contexts=]. However, this is not compatible with usage of
 the term "user agent" to mean the entire web client with multiple [=user
 context|user contexts=]. Although this difference is not visible to web content,
-it is observed via WebDriver, so we avoid reusing existing terminology.
+it is observed via WebDriver, so we avoid using this terminology.
+
+A [=user context=] has a <dfn>user context id</dfn>, which is a unique string
+set upon the user context creation.
+
+A [=navigable=] has an <dfn>associated user context</dfn>, which is a
+[=user context=].
+
+When a new [=/top-level traversable=] is created its [=associated user context=]
+is set to a user context in the [=set of user contexts=].
+
+Note: In some cases the user context is set by specification when the
+[=/top-level traversable=] is created, however in cases where no such
+requirements are present, the [=associated user context=] for a [=/top-level
+traversable=] is implemenation-defined.
+
+Issue: Should we specify that [=/top-level traversables=] with a non-null
+opener have the same [=associated user context=] as their opener?
+Need to check if this is something existing implementations enforce.
+
+A [=child navigable=]'s [=associated user context=] is it's
+[=navigable/parent=]'s [=associated user context=].
+
+A [=user context=] which isn't the [=associated user context=] for any
+[=/top-level traversable=] is an <dfn>empty user context</dfn>.
+
+The <dfn>default user context</dfn> is a [=user context=] with [=user context
+id=] <code>"default"</code>.
+
+An implementation has a <dfn>set of user contexts</dfn>, which is a [=/set=] of
+[=user contexts=]. Initially this contains the [=default user context=].
+
+Implementations may [=set/append=] new [=user contexts=] to the [=set of user
+contexts=] at any time, for example in response to user actions.
+
+Note: "At any time" here includes during implementation startup, so a given
+implementation might always have multiple entries in the [=set of user contexts=].
+
+Implementations may [=set/remove=] any [=empty user context=], with exception of
+the [=default user context=], from the [=set of user contexts=] at any
+time. However they are not required to remove such [=user contexts=]. [=User
+contexts=] that are not [=empty user contexts=] must not be removed from the
+[=set of user contexts=].
 
 # Modules # {#modules}
 
@@ -2032,7 +2066,9 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 The [=remote end steps=] are:
 
-1. Let |user context| be a new [=empty user context=].
+1. Let |user context| be a new [=user context=].
+
+1. [=set/Append=] |user context| to the [=set of user contexts=].
 
 1. Let |result| be a [=/map=] matching the
    <code>browser.createUserContextResult</code> production with the
@@ -2072,22 +2108,26 @@ user context and all browsing contexts in it without running
 
 The [=remote end steps=] with |command parameters| are:
 
-1. Let |user context| be |command  parameters|["<code>userContext</code>"].
+1. Let |user context id| be |command  parameters|["<code>userContext</code>"].
 
-1. If |user context| is <code>"default"</code>, return [=error=] with [=error
+1. If |user context id| is <code>"default"</code>, return [=error=] with [=error
    code=] [=invalid argument=].
 
-1. If the [=user context=] with the [=user context id=] equal to |user context|
-   does not exist in the [=remote end=], return [=error=] with [=error code=] [=no
-   such user context=].
+1. For each |user context| in the [=set of user contexts=]:
 
-1. [=Close=] any [=top-level browsing contexts=] whose [=user context=]'s [=user
-   context id=] is |user context| without [=prompting to unload=].
+  1. If |user context|'s [=user context id=] is |user context id|:
 
-1. Perform implementation-defined steps to remove |user context| from the
-   [=remote end=].
+    1. For each [=/top-level traversable=] |navigable|:
 
-1. Return [=success=] with data null.
+      1. If |navigable|'s [=associated user context=] is |user context|:
+
+        1. [=Close=] |navigable| without [=prompting to unload=].
+
+    1. [=set/Remove=] |user context| for the [=set of user contexts=].
+
+    1. Return [=success=] with data null.
+
+1. Return [=error=] with [=error code=] [=no such user context=].
 
 </div>
 
@@ -2205,11 +2245,11 @@ To <dfn export>get a browsing context</dfn> given |context id|:
 browsingContext.InfoList = [*browsingContext.Info]
 
 browsingContext.Info = {
+  children: browsingContext.InfoList / null,
   context: browsingContext.BrowsingContext,
   url: text,
-  children: browsingContext.InfoList / null
+  userContext: browser.UserContext
   ? parent: browsingContext.BrowsingContext / null,
-  ? userContext: browser.UserContext
 }
 </pre>
 
@@ -2283,20 +2323,22 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
   1. Set |child infos| to an empty [=/list=].
 
-  1. For each |context| of |child contexts|:
+  1. For each |child context| of |child contexts|:
 
     1. Let |info| be the result of [=get the browsing context info=] given
-       |context|, |child depth|, and false.
+       |child context|, |child depth|, and false.
 
     1. Append |info| to |child infos|
+
+1. Let |user context| be |context|'s [=associated user context=].
 
 1. Let |context info| be a [=/map=] matching the
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
    if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, the <code>userContext</code> field set to |context|'s
-   [=user context id=], and the <code>children</code> field set to |child
-   infos|.
+   field set to |url|, the <code>userContext</code> field set to
+   |user context|'s [=user context id=], and the <code>children</code> field
+   set to |child infos|.
 
 1. Return |context info|.
 

--- a/index.bs
+++ b/index.bs
@@ -1983,9 +1983,6 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
   1. [=Close=] any [=top-level browsing contexts=] without [=prompting to unload=].
 
-     Note: This implicitly only affects browsing contexts that were under
-     automation in the first place.
-
   1. Perform implementation defined steps to clean up resources associated with
      the [=remote end=] under automation.
 
@@ -2076,11 +2073,6 @@ The [=remote end steps=] with |command parameters| are:
 
 1. [=Close=] any [=top-level browsing contexts=] that belong to the |user
    context| without [=prompting to unload=].
-
-    Note: This implicitly only affects browsing contexts that were under
-    automation in the first place.
-
-    Issue: Should we allow closing the default context? Probably not.
 
 1. Perform implementation defined steps to remove the |user context| from the
    user agent.

--- a/index.bs
+++ b/index.bs
@@ -604,9 +604,6 @@ with the following additional codes:
   <dt><dfn>no such user context</dfn>
   <dd>Tried to reference an unknown [=user context=].
 
-  <dt><dfn>no such user context</dfn>
-  <dd>Tried to reference an unknown [=user context=].
-
   <dt><dfn>unable to close browser</dfn>
   <dd>Tried to close the browser, but failed to do so.
 

--- a/index.bs
+++ b/index.bs
@@ -1353,6 +1353,19 @@ time. However they are not required to remove such [=user contexts=]. [=User
 contexts=] that are not [=empty user contexts=] must not be removed from the
 [=set of user contexts=].
 
+<div algorithm>
+To <dfn>get user context</dfn> given |user context id|:
+
+1. For each |user context| in the [=set of user contexts=]:
+
+ 1. If |user context|'s [=user context id=] equals |user context id|:
+
+   1. Return |user context|.
+
+1. Return null.
+
+</div>
+
 # Modules # {#modules}
 
 ## The session Module ## {#module-session}
@@ -2157,21 +2170,19 @@ The [=remote end steps=] with |command parameters| are:
 1. If |user context id| is <code>"default"</code>, return [=error=] with [=error
    code=] [=invalid argument=].
 
-1. For each |user context| in the [=set of user contexts=]:
+1. Set |user context| to [=get user context=] with |user context id|.
 
-  1. If |user context|'s [=user context id=] is |user context id|:
+1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
-    1. For each [=/top-level traversable=] |navigable|:
+1. For each [=/top-level traversable=] |navigable|:
 
-      1. If |navigable|'s [=associated user context=] is |user context|:
+  1. If |navigable|'s [=associated user context=] is |user context|:
 
-        1. [=Close=] |navigable| without [=prompting to unload=].
+    1. [=Close=] |navigable| without [=prompting to unload=].
 
-    1. [=set/Remove=] |user context| for the [=set of user contexts=].
+1. [=set/Remove=] |user context| for the [=set of user contexts=].
 
-    1. Return [=success=] with data null.
-
-1. Return [=error=] with [=error code=] [=no such user context=].
+1. Return [=success=] with data null.
 
 </div>
 
@@ -3037,12 +3048,9 @@ The [=remote end steps=] with |command parameters| are:
 
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
-    1. Let |user context id| be |command parameters|[<code>userContext</code>].
+    1. Set |user context| to [=get user context=] with |command parameters|["<code>userContextId</code>"].
 
-    1. If the [=user context=] with the [=user context id=] |user context id| does
-      not exist in the [=remote end=], return [=error=] with [=error code=] [=no such user context=].
-
-    1. Set |user context| to the [=user context=] with the [=user context id=] |user context id|.
+    1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
   1. If the implementation is unable to create a new [=/top-level traversable=]
      with [=associated user context=] |user context| for any reason, return

--- a/index.bs
+++ b/index.bs
@@ -577,9 +577,6 @@ WebDriver BiDi extends the set of [=error codes=] from [[WEBDRIVER|WebDriver]]
 with the following additional codes:
 
 <dl>
-  <dt><dfn>invalid user context id</dfn>
-  <dd>Tried to use a [=user context=] that contradicts the provided reference context.
-
   <dt><dfn>no such handle</dfn>
   <dd>Tried to deserialize an unknown <code>RemoteObjectReference</code>.
 
@@ -620,7 +617,6 @@ with the following additional codes:
 <pre class="cddl local-cddl">
 ErrorCode = "invalid argument" /
             "invalid session id" /
-            "invalid user context id" /
             "move target out of bounds" /
             "no such alert" /
             "no such element" /
@@ -3038,29 +3034,31 @@ The [=remote end steps=] with |command parameters| are:
   1. If the implementation is unable to create a new browsing context for any
      reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-  1. Let |user context| be the [=default user context=] if |reference context| is null, and |reference context|' [=user context=] otherwise.
+  1. Let |user context| be the [=default user context=] if |reference context|
+     is null, and |reference context|' [=associated user context=] otherwise.
 
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
     1. Let |user context id| be |command parameters|[<code>userContext</code>].
 
-    1. If the [=user context=] with the [=user context id=] equal to |user context id| does
+    1. If the [=user context=] with the [=user context id=] |user context id| does
       not exist in the [=remote end=], return [=error=] with [=error code=] [=no such user context=].
 
-    1. Set |user context| to the [=user context=] with the [=user context id=] equal
-      to |user context id|.
+    1. Set |user context| to the [=user context=] with the [=user context id=] |user context id|.
 
-    1. If |reference context| is not null and |reference context|'s [=user context=] is not |user context|,
-      return [=error=] with [=error code=] [=invalid user context id=].
+  1. If the implementation is unable to create a new [=/top-level traversable=]
+     with [=associated user context=] |user context| for any reason, return
+     [=error=] with [=error code=] [=unsupported operation=].
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->
   1. Create a new [=top-level browsing context=] by running the [=window open
-     steps=] in the |user context| with <var ignore>url</var> set to
-     "<code>about:blank</code>", <var ignore>target</var> set to the empty
-     string, and <var ignore>features</var> set to "<code>noopener</code>".
-     Which OS window the new [=/browsing context=] is created in depends on
-     |type| and |reference context|:
+     steps=] with <var ignore>url</var> set to "<code>about:blank</code>", <var
+     ignore>target</var> set to the empty string, and <var ignore>features</var>
+     set to "<code>noopener</code>", and setting the [=associated user context=]
+     for the newly created [=/top-level traversable=] to |user context|. Which OS
+     window the new [=/browsing context=] is created in depends on |type| and
+     |reference context|:
 
      * If |type| is "<code>tab</code>" and the implementation supports
        multiple browsing contexts in the same OS window:

--- a/index.bs
+++ b/index.bs
@@ -597,6 +597,9 @@ with the following additional codes:
 
   <dt><dfn>no such storage partition</dfn>
   <dd>Tried to access data in a non-existent storage partition.
+  
+  <dt><dfn>no such user context</dfn>
+  <dd>Tried to reference an unknown [=user context=].
 
   <dt><dfn>unable to close browser</dfn>
   <dd>Tried to close the browser, but failed to do so.
@@ -625,6 +628,7 @@ ErrorCode = "invalid argument" /
             "no such request" /
             "no such script" /
             "no such storage partition" /
+            "no such user context" /
             "session not created" /
             "unable to capture screen" /
             "unable to close browser" /
@@ -2067,8 +2071,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |user context| be |command  parameters|["<code>userContext</code>"].
 
 1. If the [=user context=] with the [=user context id=] equal to |user context|
-   does not exist in the [=remote end=], return [=error=] with [=error code=]
-   [=invalid argument=]
+   does not exist in the [=remote end=], return [=error=] with [=error code=] [=no
+   such user context=].
 
 1. [=Close=] any [=top-level browsing contexts=] whose [=user context=]'s [=user
    context id=] is |user context| without [=prompting to unload=].

--- a/index.bs
+++ b/index.bs
@@ -1889,7 +1889,10 @@ managing the remote end browser process.
 
 <pre class="cddl remote-cddl">
 BrowserCommand = (
-  browser.Close
+  browser.Close,
+  browser.createUserContext,
+  browser.closeUserContext,
+  browser.getUserContexts,
 )
 </pre>
 
@@ -1901,6 +1904,26 @@ BrowserCommand = (
 
 
 ### Commands ### {#module-browser-commands}
+
+### Types ### {#module-browser-types}
+
+#### The browser.UserContext Type #### {#type-browser-UserContext}
+
+<pre class="cddl remote-cddl local-cddl">
+browser.UserContext = text;
+</pre>
+
+The <code>browser.UserContext</code> unique identifies a [=user context=].
+
+#### The browser.UserContextInfo Type #### {#type-browser-UserContextInfo}
+
+<pre class="cddl remote-cddl local-cddl">
+browser.UserContextInfo = (
+  userContext: browser.UserContext,
+)
+</pre>
+
+The <code>browser.UserContextInfo</code> type represents properties of a [=user context=].
 
 #### The browser.close Command #### {#command-browser-close}
 
@@ -2076,12 +2099,8 @@ The <dfn export for=commands>browser.getUserContexts</dfn> command returns a lis
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.UserContextInfo = (
-        userContext: browser.UserContext,
-      )
-      browser.UserContextInfoList = [*browser.UserContextInfo]
       browser.getUserContextsResult = {
-        userContexts: browser.UserContextInfoList
+        userContexts: [*browser.UserContextInfo]
       }
     </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -600,7 +600,7 @@ with the following additional codes:
 
   <dt><dfn>no such storage partition</dfn>
   <dd>Tried to access data in a non-existent storage partition.
-  
+
   <dt><dfn>no such user context</dfn>
   <dd>Tried to reference an unknown [=user context=].
 
@@ -2958,7 +2958,7 @@ The [=remote end steps=] with |command parameters| are:
     1. Set |user context| to the [=user context=] with the [=user context id=] equal
       to |user context id|.
 
-    1. If |reference context| is not null and |reference context|'s [=user context=] is not |user context|, 
+    1. If |reference context| is not null and |reference context|'s [=user context=] is not |user context|,
       return [=error=] with [=error code=] [=invalid user context id=].
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,

--- a/index.bs
+++ b/index.bs
@@ -1958,9 +1958,9 @@ The <code>browser.UserContext</code> unique identifies a [=user context=].
 #### The browser.UserContextInfo Type #### {#type-browser-UserContextInfo}
 
 <pre class="cddl remote-cddl local-cddl">
-browser.UserContextInfo = (
+browser.UserContextInfo = {
   userContext: browser.UserContext
-)
+}
 </pre>
 
 The <code>browser.UserContextInfo</code> type represents properties of a [=user

--- a/index.bs
+++ b/index.bs
@@ -3048,7 +3048,7 @@ The [=remote end steps=] with |command parameters| are:
 
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
-    1. Set |user context| to [=get user context=] with |command parameters|["<code>userContextId</code>"].
+    1. Set |user context| to [=get user context=] with |command parameters|["<code>userContext</code>"].
 
     1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 

--- a/index.bs
+++ b/index.bs
@@ -2083,7 +2083,7 @@ The [=remote end steps=] with |command parameters| are:
 
 #### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
 
-The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing user contexts in the user agent.
+The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing user contexts in the [=remote end=].
 
 <dl>
    <dt>Command Type</dt>
@@ -2991,7 +2991,7 @@ The [=remote end steps=] with |command parameters| are:
     1. Let |user context id| be |command parameters|[<code>userContext</code>].
 
     1. If the [=user context=] with the [=user context id=] equal to |user context id| does
-      not exist in the user agent, return [=error=] with [=error code=] [=invalid argument=].
+      not exist in the [=remote end=], return [=error=] with [=error code=] [=invalid argument=].
 
     1. Set |user context| to the [=user context=] with the [=user context id=] equal
       to |user context id|.

--- a/index.bs
+++ b/index.bs
@@ -2000,7 +2000,7 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
 #### The browser.createUserContext Command #### {#command-browser-createUserContext}
 
-The <dfn export for=commands>browser.createUserContext</dfn> command creates a [=user context=] in the user agent.
+The <dfn export for=commands>browser.createUserContext</dfn> command creates a [=user context=].
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -1981,7 +1981,7 @@ The <dfn export for=commands>browser.createPartition</dfn> command creates a sto
 
 #### The browser.closePartition Command #### {#command-browser-closePartition}
 
-The <dfn export for=commands>browser.closePartition</dfn> command closes the partition and all browsing contexts in it without running before unload handlers.
+The <dfn export for=commands>browser.closePartition</dfn> command closes the partition and all browsing contexts in it without running <code>beforeunload</code> handlers.
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -577,6 +577,9 @@ WebDriver BiDi extends the set of [=error codes=] from [[WEBDRIVER|WebDriver]]
 with the following additional codes:
 
 <dl>
+  <dt><dfn>invalid user context id</dfn>
+  <dd>Tried to use a [=user context=] that contradicts the provided reference context.
+
   <dt><dfn>no such handle</dfn>
   <dd>Tried to deserialize an unknown <code>RemoteObjectReference</code>.
 
@@ -617,6 +620,7 @@ with the following additional codes:
 <pre class="cddl local-cddl">
 ErrorCode = "invalid argument" /
             "invalid session id" /
+            "invalid user context id" /
             "move target out of bounds" /
             "no such alert" /
             "no such element" /
@@ -2939,17 +2943,20 @@ The [=remote end steps=] with |command parameters| are:
   1. If the implementation is unable to create a new browsing context for any
      reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-  1. Let |user context| be the [=default user context=].
+  1. Let |user context| be the [=default user context=] if |reference context| is null, and |reference context|' [=user context=] otherwise.
 
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
     1. Let |user context id| be |command parameters|[<code>userContext</code>].
 
     1. If the [=user context=] with the [=user context id=] equal to |user context id| does
-      not exist in the [=remote end=], return [=error=] with [=error code=] [=invalid argument=].
+      not exist in the [=remote end=], return [=error=] with [=error code=] [=no such user context=].
 
     1. Set |user context| to the [=user context=] with the [=user context id=] equal
       to |user context id|.
+
+    1. If |reference context| is not null and |reference context|'s [=user context=] is not |user context|, 
+      return [=error=] with [=error code=] [=invalid user context id=].
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->

--- a/index.bs
+++ b/index.bs
@@ -2052,9 +2052,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.createUserContextResult = {
-        userContext: browser.UserContext
-      }
+      browser.CreateUserContextResult = browser.UserContextInfo
     </pre>
    </dd>
 </dl>
@@ -2067,11 +2065,11 @@ The [=remote end steps=] are:
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
-1. Let |result| be a [=/map=] matching the
-   <code>browser.createUserContextResult</code> production with the
-   <code>userContext</code> field set to |user context|'s [=user context id=].
+1. Let |user context info| be a [=/map=] matching the
+    <code>browser.UserContextInfo</code> production with the
+    <code>userContext</code> field set to |user context|'s [=user context id=].
 
-1. Return [=success=] with data |result|.
+1. Return [=success=] with data |user context info|.
 
 </div>
 
@@ -2094,7 +2092,7 @@ list of [=user context=]s.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.getUserContextsResult = {
+      browser.GetUserContextsResult = {
         userContexts: [ + browser.UserContextInfo]
       }
     </pre>
@@ -2116,7 +2114,7 @@ The [=remote end steps=] are:
   1. [=list/Append=] |user context info| to |user contexts|.
 
 1. Let |result| be a [=/map=] matching the
-   <code>browser.getUserContextsResult</code> production with the
+   <code>browser.GetUserContextsResult</code> production with the
    <code>userContexts</code> field set to |user contexts|.
 
 1. Return [=success=] with data |result|.

--- a/index.bs
+++ b/index.bs
@@ -604,6 +604,9 @@ with the following additional codes:
   <dt><dfn>no such user context</dfn>
   <dd>Tried to reference an unknown [=user context=].
 
+  <dt><dfn>no such user context</dfn>
+  <dd>Tried to reference an unknown [=user context=].
+
   <dt><dfn>unable to close browser</dfn>
   <dd>Tried to close the browser, but failed to do so.
 

--- a/index.bs
+++ b/index.bs
@@ -1890,7 +1890,7 @@ managing the remote end browser process.
 BrowserCommand = (
   browser.Close,
   browser.CreateUserContext,
-  browser.CloseUserContext,
+  browser.RemoveUserContext,
   browser.GetUserContexts,
 )
 </pre>
@@ -1920,7 +1920,8 @@ browser.UserContextInfo = (
 )
 </pre>
 
-The <code>browser.UserContextInfo</code> type represents properties of a [=user context=].
+The <code>browser.UserContextInfo</code> type represents properties of a [=user
+context=].
 
 ### Commands ### {#module-browser-commands}
 
@@ -1999,7 +2000,8 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
 #### The browser.createUserContext Command #### {#command-browser-createUserContext}
 
-The <dfn export for=commands>browser.createUserContext</dfn> command creates a [=user context=].
+The <dfn export for=commands>browser.createUserContext</dfn> command creates a
+[=user context=].
 
 <dl>
    <dt>Command Type</dt>
@@ -2036,16 +2038,18 @@ The [=remote end steps=] are:
 
 </div>
 
-#### The browser.closeUserContext Command #### {#command-browser-closeUserContext}
+#### The browser.removeUserContext Command #### {#command-browser-removeUserContext}
 
-The <dfn export for=commands>browser.closeUserContext</dfn> command closes a user context and all browsing contexts in it without running <code>beforeunload</code> handlers.
+The <dfn export for=commands>browser.removeUserContext</dfn> command closes a
+user context and all browsing contexts in it without running
+<code>beforeunload</code> handlers.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browser.CloseUserContext = (
-        method: "browser.closeUserContext",
+      browser.RemoveUserContext = (
+        method: "browser.removeUserContext",
         params: {
           userContext: browser.UserContext
         },
@@ -2060,7 +2064,7 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes a use
    </dd>
 </dl>
 
-<div algorithm="remote end steps for browser.closeUserContext">
+<div algorithm="remote end steps for browser.removeUserContext">
 
 The [=remote end steps=] with |command parameters| are:
 

--- a/index.bs
+++ b/index.bs
@@ -1294,8 +1294,14 @@ Issue: Define how this works.
 # User Contexts # {#user-contexts}
 
 A <dfn>user context</dfn> represents a collection of top-level navigables within a remote
-end. Each top-level navigable belongs to exactly one user contexts, and child
-navigables belong to the same user context as their parent.
+end. Each top-level navigable belongs to exactly one user context, and child
+navigables belong to the same user context as their parent. A [=user context=] without
+navigables belonging to it is an <dfn>empty user context</dfn>. 
+
+The remote end always contains one [=user context=] referred as the <dfn>default user
+context</dfn>.
+
+Issue: Should we have a default user context?
 
 Each user context represents an additional [=storage key=], so that no storage
 state is shared between different user contexts.
@@ -1995,6 +2001,16 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a [
 
 <div algorithm="remote end steps for browser.createUserContext">
 
+The [=remote end steps=] are:
+
+1. Let |user context| be the result of performing implementation defined steps to create an [=empty user context=].
+
+1. Let |result| be a [=/map=] matching the
+   <code>browser.createUserContextResult</code> production with the <code>userContext</code>
+   field set to |user context|'s [=user context id=].
+
+1. Return [=success=] with data |result|.
+
 </div>
 
 #### The browser.closeUserContext Command #### {#command-browser-closeUserContext}
@@ -2015,11 +2031,9 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes a use
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
-      browser.closeUserContextResult = {
-        userContext: browser.UserContext
-      }
-    </pre>
+      <pre class="cddl">
+      EmptyResult
+      </pre>
    </dd>
 </dl>
 
@@ -2033,7 +2047,7 @@ The [=remote end steps=] with |command parameters| are:
 
    Issue: Do we need to define "find" to be able to combine it with [=trying=]?
 
-   Issue: Should we allow closing the default context?
+   Issue: Should we allow closing the default context? Probably not.
 
 1. [=Close=] any [=top-level browsing contexts=] contained that belong to the
    |user context| without [=prompting to unload=].
@@ -2077,7 +2091,8 @@ The <dfn export for=commands>browser.getUserContexts</dfn> command returns a lis
 
 The [=remote end steps=] are:
 
-1. Let |user contexts| be the result of implementation-specific steps to get [=user contexts=] from the user agent.
+1. Let |user contexts| be the result of performing implementation defined steps
+   to get [=user contexts=] from the user agent.
 
 1. Let |user context info list| be an empty [=/list=].
 
@@ -2278,6 +2293,10 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
+1. Let |user context| be null if |context| belongs to the [=default user
+   context=] or the [=user context id=] if the [=user context=] the |context|
+   belongs to otherwise.
+
 1. Let |child infos| be null.
 
 1. If |max depth| is null, or |max depth| is greater than 0:
@@ -2299,7 +2318,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
    if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, and the <code>children</code> field set to |child infos|.
+   field set to |url|, the <code>userContext</code> field set to |user context| and the <code>children</code> field set to |child infos|.
 
 1. Return |context info|.
 
@@ -2949,13 +2968,20 @@ The [=remote end steps=] with |command parameters| are:
   1. If the implementation is unable to create a new browsing context for any
      reason then return [=error=] with [=error code=] [=unsupported operation=].
 
+  1. Let |user context| be the [=default user context=].
+  
+  1. If |command parameters|[<code>userContext</code>] is present and is not null:
+
+    1. Let |user context| be the result of [=trying=] to find a [=user context=] whose [=user context id=] equals |command parameters|[<code>userContext</code>].
+
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->
   1. Create a new [=top-level browsing context=] by running the [=window open
-     steps=] with <var ignore>url</var> set to "<code>about:blank</code>",
-     <var ignore>target</var> set to the empty string, and
-     <var ignore>features</var> set to "<code>noopener</code>". Which OS window the new [=/browsing context=]
-     is created in depends on |type| and |reference context|:
+     steps=] in the |user context| with <var ignore>url</var> set to
+     "<code>about:blank</code>", <var ignore>target</var> set to the empty
+     string, and <var ignore>features</var> set to "<code>noopener</code>".
+     Which OS window the new [=/browsing context=] is created in depends on
+     |type| and |reference context|:
 
      * If |type| is "<code>tab</code>" and the implementation supports
        multiple browsing contexts in the same OS window:

--- a/index.bs
+++ b/index.bs
@@ -1293,9 +1293,10 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn interface>UserContext</dfn> is an aggregation of browsing contexts that separates the browsing contexts in one user context from browsing contexts in another user context.
+A <dfn>user context</dfn> is an aggregation of browsing contexts that separates the browser state for browsing contexts in one user context from browsing contexts in another user context.
+The user agent contains at least one user context, the <dfn>default user context</dfn>. 
 
-Note: User contexts are a WebDriver BiDi-specific equivalent to private browsing modes (https://www.w3.org/2001/tag/doc/private-browsing-modes/).
+Note: User contexts are a WebDriver-specific abstraction to allow working with private browsing modes (https://www.w3.org/2001/tag/doc/private-browsing-modes/).
 While we don't want to pose any restrictions on the implementations of private browsing modes, we want to allow to perform basic operations with private browsing
 contexts. A user context can be seen as a user agent in terms of the Infra spec but currently WebDriver BiDi spec is not compliant with that definition of the user agent.
 
@@ -1961,7 +1962,7 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
 #### The browser.createUserContext Command #### {#command-browser-createUserContext}
 
-The <dfn export for=commands>browser.createUserContext</dfn> command creates a {{UserContext}} of browsing contexts.
+The <dfn export for=commands>browser.createUserContext</dfn> command creates a [=user context=] in the user agent.
 
 <dl>
    <dt>Command Type</dt>
@@ -1989,7 +1990,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a {
 
 #### The browser.closeUserContext Command #### {#command-browser-closeUserContext}
 
-The <dfn export for=commands>browser.closeUserContext</dfn> command closes the userContext and all browsing contexts in it without running <code>beforeunload</code> handlers.
+The <dfn export for=commands>browser.closeUserContext</dfn> command closes a user context and all browsing contexts in it without running <code>beforeunload</code> handlers.
 
 <dl>
    <dt>Command Type</dt>
@@ -2019,7 +2020,7 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes the u
 
 #### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
 
-The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing userContexts in the browser instance.
+The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing user contexts in the user agent.
 
 <dl>
    <dt>Command Type</dt>
@@ -2046,6 +2047,27 @@ The <dfn export for=commands>browser.getUserContexts</dfn> command returns a lis
 </dl>
 
 <div algorithm="remote end steps for browser.getUserContexts">
+
+The [=remote end steps=] are:
+
+1. Let |user contexts| be the result of implementation-specific steps to get [=user contexts=] from the user agent.
+
+1. Let |user context info list| be an empty [=/list=].
+
+1. For each |user context| in |user contexts|:
+
+  1. If the |user context| is the [=default user context=], continue.
+
+  1. Let |info| be a [=/map=] matching the <code>browser.UserContextInfo</code>
+     production with the <code>userContext</code> field set to |user context|'s ID.
+
+  1. Append |info| to |user context info list|.
+
+1. Let |result| be a [=/map=] matching the
+   <code>browser.getUserContextsResult</code> production with the <code>userContexts</code>
+   field set to |user context info list|.
+
+1. Return [=success=] with data |result|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2064,19 +2064,22 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes a use
 
 The [=remote end steps=] with |command parameters| are:
 
-1. Let |user context| be the result of [=trying=] to find a [=user context=]
-   whose [=user context id=] equals |command
-   parameters|["<code>userContext</code>"].
+1. Let |user context| be |command  parameters|["<code>userContext</code>"].
 
-   Issue: Do we need to define "find" to be able to combine it with [=trying=]?
+1. If the [=user context=] with the [=user context id=] equal to |user context|
+   does not exist in the user agent, return [=error=] with [=error code=] [=invalid
+   argument=]
 
-   Issue: Should we allow closing the default context? Probably not.
-
-1. [=Close=] any [=top-level browsing contexts=] contained that belong to the
-   |user context| without [=prompting to unload=].
+1. [=Close=] any [=top-level browsing contexts=] that belong to the |user
+   context| without [=prompting to unload=].
 
     Note: This implicitly only affects browsing contexts that were under
     automation in the first place.
+
+    Issue: Should we allow closing the default context? Probably not.
+
+1. Perform implementation defined steps to remove the |user context| from the
+   user agent.
 
 1. Return [=success=] with data null.
 
@@ -2991,7 +2994,10 @@ The [=remote end steps=] with |command parameters| are:
   
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
-    1. Let |user context| be the result of [=trying=] to find a [=user context=] whose [=user context id=] equals |command parameters|[<code>userContext</code>].
+    1. Let |user context| be |command parameters|[<code>userContext</code>].
+
+    1. If the [=user context=] with the [=user context id=] equal to |user context| does 
+      not exist in the user agent, return [=error=] with [=error code=] [=invalid argument=].
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->

--- a/index.bs
+++ b/index.bs
@@ -2314,7 +2314,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. Let |user context| be undefined if |context| belongs to the [=default user
+1. Let |user context| be null if |context| belongs to the [=default user
    context=] or the [=user context id=] of the [=user context=] which the |context|
    belongs to otherwise.
 

--- a/index.bs
+++ b/index.bs
@@ -2316,7 +2316,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
    Note: This includes the fragment component of the URL.
 
 1. Let |user context| be null if |context| belongs to the [=default user
-   context=] or the [=user context id=] if the [=user context=] the |context|
+   context=] or the [=user context id=] of the [=user context=] which the |context|
    belongs to otherwise.
 
 1. Let |child infos| be null.

--- a/index.bs
+++ b/index.bs
@@ -2074,6 +2074,9 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |user context| be |command  parameters|["<code>userContext</code>"].
 
+1. If |user context| is <code>"default"</code>, return [=error=] with [=error
+   code=] [=invalid argument=].
+
 1. If the [=user context=] with the [=user context id=] equal to |user context|
    does not exist in the [=remote end=], return [=error=] with [=error code=] [=no
    such user context=].

--- a/index.bs
+++ b/index.bs
@@ -1951,6 +1951,96 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
 </div>
 
+#### The browser.createPartition Command #### {#command-browser-createPartition}
+
+The <dfn export for=commands>browser.createPartition</dfn> command creates a storage partition for a group of browsing contexts.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      browser.Close = (
+        method: "browser.createPartition",
+        params: EmptyParams,
+      )
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      browser.createPartitionResult = {
+        partition: browser.Partition
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browser.createPartition">
+
+</div>
+
+#### The browser.closePartition Command #### {#command-browser-closePartition}
+
+The <dfn export for=commands>browser.closePartition</dfn> command closes the partition and all browsing contexts in it without running before unload handlers.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      browser.Close = (
+        method: "browser.closePartition",
+        params: {
+          partition: browser.Partition
+        },
+      )
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      browser.closePartitionResult = {
+        partition: browser.Partition
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browser.closePartition">
+
+</div>
+
+#### The browser.getPartitions Command #### {#command-browser-getPartitions}
+
+The <dfn export for=commands>browser.getPartitions</dfn> command returns a list of existing partitions in the browser instance.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      browser.Close = (
+        method: "browser.getPartitions",
+        params: EmptyParams,
+      )
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      browser.PartitionInfo = (
+        partition: browser.Partition,
+      )
+      browser.PartitionInfoList = [*browser.PartitionInfo]
+      browser.getPartitionsResult = {
+        partitions: browser.PartitionInfoList
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browser.getPartitions">
+
+</div>
+
 ## The browsingContext Module ## {#module-browsingContext}
 
 The <dfn export for=modules>browsingContext</dfn> module contains commands and
@@ -2069,6 +2159,7 @@ browsingContext.Info = {
   url: text,
   children: browsingContext.InfoList / null
   ? parent: browsingContext.BrowsingContext / null,
+  ? partition: Browser.Partition / null
 }
 </pre>
 
@@ -2769,7 +2860,8 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
       browsingContext.CreateParameters = {
         type: browsingContext.CreateType,
         ? referenceContext: browsingContext.BrowsingContext,
-        ? background: bool .default false
+        ? background: bool .default false,
+        ? partition: Browser.Partition / null
       }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -1903,8 +1903,6 @@ BrowserCommand = (
 </pre>
 
 
-### Commands ### {#module-browser-commands}
-
 ### Types ### {#module-browser-types}
 
 #### The browser.UserContext Type #### {#type-browser-UserContext}
@@ -1924,6 +1922,8 @@ browser.UserContextInfo = (
 </pre>
 
 The <code>browser.UserContextInfo</code> type represents properties of a [=user context=].
+
+### Commands ### {#module-browser-commands}
 
 #### The browser.close Command #### {#command-browser-close}
 

--- a/index.bs
+++ b/index.bs
@@ -1293,10 +1293,10 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn>user context</dfn> represents a collection of top-level navigables within a 
+A <dfn>user context</dfn> represents a collection of top-level navigables within a
 [=remote end=]. Each top-level navigable belongs to exactly one user context, and child
 navigables belong to the same user context as their parent. A [=user context=] without
-navigables belonging to it is an <dfn>empty user context</dfn>. 
+navigables belonging to it is an <dfn>empty user context</dfn>.
 
 A [=remote end=] always contains one [=user context=] referred as the <dfn>default user
 context</dfn>.
@@ -1306,7 +1306,7 @@ state is shared between different user contexts.
 
 User contexts other than the [=default user context=] have a <dfn>user context
 id</dfn>, which is a string set upon context creation. The [=default user
-context=]'s does not have a [=user context id=]. 
+context=]'s does not have a [=user context id=].
 
 Note: the infra spec uses the term "user agent" to refer to the same concept as
 user contexts. However this is not compatible with usage of the term "user
@@ -1889,9 +1889,9 @@ managing the remote end browser process.
 <pre class="cddl remote-cddl">
 BrowserCommand = (
   browser.Close,
-  browser.createUserContext,
-  browser.closeUserContext,
-  browser.getUserContexts,
+  browser.CreateUserContext,
+  browser.CloseUserContext,
+  browser.GetUserContexts,
 )
 </pre>
 
@@ -2991,7 +2991,7 @@ The [=remote end steps=] with |command parameters| are:
      reason then return [=error=] with [=error code=] [=unsupported operation=].
 
   1. Let |user context| be the [=default user context=].
-  
+
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
     1. Let |user context id| be |command parameters|[<code>userContext</code>].
@@ -2999,7 +2999,7 @@ The [=remote end steps=] with |command parameters| are:
     1. If the [=user context=] with the [=user context id=] equal to |user context id| does
       not exist in the user agent, return [=error=] with [=error code=] [=invalid argument=].
 
-    1. Set |user context| to the [=user context=] with the [=user context id=] equal 
+    1. Set |user context| to the [=user context=] with the [=user context id=] equal
       to |user context id|.
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,

--- a/index.bs
+++ b/index.bs
@@ -1293,8 +1293,8 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn>user context</dfn> represents a collection of top-level navigables within a remote
-end. Each top-level navigable belongs to exactly one user context, and child
+A <dfn>user context</dfn> represents a collection of top-level navigables within a 
+[=remote end=]. Each top-level navigable belongs to exactly one user context, and child
 navigables belong to the same user context as their parent. A [=user context=] without
 navigables belonging to it is an <dfn>empty user context</dfn>. 
 

--- a/index.bs
+++ b/index.bs
@@ -2339,7 +2339,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
    if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, the <code>userContext</code> field set to |user context|
+   field set to |url|, the <code>userContext</code> field set to |user context| if it’s not null, or omitted otherwise,
    and the <code>children</code> field set to |child infos|.
 
 1. Return |context info|.

--- a/index.bs
+++ b/index.bs
@@ -2994,10 +2994,13 @@ The [=remote end steps=] with |command parameters| are:
   
   1. If |command parameters|[<code>userContext</code>] is present and is not null:
 
-    1. Let |user context| be |command parameters|[<code>userContext</code>].
+    1. Let |user context id| be |command parameters|[<code>userContext</code>].
 
-    1. If the [=user context=] with the [=user context id=] equal to |user context| does 
+    1. If the [=user context=] with the [=user context id=] equal to |user context id| does
       not exist in the user agent, return [=error=] with [=error code=] [=invalid argument=].
+
+    1. Set |user context| to the [=user context=] with the [=user context id=] equal 
+      to |user context id|.
 
   <!-- This is based on step 5 of https://w3c.github.io/webdriver/#new-window,
        but without using the "current browsing context" concept. -->

--- a/index.bs
+++ b/index.bs
@@ -1291,6 +1291,14 @@ access to that data in a {{Window}} global.
 
 Issue: Define how this works.
 
+# User Contexts # {#user-contexts}
+
+A <dfn interface>UserContext</dfn> is an aggregation of browsing contexts that separates the browsing contexts in one user context from browsing contexts in another user context.
+
+Note: User contexts are a WebDriver BiDi-specific equivalent to private browsing modes (https://www.w3.org/2001/tag/doc/private-browsing-modes/).
+While we don't want to pose any restrictions on the implementations of private browsing modes, we want to allow to perform basic operations with private browsing
+contexts. A user context can be seen as a user agent in terms of the Infra spec but currently WebDriver BiDi spec is not compliant with that definition of the user agent.
+
 # Modules # {#modules}
 
 ## The session Module ## {#module-session}
@@ -1951,16 +1959,16 @@ The [=remote end steps=] with |session| and <var ignore>command parameters</var>
 
 </div>
 
-#### The browser.createPartition Command #### {#command-browser-createPartition}
+#### The browser.createUserContext Command #### {#command-browser-createUserContext}
 
-The <dfn export for=commands>browser.createPartition</dfn> command creates a storage partition for a group of browsing contexts.
+The <dfn export for=commands>browser.createUserContext</dfn> command creates a {{UserContext}} of browsing contexts.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
       browser.Close = (
-        method: "browser.createPartition",
+        method: "browser.createUserContext",
         params: EmptyParams,
       )
       </pre>
@@ -1968,29 +1976,29 @@ The <dfn export for=commands>browser.createPartition</dfn> command creates a sto
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.createPartitionResult = {
-        partition: browser.Partition
+      browser.createUserContextResult = {
+        userContext: browser.UserContext
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for browser.createPartition">
+<div algorithm="remote end steps for browser.createUserContext">
 
 </div>
 
-#### The browser.closePartition Command #### {#command-browser-closePartition}
+#### The browser.closeUserContext Command #### {#command-browser-closeUserContext}
 
-The <dfn export for=commands>browser.closePartition</dfn> command closes the partition and all browsing contexts in it without running <code>beforeunload</code> handlers.
+The <dfn export for=commands>browser.closeUserContext</dfn> command closes the userContext and all browsing contexts in it without running <code>beforeunload</code> handlers.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
       browser.Close = (
-        method: "browser.closePartition",
+        method: "browser.closeUserContext",
         params: {
-          partition: browser.Partition
+          userContext: browser.UserContext
         },
       )
       </pre>
@@ -1998,27 +2006,27 @@ The <dfn export for=commands>browser.closePartition</dfn> command closes the par
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.closePartitionResult = {
-        partition: browser.Partition
+      browser.closeUserContextResult = {
+        userContext: browser.UserContext
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for browser.closePartition">
+<div algorithm="remote end steps for browser.closeUserContext">
 
 </div>
 
-#### The browser.getPartitions Command #### {#command-browser-getPartitions}
+#### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
 
-The <dfn export for=commands>browser.getPartitions</dfn> command returns a list of existing partitions in the browser instance.
+The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing userContexts in the browser instance.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
       browser.Close = (
-        method: "browser.getPartitions",
+        method: "browser.getUserContexts",
         params: EmptyParams,
       )
       </pre>
@@ -2026,18 +2034,18 @@ The <dfn export for=commands>browser.getPartitions</dfn> command returns a list 
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      browser.PartitionInfo = (
-        partition: browser.Partition,
+      browser.UserContextInfo = (
+        userContext: browser.UserContext,
       )
-      browser.PartitionInfoList = [*browser.PartitionInfo]
-      browser.getPartitionsResult = {
-        partitions: browser.PartitionInfoList
+      browser.UserContextInfoList = [*browser.UserContextInfo]
+      browser.getUserContextsResult = {
+        userContexts: browser.UserContextInfoList
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for browser.getPartitions">
+<div algorithm="remote end steps for browser.getUserContexts">
 
 </div>
 
@@ -2159,7 +2167,7 @@ browsingContext.Info = {
   url: text,
   children: browsingContext.InfoList / null
   ? parent: browsingContext.BrowsingContext / null,
-  ? partition: Browser.Partition / null
+  ? userContext: Browser.UserContext / null
 }
 </pre>
 
@@ -2861,7 +2869,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
         type: browsingContext.CreateType,
         ? referenceContext: browsingContext.BrowsingContext,
         ? background: bool .default false,
-        ? partition: Browser.Partition / null
+        ? userContext: Browser.UserContext / null
       }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -1891,8 +1891,7 @@ managing the remote end browser process.
 BrowserCommand = (
   browser.Close //
   browser.CreateUserContext //
-  browser.RemoveUserContext //
-  browser.GetUserContexts
+  browser.RemoveUserContext
 )
 </pre>
 
@@ -2078,54 +2077,6 @@ The [=remote end steps=] with |command parameters| are:
    [=remote end=].
 
 1. Return [=success=] with data null.
-
-</div>
-
-#### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
-
-The <dfn export for=commands>browser.getUserContexts</dfn> command returns a list of existing user contexts in the [=remote end=].
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-      <pre class="cddl remote-cddl">
-      browser.GetUserContexts = (
-        method: "browser.getUserContexts",
-        params: EmptyParams,
-      )
-      </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <pre class="cddl local-cddl">
-      browser.getUserContextsResult = {
-        userContexts: [*browser.UserContextInfo]
-      }
-    </pre>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for browser.getUserContexts">
-
-The [=remote end steps=] are:
-
-1. Let |user contexts| be the [=user contexts=] within the [=remote end=].
-
-1. Let |user context info list| be an empty [=/list=].
-
-1. For each |user context| in |user contexts|:
-
-  1. Let |info| be a [=/map=] matching the <code>browser.UserContextInfo</code>
-     production with the <code>userContext</code> field set to |user context|'s
-     [=user context id|id=].
-
-  1. Append |info| to |user context info list|.
-
-1. Let |result| be a [=/map=] matching the
-   <code>browser.getUserContextsResult</code> production with the <code>userContexts</code>
-   field set to |user context info list|.
-
-1. Return [=success=] with data |result|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2074,7 +2074,7 @@ The [=remote end steps=] with |command parameters| are:
 1. [=Close=] any [=top-level browsing contexts=] that belong to the |user
    context| without [=prompting to unload=].
 
-1. Perform implementation defined steps to remove the |user context| from the
+1. Perform implementation-defined steps to remove the |user context| from the
    user agent.
 
 1. Return [=success=] with data null.

--- a/index.bs
+++ b/index.bs
@@ -1301,13 +1301,12 @@ navigables belonging to it is an <dfn>empty user context</dfn>.
 A [=remote end=] always contains one [=user context=] referred as the <dfn>default user
 context</dfn>.
 
-Issue: Should we have a default user context?
-
 Each user context represents an additional [=storage key=], so that no storage
 state is shared between different user contexts.
 
-A user context has a <dfn>user context id</dfn>, which is a string set upon
-context creation.
+User contexts other than the [=default user context=] have a <dfn>user context
+id</dfn>, which is a string set upon context creation. The [=default user
+context=]'s does not have a [=user context id=]. 
 
 Note: the infra spec uses the term "user agent" to refer to the same concept as
 user contexts. However this is not compatible with usage of the term "user
@@ -2315,7 +2314,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
 
    Note: This includes the fragment component of the URL.
 
-1. Let |user context| be null if |context| belongs to the [=default user
+1. Let |user context| be undefined if |context| belongs to the [=default user
    context=] or the [=user context id=] of the [=user context=] which the |context|
    belongs to otherwise.
 
@@ -2340,7 +2339,8 @@ To <dfn>get the browsing context info</dfn> given |context|,
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
    if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
-   field set to |url|, the <code>userContext</code> field set to |user context| and the <code>children</code> field set to |child infos|.
+   field set to |url|, the <code>userContext</code> field set to |user context|
+   and the <code>children</code> field set to |child infos|.
 
 1. Return |context info|.
 

--- a/index.bs
+++ b/index.bs
@@ -1977,7 +1977,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a [
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browser.Close = (
+      browser.CreateUserContext = (
         method: "browser.createUserContext",
         params: EmptyParams,
       )
@@ -2005,7 +2005,7 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes a use
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browser.Close = (
+      browser.CloseUserContext = (
         method: "browser.closeUserContext",
         params: {
           userContext: browser.UserContext
@@ -2025,6 +2025,24 @@ The <dfn export for=commands>browser.closeUserContext</dfn> command closes a use
 
 <div algorithm="remote end steps for browser.closeUserContext">
 
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |user context| be the result of [=trying=] to find a [=user context=]
+   whose [=user context id=] equals |command
+   parameters|["<code>userContext</code>"].
+
+   Issue: Do we need to define "find" to be able to combine it with [=trying=]?
+
+   Issue: Should we allow closing the default context?
+
+1. [=Close=] any [=top-level browsing contexts=] contained that belong to the
+   |user context| without [=prompting to unload=].
+
+    Note: This implicitly only affects browsing contexts that were under
+    automation in the first place.
+
+1. Return [=success=] with data null.
+
 </div>
 
 #### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
@@ -2035,7 +2053,7 @@ The <dfn export for=commands>browser.getUserContexts</dfn> command returns a lis
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      browser.Close = (
+      browser.GetUserContexts = (
         method: "browser.getUserContexts",
         params: EmptyParams,
       )

--- a/index.bs
+++ b/index.bs
@@ -1293,12 +1293,21 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn>user context</dfn> is an aggregation of browsing contexts that separates the browser state for browsing contexts in one user context from browsing contexts in another user context.
-The user agent contains at least one user context, the <dfn>default user context</dfn>. 
+A <dfn>user context</dfn> represents a collection of top-level navigables within a remote
+end. Each top-level navigable belongs to exactly one user contexts, and child
+navigables belong to the same user context as their parent.
 
-Note: User contexts are a WebDriver-specific abstraction to allow working with private browsing modes (https://www.w3.org/2001/tag/doc/private-browsing-modes/).
-While we don't want to pose any restrictions on the implementations of private browsing modes, we want to allow to perform basic operations with private browsing
-contexts. A user context can be seen as a user agent in terms of the Infra spec but currently WebDriver BiDi spec is not compliant with that definition of the user agent.
+Each user context represents an additional [=storage key=], so that no storage
+state is shared between different user contexts.
+
+A user context has a <dfn>user context id</dfn>, which is a string set upon
+context creation.
+
+Note: the infra spec uses the term "user agent" to refer to the same concept as
+user contexts. However this is not compatible with usage of the term "user
+agent" to mean the entire web client, which may contain multiple user contexts.
+Although this difference is not visible to web content, it can be observed via
+WebDriver, so we avoid reusing existing terminology.
 
 # Modules # {#modules}
 
@@ -2056,10 +2065,8 @@ The [=remote end steps=] are:
 
 1. For each |user context| in |user contexts|:
 
-  1. If the |user context| is the [=default user context=], continue.
-
   1. Let |info| be a [=/map=] matching the <code>browser.UserContextInfo</code>
-     production with the <code>userContext</code> field set to |user context|'s ID.
+     production with the <code>userContext</code> field set to |user context|'s [=user context id=].
 
   1. Append |info| to |user context info list|.
 
@@ -2189,7 +2196,7 @@ browsingContext.Info = {
   url: text,
   children: browsingContext.InfoList / null
   ? parent: browsingContext.BrowsingContext / null,
-  ? userContext: Browser.UserContext / null
+  ? userContext: browser.UserContext / null
 }
 </pre>
 
@@ -2891,7 +2898,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
         type: browsingContext.CreateType,
         ? referenceContext: browsingContext.BrowsingContext,
         ? background: bool .default false,
-        ? userContext: Browser.UserContext / null
+        ? userContext: browser.UserContext / null
       }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -1293,26 +1293,27 @@ Issue: Define how this works.
 
 # User Contexts # {#user-contexts}
 
-A <dfn>user context</dfn> represents a collection of top-level navigables within a
-[=remote end=]. Each top-level navigable belongs to exactly one user context, and child
-navigables belong to the same user context as their parent. A [=user context=] without
-navigables belonging to it is an <dfn>empty user context</dfn>.
+A <dfn>user context</dfn> represents a collection of top-level navigables within
+a [=remote end=]. Each top-level navigable belongs to exactly one [=user
+context=], and child navigables belong to the same [=user context=] as their
+parent. A [=user context=] without navigables belonging to it is an <dfn>empty
+user context</dfn>.
 
-A [=remote end=] always contains one [=user context=] referred as the <dfn>default user
-context</dfn>.
+A [=remote end=] always contains at least one [=user context=] referred as the
+<dfn>default user context</dfn>.
 
-Each user context represents an additional [=storage key=], so that no storage
-state is shared between different user contexts.
+Each [=user context=] represents an additional [=storage key=], so that no
+storage state is shared between different [=user context|user contexts=].
 
-User contexts other than the [=default user context=] have a <dfn>user context
-id</dfn>, which is a string set upon context creation. The [=default user
-context=]'s does not have a [=user context id=].
+A [=user context=] other than the [=default user context=] has a <dfn>user
+context id</dfn>, which is a string set upon context creation. The [=default
+user context=] does not have a [=user context id=].
 
-Note: the infra spec uses the term "user agent" to refer to the same concept as
-user contexts. However this is not compatible with usage of the term "user
-agent" to mean the entire web client, which may contain multiple user contexts.
-Although this difference is not visible to web content, it can be observed via
-WebDriver, so we avoid reusing existing terminology.
+Note: The infra spec uses the term "user agent" to refer to the same concept as
+[=user context|user contexts=]. However, this is not compatible with usage of
+the term "user agent" to mean the entire web client with multiple [=user
+context|user contexts=]. Although this difference is not visible to web content,
+it is observed via WebDriver, so we avoid reusing existing terminology.
 
 # Modules # {#modules}
 
@@ -2068,14 +2069,14 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |user context| be |command  parameters|["<code>userContext</code>"].
 
 1. If the [=user context=] with the [=user context id=] equal to |user context|
-   does not exist in the user agent, return [=error=] with [=error code=] [=invalid
-   argument=]
+   does not exist in the user agent, return [=error=] with [=error code=]
+   [=invalid argument=]
 
 1. [=Close=] any [=top-level browsing contexts=] that belong to the |user
    context| without [=prompting to unload=].
 
-1. Perform implementation-defined steps to remove the |user context| from the
-   user agent.
+1. Perform implementation-defined steps to remove |user context| from the user
+   agent.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -1298,7 +1298,7 @@ end. Each top-level navigable belongs to exactly one user context, and child
 navigables belong to the same user context as their parent. A [=user context=] without
 navigables belonging to it is an <dfn>empty user context</dfn>. 
 
-The remote end always contains one [=user context=] referred as the <dfn>default user
+A [=remote end=] always contains one [=user context=] referred as the <dfn>default user
 context</dfn>.
 
 Issue: Should we have a default user context?

--- a/index.bs
+++ b/index.bs
@@ -1296,8 +1296,8 @@ Issue: Define how this works.
 A <dfn>user context</dfn> represents a collection of top-level navigables within
 a [=remote end=]. User contexts have a <dfn>user context id</dfn>, which is a
 string set upon the user context creation. The [=default user context=]'s [=user
-context id|id=] is <code>"default"</code>. A [=remote end=] always contains at
-least one [=user context=] referred as the <dfn>default user context</dfn>.
+context id|id=] is <code>"default"</code>. A [=remote end=] always contains one
+[=user context=] referred as the <dfn>default user context</dfn>.
 
 Each top-level navigable belongs to exactly one [=user context=], and child
 navigables belong to the same [=user context=] as their parent. Each navigable's

--- a/index.bs
+++ b/index.bs
@@ -1933,6 +1933,7 @@ managing the remote end browser process.
 BrowserCommand = (
   browser.Close //
   browser.CreateUserContext //
+  browser.GetUserContexts //
   browser.RemoveUserContext
 )
 </pre>
@@ -1958,7 +1959,7 @@ The <code>browser.UserContext</code> unique identifies a [=user context=].
 
 <pre class="cddl remote-cddl local-cddl">
 browser.UserContextInfo = (
-  userContext: browser.UserContext,
+  userContext: browser.UserContext
 )
 </pre>
 
@@ -2077,6 +2078,55 @@ The [=remote end steps=] are:
 1. Return [=success=] with data |result|.
 
 </div>
+
+
+#### The browser.getUserContexts Command #### {#command-browser-getUserContexts}
+
+The <dfn export for=commands>browser.getUserContexts</dfn> command returns a
+list of [=user context=]s.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      browser.GetUserContexts = (
+        method: "browser.getUserContexts",
+        params: EmptyParams,
+      )
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      browser.getUserContextsResult = {
+        userContexts: [ + browser.UserContextInfo]
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browser.getUserContexts">
+
+The [=remote end steps=] are:
+
+1. Let |user contexts| be an empty [=/list=].
+
+1. For each |user context| in the [=set of user contexts=]:
+
+  1. Let |user context info| be a [=/map=] matching the
+     <code>browser.UserContextInfo</code> production with the
+     <code>userContext</code> field set to |user context|'s [=user context id=].
+
+  1. [=list/Append=] |user context info| to |user contexts|.
+
+1. Let |result| be a [=/map=] matching the
+   <code>browser.getUserContextsResult</code> production with the
+   <code>userContexts</code> field set to |user contexts|.
+
+1. Return [=success=] with data |result|.
+
+</div>
+
 
 #### The browser.removeUserContext Command #### {#command-browser-removeUserContext}
 

--- a/index.bs
+++ b/index.bs
@@ -2250,7 +2250,7 @@ browsingContext.Info = {
   url: text,
   children: browsingContext.InfoList / null
   ? parent: browsingContext.BrowsingContext / null,
-  ? userContext: browser.UserContext / null
+  ? userContext: browser.UserContext
 }
 </pre>
 


### PR DESCRIPTION
User Contexts allow basic isolation of the web content state and parallelization of test runs without paying the costs of launching a fresh/multiple browser processes. In this proposal, there is no session created for the user context: multiple user contexts are managed by the same session. The advantage is that the same session can create a fresh state for its operations. In practical terms, we want to have something that would allow us to implement https://pptr.dev/api/puppeteer.browsercontext/#example In Chrome, that corresponds to an incognito window (but you can have multiple for automation). 

Issue https://github.com/w3c/webdriver-bidi/issues/289

Related links:
- Latest discussion: https://www.w3.org/2023/09/15-webdriver-minutes.html#t02
- https://github.com/whatwg/infra/issues/400
- https://www.w3.org/2001/tag/doc/private-browsing-modes/
- https://gist.github.com/mnot/96440a5ca74fcf328d23

Open questions/TODOs:

- [ ] move to the storage domain?
- [ ] support for context names?
- [ ] define what happens to contexts if the browser is closed


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/570.html" title="Last updated on Jan 19, 2024, 12:09 PM UTC (253d3eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/570/6462133...253d3eb.html" title="Last updated on Jan 19, 2024, 12:09 PM UTC (253d3eb)">Diff</a>