### PR TITLE
Normalize types of values returned by locators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2965,9 +2965,9 @@ To <dfn>locate nodes using CSS</dfn> with given |context target|, |context nodes
 
     1. If |maximum returned node count| is not null and [=list/size=] of
        |returned nodes| is equal to |maximum returned node count|,
-       return |returned nodes|.
+       return [=success=] with data |returned nodes|.
 
-1. Return |returned nodes|.
+1. Return [=success=] with data |returned nodes|.
 
 </div>
 
@@ -3006,11 +3006,11 @@ without going via the ECMAScript runtime.
 
       1. If |maximum returned node count| not null and [=list/size=] of
          |returned nodes| is equal to |maximum returned node count|,
-         return |returned nodes|.
+         return [=success=] with data |returned nodes|.
 
       1. Set |index| to |index| + 1.
 
-1. Return |returned nodes|.
+1. Return [=success=] with data |returned nodes|.
 
 </div>
 
@@ -3072,7 +3072,7 @@ and |session|:
    in |returned nodes| with an index greater than or equal to |maximum returned
    node count|.
 
-1. Return |returned nodes|.
+1. Return [=success=] with data |returned nodes|.
 
 </div>
 


### PR DESCRIPTION
Consistently return a WebDriver "error" type or a WebDriver "success" type to support invocation of these algorithms using WebDriver's "try".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/626.html" title="Last updated on Dec 19, 2023, 3:45 AM UTC (25a7e9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/626/46d0bc1...bocoup:25a7e9a.html" title="Last updated on Dec 19, 2023, 3:45 AM UTC (25a7e9a)">Diff</a>