### PR TITLE
Remove `owners` for shared and service workers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7120,14 +7120,12 @@ script.DedicatedWorkerRealmInfo = {
 
 script.SharedWorkerRealmInfo = {
   script.BaseRealmInfo,
-  type: "shared-worker",
-  owners: [+script.Realm]
+  type: "shared-worker"
 }
 
 script.ServiceWorkerRealmInfo = {
   script.BaseRealmInfo,
   type: "service-worker"
-  owners: [*script.Realm]
 }
 
 script.WorkerRealmInfo = {
@@ -7242,18 +7240,15 @@ To <dfn>get the realm info</dfn> given |environment settings|:
 
     <dt>|global object| is a {{SharedWorkerGlobalScope}} object
     <dd>
-      1. Let |owners| be the result of [=get the worker's owners=] given |global object|.
-      1. Assert: |owners| has at least one item.
       1. Let |realm info| be a [=/map=] matching the <code>script.SharedWorkerRealmInfo</code> production,
-         with the <code>realm</code> field set to |realm id|, the <code>origin</code> field
-         set to |origin|, and the <code>owners</code> field set to |owners|.
+         with the <code>realm</code> field set to |realm id|, and the <code>origin</code> field
+         set to |origin|.
 
     <dt>|global object| is a {{ServiceWorkerGlobalScope}} object
     <dd>
-      1. Let |owners| be the result of [=get the worker's owners=] given |global object|.
       1. Let |realm info| be a [=/map=] matching the <code>script.ServiceWorkerRealmInfo</code> production,
-         with the <code>realm</code> field set to |realm id|, the <code>origin</code> field
-         set to |origin|, and the <code>owners</code> field set to |owners|.
+         with the <code>realm</code> field set to |realm id|, and the <code>origin</code> field
+         set to |origin|.
 
    <dt>|global object| is a {{WorkerGlobalScope}} object
    <dd>


### PR DESCRIPTION
This PR removes the `owners` property for shared and service workers.

For shared and service workers, the `owners` property makes little sense since the set of owners is dynamic. In particular, to properly implement the `owners` property, we would need another lifecycle method such as `script.RealmUpdated` which contains updates to the list of owners. As of now, we've never come across the need inspecting ownership of service and shared worker owners, so removing this and adding it when the use-case arises may be more beneficial for implementors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/651.html" title="Last updated on Jan 31, 2024, 10:21 PM UTC (760fbd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/651/6462133...760fbd7.html" title="Last updated on Jan 31, 2024, 10:21 PM UTC (760fbd7)">Diff</a>