### PR TITLE
Remove unused value for `webSocketUrl`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1601,7 +1601,7 @@ This is a [=static command=].
           platformName: text,
           setWindowRect: bool,
           ? proxy: session.ProxyConfiguration,
-          ? webSocketUrl: text / true,
+          ? webSocketUrl: text,
           Extensible
         }
       }


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/633.html" title="Last updated on Jan 5, 2024, 2:37 PM UTC (8314810)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/633/d3ec8cb...8314810.html" title="Last updated on Jan 5, 2024, 2:37 PM UTC (8314810)">Diff</a>