### PR TITLE
Update blocked requests map in authRequired & responseStarted

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6030,6 +6030,8 @@ steps given |request| and |response|:
     <!-- We can ignore the return value here, since we update response -->
     1. [=Await=] with «"<code>continue request</code>"», and |request id|.
 
+    1. [=map/Remove=] |blocked requests|[|request id|].
+
 </div>
 
 #### The network.beforeRequestSent Event #### {#event-network-beforeSendRequest}
@@ -6303,6 +6305,8 @@ started</dfn> steps given |request| and |response|:
        |request id|.
 
     1. If |status| is "<code>complete</code>", set |response status| to |status|.
+
+    1. [=map/Remove=] |blocked requests|[|request id|].
 
 1. Return (|response|, |response status|).
 


### PR DESCRIPTION
Fixes #615 

Removes the entry corresponding to request id at the end of the authRequired and responseStarted events.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/629.html" title="Last updated on Dec 19, 2023, 5:17 PM UTC (ccc3f46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/629/bb3f568...juliandescottes:ccc3f46.html" title="Last updated on Dec 19, 2023, 5:17 PM UTC (ccc3f46)">Diff</a>