### PR TITLE
Use `text / true` for `webSocketUrl`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1594,7 +1594,7 @@ This is a [=static command=].
           platformName: text,
           setWindowRect: bool,
           ? proxy: session.ProxyConfiguration,
-          ? webSocketUrl: bool,
+          ? webSocketUrl: text / true,
           Extensible
         }
       }


### PR DESCRIPTION
See https://w3c.github.io/webdriver/#ref-for-dfn-remote-end-steps-6

In step 4 we process capabilities and (assuming there's a match and we're starting a websocket connection), end up with an object that contains {webSocketUrl: true}.

In step 9 we call into https://w3c.github.io/webdriver-bidi/#establishing which updates the capabilities object so that it contains the actual URL as the value of the webSocketUrl property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/606.html" title="Last updated on Nov 17, 2023, 10:46 AM UTC (d564aa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/606/ffbf706...d564aa0.html" title="Last updated on Nov 17, 2023, 10:46 AM UTC (d564aa0)">Diff</a>