### PR TITLE
editorial: remove trailing whitespace

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9630,7 +9630,7 @@ end:
 </div>
 ## Console ##  {#patches-console}
 
-Other specifications can define <dfn>console steps</dfn>. 
+Other specifications can define <dfn>console steps</dfn>.
 
 1. At the point when the [=Printer=] operation is called with
    arguments |name|, |printerArgs| and |options| (which is undefined if the


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/607.html" title="Last updated on Nov 17, 2023, 2:14 PM UTC (a22071a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/607/19777fa...a22071a.html" title="Last updated on Nov 17, 2023, 2:14 PM UTC (a22071a)">Diff</a>