### PR TITLE
Restrict cddl to version 0.9.1 because of broken cli command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,11 @@ jobs:
         with:
           node-version: 16
       - name: Get cddl version
-        run: curl -s https://crates.io/api/v1/crates/cddl | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_stable_version'])" | tee cddl.txt
+        # Remove strict version requirement here and in the test script
+        # once the CLI command works again.
+        # See: https://github.com/anweiss/cddl/issues/213
+        # run: curl -s https://crates.io/api/v1/crates/cddl | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_stable_version'])" | tee cddl.txt
+        run: echo "0.9.1" > cddl.txt
       - name: "Cache rust binaries"
         uses: actions/cache@v3
         id: cache-cddl

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 /index.html
 *.cddl

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,9 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 
 if ! [ -x "$(command -v cddl)" ] || [ "$1" = "--upgrade" ]; then
   echo 'Installing cddl'
-  cargo install cddl
+  # Remove strict version requirement once the CLI command works again
+  # See: https://github.com/anweiss/cddl/issues/213
+  cargo install cddl --version 0.9.1
 fi
 
 if [[ "$(npm list parse5)" =~ "empty" ]] || [ "$1" = "--upgrade" ]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,8 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 
 if ! [ -x "$(command -v cddl)" ] || [ "$1" = "--upgrade" ]; then
   echo 'Installing cddl'
-  # Remove strict version requirement once the CLI command works again
+  # Remove strict version requirement here and for the Rust cache
+  # once the CLI command works again.
   # See: https://github.com/anweiss/cddl/issues/213
   cargo install cddl --version 0.9.1
 fi


### PR DESCRIPTION
Closes #614.

<strike>We most likely need to clear the cache on GitHub to get this version installed.</strike> With my changes I've also forced the Rust cache to use version 0.9.1.