### PR TITLE
`script.addPreloadScripts` don't allow empty contexts list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7605,7 +7605,7 @@ script=].
       script.AddPreloadScriptParameters = {
         functionDeclaration: text,
         ? arguments: [*script.ChannelValue],
-        ? contexts: [*browsingContext.BrowsingContext],
+        ? contexts: [+browsingContext.BrowsingContext],
         ? sandbox: text
       }
       </pre>


### PR DESCRIPTION
Found at https://github.com/web-platform-tests/wpt/pull/41932.
There is an edge case with the `contexts` parameter in `script.addPreloadScripts`.
If you provide an empty list to the parameter the script will never run.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/webdriver-bidi/pull/577.html" title="Last updated on Oct 24, 2023, 2:25 PM UTC (70feaca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/577/6b2b25c...Lightning00Blade:70feaca.html" title="Last updated on Oct 24, 2023, 2:25 PM UTC (70feaca)">Diff</a>