### PR TITLE
Normative: correct locator handling of "max depth"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3055,7 +3055,9 @@ and |session|:
 
     1. Otherwise, perform the following steps:
 
-      1. Set |max depth| to |max depth| - 1.
+      1. If |max depth| is not null:
+
+        1. Set |max depth| to |max depth| - 1.
 
       1. Let |child node matches| be the result of [=locate nodes using inner text=]
          with |context target|, |child nodes|, |selector|, |max depth|,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/611.html" title="Last updated on Nov 22, 2023, 9:41 PM UTC (0a9684d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/611/829057e...bocoup:0a9684d.html" title="Last updated on Nov 22, 2023, 9:41 PM UTC (0a9684d)">Diff</a>