### PR TITLE
Remove unused parameter from "inner text" locator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3015,7 +3015,7 @@ without going via the ECMAScript runtime.
 </div>
 
 <div algorithm="locate nodes using inner text">
-To <dfn>locate nodes using inner text</dfn> with given |context target|, |context nodes|,
+To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 |selector|, |max depth|, |match type|, |ignore case|, |maximum returned node count|,
 and |session|:
 
@@ -3061,8 +3061,8 @@ and |session|:
         1. Set |max depth| to |max depth| - 1.
 
       1. Let |child node matches| be the result of [=locate nodes using inner text=]
-         with |context target|, |child nodes|, |selector|, |max depth|,
-         |match type|, |ignore case|, |maximum returned node count|, and |session|.
+         with |child nodes|, |selector|, |max depth|, |match type|,
+         |ignore case|, |maximum returned node count|, and |session|.
 
       1. If [=list/size=] of |child node matches| is equal to 0 and |match type| is
          <code>"partial"</code>, append |context node| to |returned nodes|. Otherwise,
@@ -3158,8 +3158,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
             |locator|["<code>matchType</code>"]. Otherwise, let |match type| be "full".
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using inner text=]
-            given |current context target|, |context nodes|, |selector|, |max depth|,
-            |match type|, |ignore case|, |maximum returned node count| and |session|.
+            given |context nodes|, |selector|, |max depth|, |match type|,
+            |ignore case|, |maximum returned node count| and |session|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/625.html" title="Last updated on Dec 19, 2023, 3:38 AM UTC (8787ba9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/625/46d0bc1...bocoup:8787ba9.html" title="Last updated on Dec 19, 2023, 3:38 AM UTC (8787ba9)">Diff</a>