### PR TITLE
Add a capability for returning the default user agent header value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -269,9 +269,6 @@ spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
-spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: default User-Agent value; url: #default-user-agent-value
 </pre>
 
 <pre class="biblio">
@@ -1572,13 +1569,6 @@ Value type: boolean
 Description: Defines the current session's support for bidirection connection.
 </pre>
 
-<pre class=simpledef>
-Capability: <dfn export>User Agent</dfn>
-Key: "<code>userAgent</code>"
-Value type: string
-Description: Provides the [=remote end=]'s [=default User-Agent value=].
-</pre>
-
 <div algorithm="webSocketUrl capability deserialization algorithm">
 The [=additional capability deserialization algorithm=] for the
 "<code>webSocketUrl</code>" capability, with parameter |value| is:
@@ -1597,15 +1587,6 @@ with parameter |value| is:
 1. If |value| is false, return [=success=] with data null.
 
 1. Return [=success=] with data true.
-
-</div>
-
-<div algorithm="userAgent capability serialization algorithm">
-The [=matched capability serialization algorithm=] for the "<code>userAgent</code>" capability is:
-
-1. Let |user agent| be [=default User-Agent value=]
-
-1. Return [=success=] with data |user agent|.
 
 </div>
 
@@ -1758,6 +1739,7 @@ This is a [=static command=].
           browserVersion: text,
           platformName: text,
           setWindowRect: bool,
+          userAgent: text,
           ? proxy: session.ProxyConfiguration,
           ? webSocketUrl: text,
           Extensible

--- a/index.bs
+++ b/index.bs
@@ -269,6 +269,9 @@ spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
+spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
+  type: dfn
+    text: default User-Agent value; url: #default-user-agent-value
 </pre>
 
 <pre class="biblio">
@@ -1569,6 +1572,13 @@ Value type: boolean
 Description: Defines the current session's support for bidirection connection.
 </pre>
 
+<pre class=simpledef>
+Capability: <dfn export>User Agent</dfn>
+Key: "<code>userAgent</code>"
+Value type: string
+Description: Provides the [=remote end=]'s [=default User-Agent value=].
+</pre>
+
 <div algorithm="webSocketUrl capability deserialization algorithm">
 The [=additional capability deserialization algorithm=] for the
 "<code>webSocketUrl</code>" capability, with parameter |value| is:
@@ -1587,6 +1597,15 @@ with parameter |value| is:
 1. If |value| is false, return [=success=] with data null.
 
 1. Return [=success=] with data true.
+
+</div>
+
+<div algorithm="userAgent capability serialization algorithm">
+The [=matched capability serialization algorithm=] for the "<code>userAgent</code>" capability is:
+
+1. Let |user agent| be [=default User-Agent value=]
+
+1. Return [=success=] with data |user agent|.
 
 </div>
 


### PR DESCRIPTION
This PR would allow client to get the original default User-Agent header value. In Puppeteer, it would allow supporting the `Browser.userAgent()` API.

Closes #446


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/652.html" title="Last updated on Mar 7, 2024, 2:33 PM UTC (f57ecd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/652/f7e2538...f57ecd1.html" title="Last updated on Mar 7, 2024, 2:33 PM UTC (f57ecd1)">Diff</a>