### PR TITLE
(cddl): merging groups

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7313,14 +7313,16 @@ script.FunctionRemoteValue = {
 }
 
 script.RegExpRemoteValue = {
+  script.RegExpLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-} .and script.RegExpLocalValue
+}
 
 script.DateRemoteValue = {
+  script.DateLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-} .and script.DateLocalValue
+}
 
 script.MapRemoteValue = {
   type: "map",


### PR DESCRIPTION
In 2.1 of the [cddl spec](https://datatracker.ietf.org/doc/rfc8610/) it is defined how groups can be merged together:

> Groups can be used to factor out common parts of structs, e.g.,
   instead of writing specifications in copy/paste style, such as in
   Figure 5, one can factor out the common subgroup, choose a name for
   it, and write only the specific parts into the individual maps
   (Figure 6).

While the `.and` type describes the same:

>    A ".and" control on a type indicates that the data item matches both
   the left-hand-side type and the type given as the right-hand side.
   (Formally, the resulting type is the intersection of the two types
   given.)

      "type1 .and type2"

I don't think it can be used in the context when a group is assigned to a variable especially as we can just use the format described in 2.1.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/600.html" title="Last updated on Nov 9, 2023, 7:29 PM UTC (2785795)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/600/d327638...2785795.html" title="Last updated on Nov 9, 2023, 7:29 PM UTC (2785795)">Diff</a>