### PR TITLE
Serialize entire browsing context tree for contextDestroyed events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3229,7 +3229,7 @@ Define the following [=browsing context tree discarded=] steps:
 1. Let |context| be the browsing context being discarded.
 
 1. Let |params| be the result of [=get the browsing context info=], given
-   |context|, 0, and true.
+   |context|, null, and true.
 
 1. Let |body| be a [=/map=] matching the
     <code>browsingContext.ContextDestroyed</code> production, with the


### PR DESCRIPTION
When multiple navigables / contexts are destroyed at once we only emit a single event. To ensure that that the client gets information about every context that's destroyed, send the whole context tree in that event, rather than just the topmost context.

Closes https://github.com/w3c/webdriver-bidi/issues/573


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/578.html" title="Last updated on Oct 24, 2023, 2:59 PM UTC (110dc7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/578/cf8c89a...110dc7e.html" title="Last updated on Oct 24, 2023, 2:59 PM UTC (110dc7e)">Diff</a>