### PR TITLE
Revert "Force Rust cache for GitHub workflow to cddl version 0.9.1"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,7 @@ jobs:
         with:
           node-version: 16
       - name: Get cddl version
-        # Remove strict version requirement here and in the test script
-        # once the CLI command works again.
-        # See: https://github.com/anweiss/cddl/issues/213
-        # run: curl -s https://crates.io/api/v1/crates/cddl | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_stable_version'])" | tee cddl.txt
-        run: echo "0.9.1" > cddl.txt
+        run: curl -s https://crates.io/api/v1/crates/cddl | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_stable_version'])" | tee cddl.txt
       - name: "Cache rust binaries"
         uses: actions/cache@v3
         id: cache-cddl

--- a/index.bs
+++ b/index.bs
@@ -6443,7 +6443,7 @@ used to send custom messages from the [=remote end=] to the [=local end=].
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl remote-cddl local-cddl">
 script.ChannelValue = {
   type: "channel",
   value: script.ChannelProperties,
@@ -6591,7 +6591,7 @@ a previously serialized <code>script.RemoteValue</code> during
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl remote-cddl local-cddl">
 script.LocalValue = (
   script.RemoteReference /
   script.PrimitiveProtocolValue /
@@ -7198,7 +7198,7 @@ The <code>script.RealmType</code> type represents the different types of Realm.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl remote-cddl local-cddl">
 <!-- This is specifically ordered in the order in which matches need to be -->
 <!-- evaluated, since the definitions are overlapping -->
 script.RemoteReference = (
@@ -8020,7 +8020,7 @@ ownership will be treated.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl remote-cddl local-cddl">
 script.SerializationOptions = {
   ? maxDomDepth: (js-uint / null) .default 0,
   ? maxObjectDepth: (js-uint / null) .default null,

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,8 +6,7 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 
 if ! [ -x "$(command -v cddl)" ] || [ "$1" = "--upgrade" ]; then
   echo 'Installing cddl'
-  # Remove strict version requirement here and for the Rust cache
-  # once the CLI command works again.
+  # Remove strict version requirement once the CLI command works again
   # See: https://github.com/anweiss/cddl/issues/213
   cargo install cddl --version 0.9.1
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,9 +6,7 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 
 if ! [ -x "$(command -v cddl)" ] || [ "$1" = "--upgrade" ]; then
   echo 'Installing cddl'
-  # Remove strict version requirement once the CLI command works again
-  # See: https://github.com/anweiss/cddl/issues/213
-  cargo install cddl --version 0.9.1
+  cargo install cddl
 fi
 
 if [[ "$(npm list parse5)" =~ "empty" ]] || [ "$1" = "--upgrade" ]; then


### PR DESCRIPTION
This reverts commit 9ddaeb4ee371c843d96d8b94a3c1efe19e9e70a2 because a new [cddl 0.9.4 release](https://github.com/anweiss/cddl/releases/tag/0.9.4) with the fix is out.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/622.html" title="Last updated on Dec 14, 2023, 4:54 PM UTC (662bd5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/622/9ddaeb4...whimboo:662bd5b.html" title="Last updated on Dec 14, 2023, 4:54 PM UTC (662bd5b)">Diff</a>