### PR TITLE
Fix handling of userContext field for browsingContext.create

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3014,7 +3014,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
         type: browsingContext.CreateType,
         ? referenceContext: browsingContext.BrowsingContext,
         ? background: bool .default false,
-        ? userContext: browser.UserContext / null
+        ? userContext: browser.UserContext
       }
       </pre>
    </dd>
@@ -3050,11 +3050,13 @@ The [=remote end steps=] with |command parameters| are:
   1. Let |user context| be the [=default user context=] if |reference context|
      is null, and |reference context|' [=associated user context=] otherwise.
 
-  1. If |command parameters|[<code>userContext</code>] is present and is not null:
+  1. Let |user context id| be the value of the <code>userContext</code> field of
+     |command parameters| if present, or null otherwise.
 
-    1. Set |user context| to [=get user context=] with |command parameters|["<code>userContext</code>"].
+  1. If |user context id| is not null, set |user context| to the result of
+     [=trying=] to [=get user context=] with |user context id|.
 
-    1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
+  1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
   1. If the implementation is unable to create a new [=/top-level traversable=]
      with [=associated user context=] |user context| for any reason, return


### PR DESCRIPTION
Basically `Undefined` is not used at all and as such it is enough to have the `userContext` as optional argument.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/650.html" title="Last updated on Jan 31, 2024, 3:51 PM UTC (7ffcf12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/650/fa78e30...whimboo:7ffcf12.html" title="Last updated on Jan 31, 2024, 3:51 PM UTC (7ffcf12)">Diff</a>