### PR TITLE
editorial: fix Script.InternalId type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7149,7 +7149,7 @@ script.RemoteValue = (
   script.WindowProxyRemoteValue
 )
 
-script.InternalId = js-uint;
+script.InternalId = text;
 
 script.ListRemoteValue = [*script.RemoteValue];
 

--- a/index.bs
+++ b/index.bs
@@ -6402,6 +6402,19 @@ the ECMAScript runtime. The handle is only valid in a specific [=Realm=].
 Each ECMAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong [=/map=] from handle ids to their corresponding objects.
 
+#### The script.InternalId Type #### {#type-script-InternalId}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+script.InternalId = text;
+</pre>
+
+The <code>script.InternalId</code> type represents the id of 
+a previously serialized <code>script.RemoteValue</code> during
+[=serialize as a remote value|serialization=].
+
+
 #### The script.LocalValue Type #### {#type-script-LocalValue}
 
 [=Remote end definition=]
@@ -7148,8 +7161,6 @@ script.RemoteValue = (
   script.NodeRemoteValue /
   script.WindowProxyRemoteValue
 )
-
-script.InternalId = text;
 
 script.ListRemoteValue = [*script.RemoteValue];
 

--- a/index.bs
+++ b/index.bs
@@ -7395,10 +7395,10 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
     1. If |previously serialized remote value| does not have a field
        <code>internalId</code>, run the following steps:
 
-      1. Let |internal id| be a unique across the <code>internalId</code> fields of
-         the values of |serialization internal map| integer.
+      1. Let |internal id| be the string representation of a [[!RFC4122|UUID]] 
+         based on truly random, or pseudo-random numbers.
 
-       1. Set the <code>internalId</code> field of
+      1. Set the <code>internalId</code> field of
           |previously serialized remote value| to |internal id|.
 
     1. Set the <code>internalId</code> field of |remote value| to a field


### PR DESCRIPTION
We always define Ids as text, this is an exception, we should change this.
Note: Both Chromium and Firefox return strings atm


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/webdriver-bidi/pull/583.html" title="Last updated on Nov 6, 2023, 3:47 PM UTC (8068535)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/583/a7adbf0...Lightning00Blade:8068535.html" title="Last updated on Nov 6, 2023, 3:47 PM UTC (8068535)">Diff</a>