### PR TITLE
Update serialization steps for return value of "browsingContext.locateNodes" command to align with

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3174,9 +3174,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
    let |result ownership| be |command parameters|["<code>ownership</code>"].
    Otherwise, let |result ownership| be "none".
 
-1. Let |serialized nodes| be the result of [=serialize as a remote value=] with
-   |result nodes|, |serialization options|, |result ownership|, a new [=/map=]
-   as serialization internal map, |realm| and |session|.
+1. Let |serialized nodes| be an empty [=/list=].
+
+1. For each |result node| in |result nodes|:
+
+   1. Let |serialized node| be the result of [=serialize as a remote value=] with
+      |result node|, |serialization options|, |result ownership|, a new [=/map=]
+      as serialization internal map, |realm| and |session|.
+
+   1. [=list/Append=] |serialized node| to |serialized nodes|.
 
 1. Let |result| be a [=/map=] matching the <code>browsingContext.LocateNodesResult</code>
    production, with the <code>nodes</code> field set |serialized nodes|.


### PR DESCRIPTION
At the moment, [the spec for "browsingContext.locateNodes" command](https://w3c.github.io/webdriver-bidi/#command-browsingContext-locateNodes)(step 18) says that we should serialize the list of the nodes, which would mean that the response would look like:
```
{ type: “array”, handle: “handle id”, value: [{type: “node”, sharedId: “shared id”, …}, …]} }
```
Where, [in the merged tests](https://github.com/web-platform-tests/wpt/blob/master/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py#L23), the expectation output should look like: 
```
[{type: “node”, sharedId: “shared id”, handle: “handle id”, …}, …]
```
That also looks like more something clients would expect. To achieve the output specified in the tests, we should rather serialize each node individually and push them in the list after.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/623.html" title="Last updated on Dec 18, 2023, 3:28 PM UTC (38ef6d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/623/1935bea...lutien:38ef6d6.html" title="Last updated on Dec 18, 2023, 3:28 PM UTC (38ef6d6)">Diff</a>