### PR TITLE
Remove "worker" and "worklet" realm types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7017,10 +7017,8 @@ script.RealmInfo = (
   script.DedicatedWorkerRealmInfo /
   script.SharedWorkerRealmInfo /
   script.ServiceWorkerRealmInfo /
-  script.WorkerRealmInfo /
   script.PaintWorkletRealmInfo /
-  script.AudioWorkletRealmInfo /
-  script.WorkletRealmInfo
+  script.AudioWorkletRealmInfo
 )
 
 script.BaseRealmInfo = (
@@ -7053,11 +7051,6 @@ script.ServiceWorkerRealmInfo = {
   owners: [*script.Realm]
 }
 
-script.WorkerRealmInfo = {
-  script.BaseRealmInfo,
-  type: "worker"
-}
-
 script.PaintWorkletRealmInfo = {
   script.BaseRealmInfo,
   type: "paint-worklet"
@@ -7066,11 +7059,6 @@ script.PaintWorkletRealmInfo = {
 script.AudioWorkletRealmInfo = {
   script.BaseRealmInfo,
   type: "audio-worklet"
-}
-
-script.WorkletRealmInfo = {
-  script.BaseRealmInfo,
-  type: "worklet"
 }
 </pre>
 
@@ -7222,7 +7210,7 @@ Note: Future variations of this specification will retain the invariant that
 
 <pre class="cddl remote-cddl local-cddl">
 script.RealmType = "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
-                   "worker" / "paint-worklet" / "audio-worklet" / "worklet"
+                   "paint-worklet" / "audio-worklet"
 </pre>
 
 The <code>script.RealmType</code> type represents the different types of Realm.


### PR DESCRIPTION
These types are never created since their specialized types are already enumerated as realm types.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: connect ETIMEDOUT 128.30.52.141:443 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 5, 2024, 11:27 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fwebdriver-bidi%2Fpull%2F632%2Fd3ec8cb.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fwebdriver-bidi%2Fpull%2F632.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23632.)._
</details>
