### PR TITLE
(cddl): remove brackets from range

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3222,7 +3222,7 @@ PDF document represented as a Base64-encoded string.
         ? orientation: ("portrait" / "landscape") .default "portrait",
         ? page: browsingContext.PrintPageParameters,
         ? pageRanges: [*(js-uint / text)],
-        ? scale: (0.1..2.0) .default 1.0,
+        ? scale: 0.1..2.0 .default 1.0,
         ? shrinkToFit: bool .default true,
       }
 
@@ -3422,7 +3422,7 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command  specific
       browsingContext.SetViewportParameters = {
         context: browsingContext.BrowsingContext,
         ? viewport: browsingContext.Viewport / null,
-        ? devicePixelRatio: (float .gt 0.0) / null,
+        ? devicePixelRatio: float .gt 0.0 / null,
       }
 
       browsingContext.Viewport = {
@@ -9444,11 +9444,11 @@ specified sequence of user input actions.
         ? height: js-uint .default 1,
         ? pressure: float .default 0.0,
         ? tangentialPressure: float .default 0.0,
-        ? twist: (0..359) .default 0,
+        ? twist: 0..359 .default 0,
         ; 0 .. Math.PI / 2
-        ? altitudeAngle: (0.0..1.5707963267948966) .default 0.0,
+        ? altitudeAngle: 0.0..1.5707963267948966 .default 0.0,
         ; 0 .. 2 * Math.PI
-        ? azimuthAngle: (0.0..6.283185307179586) .default 0.0,
+        ? azimuthAngle: 0.0..6.283185307179586 .default 0.0,
       )
 
       input.Origin = "viewport" / "pointer" / input.ElementOrigin


### PR DESCRIPTION
I can't really read of the CDDL spec whether or not extra brackets around type primitives, e.g. ranges, can be ignored or not but if we assume not, an opening bracket (especially as part of a key assignment) creates a group that has to consist of a key value pair and can't be a single type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/599.html" title="Last updated on Nov 9, 2023, 7:34 PM UTC (95a979a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/599/d327638...95a979a.html" title="Last updated on Nov 9, 2023, 7:34 PM UTC (95a979a)">Diff</a>