### PR TITLE
Make `network.Cookie` extensible

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4597,6 +4597,7 @@ network.Cookie = {
     secure: bool,
     sameSite: network.SameSite,
     ? expiry: js-uint,
+    Extensible,
 };
 </pre>
 


### PR DESCRIPTION
In order to be able using generated types and provide some vendor-specific fields (like `goog:sameParty`), it would be very useful to have the `cookies` type explicitly extensible.