### PR TITLE
editorial: export more definitions for extension modules

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -325,7 +325,7 @@ protocol. These terms are distinct from their representation at the
 
 The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
 convenience of implementors two separate CDDL definitions are defined; the
-<dfn>remote end definition</dfn> which defines the format of messages produced
+<dfn export>remote end definition</dfn> which defines the format of messages produced
 on the [=local end=] and consumed on the [=remote end=], and the <dfn>local end
 definition</dfn> which defines the format of messages produced on the [=remote end=]
 and consumed on the [=local end=]
@@ -1920,7 +1920,7 @@ associated WebDriver [=window handle=] the [=/browsing context id=] must be the
 same as the [=window handle=].
 
 <div algorithm>
-To <dfn>get a browsing context</dfn> given |context id|:
+To <dfn export>get a browsing context</dfn> given |context id|:
 
 1. If |context id| is null, return [=success=] with data null.
 


### PR DESCRIPTION
So that they can be referenced from other specs.

Bug: #506
Bug: #587
Bug: https://github.com/w3c/permissions/pull/425


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/593.html" title="Last updated on Nov 6, 2023, 4:46 PM UTC (51bcbc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/593/7fef95c...51bcbc1.html" title="Last updated on Nov 6, 2023, 4:46 PM UTC (51bcbc1)">Diff</a>