### PR TITLE
ci: introduce pre-commit integration

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+# https://github.com/pre-commit/action
+
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: 'main'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+#
+# Install pre-commit itself:
+#   $ pip install pre-commit
+#     OR
+#   $ brew install pre-commit
+#
+# Update all pre-commit hooks to latest version:
+#   $ pre-commit autoupdate
+#
+# Install all pre-commit hooks locally:
+#   $ pre-commit install
+#
+# Apply a given pre-commit hook to all files:
+#   $ pre-commit run --all-files <id>
+#
+# Apply all pre-commit hooks to all files:
+#   $ pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,11 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell

--- a/index.bs
+++ b/index.bs
@@ -328,7 +328,7 @@ protocol. These terms are distinct from their representation at the
 <a href=#transport>transport</a> layer.
 
 The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
-convenience of implementors two separate CDDL definitions are defined; the
+convenience of implementers two separate CDDL definitions are defined; the
 <dfn export>remote end definition</dfn> which defines the format of messages produced
 on the [=local end=] and consumed on the [=remote end=], and the <dfn>local end
 definition</dfn> which defines the format of messages produced on the [=remote end=]
@@ -1154,7 +1154,7 @@ implemented as native objects in the main implementation language of the browser
 engine) and the ECMAScript-visible state. Because existing sandbox
 implementations happen at a low level in the engine, implementations converging
 toward the specification in all details might be a slow process. In the
-meantime, implementors are encouraged to provide detailed documentation on any
+meantime, implementers are encouraged to provide detailed documentation on any
 differences with the specification, and users of this feature are encouraged to
 explicitly test that scripts running in sandboxes work in all implementations.
 
@@ -2553,7 +2553,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
           |clip|["<code>height</code>"].
      </dl>
 
-1. Note: All coordiantes are now measured from the origin of the document.
+1. Note: All coordinates are now measured from the origin of the document.
 
 1. Let |rect| be the [=rectangle intersection=] of |origin rect| and |clip rect|.
 
@@ -5051,7 +5051,7 @@ A <code>network.UrlPattern</code> represents a pattern used for matching request
 URLs for [=network intercepts=].
 
 When URLs are matched against a <code>network.UrlPattern</code> the URL is
-parsed, and each component is comapred for equality with the corresponding field
+parsed, and each component is compared for equality with the corresponding field
 in the pattern, if present. Missing fields from the pattern always match.
 
 Note: This syntax is designed with future extensibility in mind. In particular

--- a/roadmap.md
+++ b/roadmap.md
@@ -110,7 +110,7 @@ This scenario sets cookies to be used when loading a web page and its subresourc
 
 ### Managing windows
 
-This scenario changes the browser window dimensions and position, maximizes/minimizes the window, and toggles full-screen mode while testing the side effects of these actions on the web page. 
+This scenario changes the browser window dimensions and position, maximizes/minimizes the window, and toggles full-screen mode while testing the side effects of these actions on the web page.
 
 - [x] Some items from the previous milestones
 - [ ] [Add commands for resizing and positioning browser windows](https://github.com/w3c/webdriver-bidi/issues/398)


### PR DESCRIPTION
Follow-up-of: #442

At the very least, this should help eliminate bikeshedding of trailing whitespace and English spelling.

There's no need to install anything locally. This will show up as an optional (non-blocking) check / action in future PRs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/604.html" title="Last updated on Nov 16, 2023, 11:15 AM UTC (40407cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/604/1108ab2...40407cd.html" title="Last updated on Nov 16, 2023, 11:15 AM UTC (40407cd)">Diff</a>