### PR TITLE
editorial: export "extension modules" definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -466,10 +466,10 @@ in the <code>ResultData</code> group for the results of commands in the module.
 Modules which contain events define [=local end definition=] fragments that are
 choices in the <code>Event</code> group for the module's [=events=].
 
-An implementation may define <dfn>extension modules</dfn>. These must have a
+An implementation may define <dfn export>extension modules</dfn>. These must have a
 [=module name=] that contains a single colon "<code>:</code>" character. The
 part before the colon is the prefix; this is typically the same for all
-extension modules specific to a given implementation and should be unique for a
+[=extension modules=] specific to a given implementation and should be unique for a
 given implementation. Such modules extend the [=local end definition=] and [=remote end definition=]
 providing additional groups as choices for the defined [=commands=] and [=events=].
 


### PR DESCRIPTION
So that it can be referred from other specs.

Currently there is no definition we can refer to in `webdriver-bidi`: https://respec.org/xref/?term=extension+modules, unlike in WebDriver classic which has an exported "extension commands" definition.

Bug: #506
Bug: #587


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/591.html" title="Last updated on Nov 6, 2023, 1:26 PM UTC (2f1d0b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/591/a7adbf0...2f1d0b3.html" title="Last updated on Nov 6, 2023, 1:26 PM UTC (2f1d0b3)">Diff</a>