### PR TITLE
Rename field in cookie representation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4407,7 +4407,7 @@ samesite-flag, which is from [[SAME-SITE-COOKIES]].
 
 1. Let |path| be |stored cookie|'s path field.
 
-1. Let |expiry| be |stored cookie|'s expires field represented as a unix
+1. Let |expiry| be |stored cookie|'s expiry-time field represented as a unix
    timestamp, if set, or null otherwise.
 
 1. Let |size| be the byte length of the result of serializing |stored cookie|

--- a/index.bs
+++ b/index.bs
@@ -4387,7 +4387,7 @@ network.Cookie = {
     httpOnly: bool,
     secure: bool,
     sameSite: "strict" / "lax" / "none",
-    ? expires: js-uint,
+    ? expiry: js-uint,
 };
 </pre>
 
@@ -4407,7 +4407,7 @@ samesite-flag, which is from [[SAME-SITE-COOKIES]].
 
 1. Let |path| be |stored cookie|'s path field.
 
-1. Let |expires| be |stored cookie|'s expires field represented as a unix
+1. Let |expiry| be |stored cookie|'s expires field represented as a unix
    timestamp, if set, or null otherwise.
 
 1. Let |size| be the byte length of the result of serializing |stored cookie|
@@ -4426,8 +4426,8 @@ samesite-flag, which is from [[SAME-SITE-COOKIES]].
 1. Return a map matching the <code>network.Cookie</code> production,
    with the <code>name</code> field set to |name|, the <code>value</code> field
    set to |value|, the <code>domain</code> field set to |domain|, the
-   <code>path</code> field set to |path|, the <code>expires</code> field set to
-   |expires| if it's not null, or omitted otherwise, the <code>size</code> field
+   <code>path</code> field set to |path|, the <code>expiry</code> field set to
+   |expiry| if it's not null, or omitted otherwise, the <code>size</code> field
    set to |size|, the <code>httpOnly</code> field set to |http only|, the
    <code>secure</code> field set to |secure|, and the <code>sameSite</code>
    field set to |same site|.
@@ -4902,7 +4902,7 @@ network.SetCookieHeader = {
     value: network.BytesValue,
     ? domain: text,
     ? httpOnly: bool,
-    ? expires: text,
+    ? expiry: text,
     ? maxAge: js-int,
     ? path: text,
     ? sameSite: "strict" / "lax" / "none",
@@ -4959,11 +4959,11 @@ To <dfn>serialize set-cookie header</dfn> given |protocol cookie|:
 1. Let |header value| be the [=byte sequence=] formed by concatenating |name|,
    `<code>=</code>`, and |value|.
 
-1. If |protocol cookie| [=map/contains=] "<code>expires</code>:
+1. If |protocol cookie| [=map/contains=] "<code>expiry</code>:
 
   1. Let |attribute| be `<code>;Expires=</code>`
 
-  1. Append [=UTF-8 encode=] |protocol cookie|["<code>expires</code>"] to
+  1. Append [=UTF-8 encode=] |protocol cookie|["<code>expiry</code>"] to
      |attribute|.
 
   1. Append |attribute| to |header value|.


### PR DESCRIPTION
From @sadym-chromium in [gh-501](https://github.com/w3c/webdriver-bidi/pull/501#discussion_r1383254805):

> I believe it's not too late for changing the [BiDi's `network.Cookie`](https://w3c.github.io/webdriver-bidi/#type-network-Cookie) "expires" to "expiry" to align with WebDriver Classic.

WebDriver Classic uses "expiry" as the "JSON key" to represent the RFC 6265 field called "expiry-time" [^1]. Rename the field in WebDriver BiDi's corresponding types to promote coherence and facilitate additional normative references to that specification.

[^1]: https://w3c.github.io/webdriver/#dfn-table-for-cookie-conversion

Also, correct reference to RFC 6265 field. The RFC uses the name "expires" for the attribute in the Set-Cookie header--not the field of the cookie within the storage model.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/596.html" title="Last updated on Nov 8, 2023, 11:10 PM UTC (58957cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/596/61ea9ac...bocoup:58957cf.html" title="Last updated on Nov 8, 2023, 11:10 PM UTC (58957cf)">Diff</a>