### PR TITLE
Specify a locator for accessible role

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,6 +246,9 @@ spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
+spec: WAI-ARIA; urlPrefix:https://w3c.github.io/aria/
+  type: dfn
+    text: WAI-ARIA role; url: #introroles
 </pre>
 
 <pre class="biblio">
@@ -2187,6 +2190,7 @@ To <dfn>await a navigation</dfn> given |context|, |request|, |wait condition|, a
 browsingContext.Locator = (
    browsingContext.CssLocator /
    browsingContext.InnerTextLocator /
+   browsingContext.RoleLocator /
    browsingContext.XPathLocator
 )
 
@@ -2201,6 +2205,11 @@ browsingContext.InnerTextLocator = {
    ? ignoreCase: bool
    ? matchType: "full" / "partial",
    ? maxDepth: js-uint,
+}
+
+browsingContext.RoleLocator = {
+   type: "role",
+   value: text
 }
 
 browsingContext.XPathLocator = {
@@ -3076,6 +3085,41 @@ and |session|:
 
 </div>
 
+<div algorithm="locate nodes using role">
+To <dfn>locate nodes using role</dfn> with given |context nodes|, |selector|,
+|maximum returned node count|, and |session|:
+
+1. If |selector| is the empty string, return [=error=] with [=error code=]
+   [=invalid selector=].
+
+1. Let |returned nodes| be an empty [=/list=].
+
+1. For each |context node| in |context nodes|:
+
+  1. Let |role| be the result of computing the [=WAI-ARIA role=] of |context node|.
+
+  1. If |selector| [=is=] |role|:
+
+    1. [=list/Append=] |context node| to |returned nodes|.
+
+  1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
+     <a spec=dom>children</a> of |context node|:
+
+    1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
+
+  1. Let |child node matches| be the result of [=locate nodes using role=]
+     with |child nodes|, |selector|, |maximum returned node count|, and |session|.
+
+  1. [=list/Extend=] |returned nodes| with |child node matches|.
+
+1. If |maximum returned node count| is not null, [=list/remove=] all entries
+   in |returned nodes| with an index greater than or equal to |maximum returned
+   node count|.
+
+1. Return [=success=] with data |returned nodes|.
+
+</div>
+
 <div algorithm="remote end steps for browsingContext.locateNodes">
 The [=remote end steps=] with |session| and |command parameters| are:
 
@@ -3160,6 +3204,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using inner text=]
             given |current context target|, |context nodes|, |selector|, |max depth|,
             |match type|, |ignore case|, |maximum returned node count| and |session|.
+
+      <dt>|type| is the string "<code>role</code>"
+      <dd>
+         1. Let |selector| be |locator|["<code>value</code>"].
+
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using role=]
+            given |context nodes|, |selector|, |maximum returned node count| and
+            |session|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.


### PR DESCRIPTION
I've referenced [the definition of "role" in WAI-ARIA](https://w3c.github.io/aria/#introroles) because [that's how WebDriver explains the computation of a role given an element](https://w3c.github.io/webdriver/#get-computed-role), but [computedrole from CORE-AAM](https://www.w3.org/TR/core-aam-1.2/#roleMappingComputedRole) seems more appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/624.html" title="Last updated on Dec 19, 2023, 3:30 AM UTC (ba4ce76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/624/46d0bc1...bocoup:ba4ce76.html" title="Last updated on Dec 19, 2023, 3:30 AM UTC (ba4ce76)">Diff</a>