### PR TITLE
Editorial: fix/refactor capabilities

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1458,52 +1458,37 @@ session.ProxyConfiguration = {
 }
 
 session.AutodetectProxyConfiguration = (
-   ; Indicates that the proxy to use should be detected in an
-   ; implementation-specific way.
    proxyType: "autodetect"
    Extensible
 )
 
 session.DirectProxyConfiguration = (
-   ; Indicates that the browser should not use a proxy at all.
    proxyType: "direct",
    Extensible
 )
 
 session.ManualProxyConfiguration = (
-   ; Indicates a manual proxy configuration.
    proxyType: "manual",
-   ; Defines the proxy host for FTP traffic.
    ? ftpProxy: text,
-   ; Defines the proxy host for HTTP traffic.
    ? httpProxy: text,
-   ; Defines the proxy host for encrypted TLS traffic.
    ? sslProxy: text,
-   ; Defines the proxy host for a SOCKS proxy.
    ? session.SocksProxyConfiguration
-   ; Lists the address for which the proxy should be bypassed.
    ? noProxy: [*text],
    Extensible
 )
 
 session.SocksProxyConfiguration = (
-   ; Defines the proxy host for a SOCKS proxy.
    socksProxy: text,
-   ; Defines the SOCKS proxy version.
    socksVersion: 0..255,
 )
 
 session.PacProxyConfiguration = (
-   ; Indicates that the proxy to use is defined by the proxyAutoconfigUrl.
    proxyType: "pac",
-   ; Defines the URL for a proxy auto-config file
    proxyAutoconfigUrl: text,
    Extensible
 )
 
 session.SystemProxyConfiguration = (
-   ; Indicates that the browser should use the various proxies configured
-   ; for the underlying Operating System.
    proxyType: "system"
    Extensible
 )
@@ -1603,21 +1588,12 @@ This is a [=static command=].
       session.NewResult = {
         sessionId: text,
         capabilities: {
-          ; Initially set to false, indicates the session will not implicitly
-          ; trust untrusted or self-signed TLS certificates on navigation.
           acceptInsecureCerts: bool,
-          ; ASCII Lowercase name of the user agent as a string.
           browserName: text,
-          ; The user agent version, as a string.
           browserVersion: text,
-          ; ASCII Lowercase name of the current platform as a string.
           platformName: text,
-          ; Indicates whether the remote end supports all of the resizing and
-          ; positioning commands.
           setWindowRect: bool,
-          ; Defined when the request defines a "proxy".
           ? proxy: session.ProxyConfiguration,
-          ; Defined when the request defined a "webSocketUrl"
           ? webSocketUrl: bool,
           Extensible
         }

--- a/index.bs
+++ b/index.bs
@@ -1466,7 +1466,7 @@ session.AutodetectProxyConfiguration = (
 
 session.DirectProxyConfiguration = (
    ; Indicates that the browser should not use a proxy at all.
-   proxyType: "direct"
+   proxyType: "direct",
    Extensible
 )
 

--- a/index.bs
+++ b/index.bs
@@ -1067,33 +1067,8 @@ To <dfn>close the WebSocket connections</dfn> given |session|:
 
 ## Establishing a Connection ## {#establishing}
 
-WebDriver clients opt in to a bidirectional connection by requesting a
-capability with the name "<code>webSocketUrl</code>" and value
-true.
-
-This specification defines an
-[=additional webdriver capability=] with the [=capability name=] "<code>webSocketUrl</code>".
-
-<div algorithm="webSocketUrl capability deserialization algorithm">
-The [=additional capability deserialization algorithm=] for the
-"<code>webSocketUrl</code>" capability, with parameter |value| is:
-
-1. If |value| is not a boolean, return [=error=] with [=error code|code=]
-   [=invalid argument=].
-
-1. Return [=success=] with data |value|.
-
-</div>
-
-<div algorithm="webSocketUrl capability serialization algorithm">
-The [=matched capability serialization algorithm=] for the "<code>webSocketUrl</code>" capability,
-with parameter |value| is:
-
-1. If |value| is false, return [=success=] with data null.
-
-1. Return [=success=] with data true.
-
-</div>
+WebDriver clients opt in to a bidirectional connection by requesting the
+[=WebSocket URL=] capability with value true.
 
 <div algorithm="webSocketUrl new session algorithm">
 The [=WebDriver new session algorithm=] defined by this specification,
@@ -1428,22 +1403,112 @@ session.CapabilityRequest = {
   ? browserName: text,
   ? browserVersion: text,
   ? platformName: text,
-  ? proxy: {
-    ? proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
-    ? proxyAutoconfigUrl: text,
-    ? ftpProxy: text,
-    ? httpProxy: text,
-    ? noProxy: [*text],
-    ? sslProxy: text,
-    ? socksProxy: text,
-    ? socksVersion: 0..255,
-  },
+  ? proxy: session.ProxyConfiguration,
+  ? webSocketUrl: bool,
   Extensible
 };
 </pre>
 
 The <code>session.CapabilityRequest</code> type represents a specific set of
 requested capabilities.
+
+WebDriver BiDi defines [=additional WebDriver capability|additional WebDriver
+capabilities=]. The following tables enumerates the capabilities each
+implementation must support for WebDriver BiDi.
+
+<pre class=simpledef>
+Capability: <dfn export>WebSocket URL</dfn>
+Key: "<code>webSocketUrl</code>"
+Value type: boolean
+Description: Defines the current session's support for bidirection connection.
+</pre>
+
+<div algorithm="webSocketUrl capability deserialization algorithm">
+The [=additional capability deserialization algorithm=] for the
+"<code>webSocketUrl</code>" capability, with parameter |value| is:
+
+1. If |value| is not a boolean, return [=error=] with [=error code|code=]
+   [=invalid argument=].
+
+1. Return [=success=] with data |value|.
+
+</div>
+
+<div algorithm="webSocketUrl capability serialization algorithm">
+The [=matched capability serialization algorithm=] for the "<code>webSocketUrl</code>" capability,
+with parameter |value| is:
+
+1. If |value| is false, return [=success=] with data null.
+
+1. Return [=success=] with data true.
+
+</div>
+
+#### The session.ProxyConfiguration Type #### {#type-session-ProxyConfiguration}
+
+[=remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+session.ProxyConfiguration = {
+   session.AutodetectProxyConfiguration //
+   session.DirectProxyConfiguration //
+   session.ManualProxyConfiguration //
+   session.PacProxyConfiguration //
+   session.SystemProxyConfiguration //
+}
+
+session.AutodetectProxyConfiguration = (
+   ; Indicates that the proxy to use should be detected in an
+   ; implementation-specific way.
+   proxyType: "autodetect"
+   Extensible
+)
+
+session.DirectProxyConfiguration = (
+   ; Indicates that the browser should not use a proxy at all.
+   proxyType: "direct"
+   Extensible
+)
+
+session.ManualProxyConfiguration = (
+   ; Indicates a manual proxy configuration.
+   proxyType: "manual",
+   ; Defines the proxy host for FTP traffic.
+   ? ftpProxy: text,
+   ; Defines the proxy host for HTTP traffic.
+   ? httpProxy: text,
+   ; Defines the proxy host for encrypted TLS traffic.
+   ? sslProxy: text,
+   ; Defines the proxy host for a SOCKS proxy.
+   ? session.SocksProxyConfiguration
+   ; Lists the address for which the proxy should be bypassed.
+   ? noProxy: [*text],
+   Extensible
+)
+
+session.SocksProxyConfiguration = (
+   ; Defines the proxy host for a SOCKS proxy.
+   socksProxy: text,
+   ; Defines the SOCKS proxy version.
+   socksVersion: 0..255,
+)
+
+session.PacProxyConfiguration = (
+   ; Indicates that the proxy to use is defined by the proxyAutoconfigUrl.
+   proxyType: "pac",
+   ; Defines the URL for a proxy auto-config file
+   proxyAutoconfigUrl: text,
+   Extensible
+)
+
+session.SystemProxyConfiguration = (
+   ; Indicates that the browser should use the various proxies configured
+   ; for the underlying Operating System.
+   proxyType: "system"
+   Extensible
+)
+
+</pre>
 
 #### The session.SubscriptionRequest Type #### {#type-session-SubscriptionRequest}
 
@@ -1538,21 +1603,22 @@ This is a [=static command=].
       session.NewResult = {
         sessionId: text,
         capabilities: {
+          ; Initially set to false, indicates the session will not implicitly
+          ; trust untrusted or self-signed TLS certificates on navigation.
           acceptInsecureCerts: bool,
+          ; ASCII Lowercase name of the user agent as a string.
           browserName: text,
+          ; The user agent version, as a string.
           browserVersion: text,
+          ; ASCII Lowercase name of the current platform as a string.
           platformName: text,
-          proxy: {
-            ? proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
-            ? proxyAutoconfigUrl: text,
-            ? ftpProxy: text,
-            ? httpProxy: text,
-            ? noProxy: [*text],
-            ? sslProxy: text,
-            ? socksProxy: text,
-            ? socksVersion: 0..255,
-          },
+          ; Indicates whether the remote end supports all of the resizing and
+          ; positioning commands.
           setWindowRect: bool,
+          ; Defined when the request defines a "proxy".
+          ? proxy: session.ProxyConfiguration,
+          ; Defined when the request defined a "webSocketUrl"
+          ? webSocketUrl: bool,
           Extensible
         }
       }


### PR DESCRIPTION
This PR moves out the proxy configuration into a separate type and splits it further for the correct semantics. It also moves "webSocketUrl" algorithms to the capabilities section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/598.html" title="Last updated on Nov 16, 2023, 1:05 PM UTC (7ff6bc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/598/5395e5d...7ff6bc8.html" title="Last updated on Nov 16, 2023, 1:05 PM UTC (7ff6bc8)">Diff</a>