### PR TITLE
Add `unable to set file input` to error enum

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -623,6 +623,7 @@ ErrorCode = "invalid argument" /
             "unable to capture screen" /
             "unable to close browser" /
             "unable to set cookie" /
+            "unable to set file input" /
             "underspecified storage partition" /
             "unknown command" /
             "unknown error" /


### PR DESCRIPTION
This was forgotten in the `Input.setFiles` PR.