### PR TITLE
Add an ability to locate nodes using computed accessibility attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -269,6 +269,9 @@ spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
+spec: WAI-ARIA; urlPrefix:https://w3c.github.io/aria/
+  type: dfn
+    text: WAI-ARIA role; url: #introroles
 </pre>
 
 <pre class="biblio">
@@ -2501,6 +2504,7 @@ To <dfn>await a navigation</dfn> given |context|, |request|, |wait condition|, a
 browsingContext.Locator = (
    browsingContext.CssLocator /
    browsingContext.InnerTextLocator /
+   browsingContext.RoleLocator /
    browsingContext.XPathLocator
 )
 
@@ -2515,6 +2519,11 @@ browsingContext.InnerTextLocator = {
    ? ignoreCase: bool
    ? matchType: "full" / "partial",
    ? maxDepth: js-uint,
+}
+
+browsingContext.RoleLocator = {
+   type: "role",
+   value: text
 }
 
 browsingContext.XPathLocator = {
@@ -3406,6 +3415,41 @@ and |session|:
 
 </div>
 
+<div algorithm="locate nodes using role">
+To <dfn>locate nodes using role</dfn> with given |context nodes|, |selector|,
+|maximum returned node count|, and |session|:
+
+1. If |selector| is the empty string, return [=error=] with [=error code=]
+   [=invalid selector=].
+
+1. Let |returned nodes| be an empty [=/list=].
+
+1. For each |context node| in |context nodes|:
+
+  1. Let |role| be the result of computing the [=WAI-ARIA role=] of |context node|.
+
+  1. If |selector| [=is=] |role|:
+
+    1. [=list/Append=] |context node| to |returned nodes|.
+
+  1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
+     <a spec=dom>children</a> of |context node|:
+
+    1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
+
+  1. Let |child node matches| be the result of [=locate nodes using role=]
+     with |child nodes|, |selector|, |maximum returned node count|, and |session|.
+
+  1. [=list/Extend=] |returned nodes| with |child node matches|.
+
+1. If |maximum returned node count| is not null, [=list/remove=] all entries
+   in |returned nodes| with an index greater than or equal to |maximum returned
+   node count|.
+
+1. Return [=success=] with data |returned nodes|.
+
+</div>
+
 <div algorithm="remote end steps for browsingContext.locateNodes">
 The [=remote end steps=] with |session| and |command parameters| are:
 
@@ -3481,6 +3525,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using inner text=]
             given |context nodes|, |selector|, |max depth|, |match type|,
             |ignore case|, |maximum returned node count| and |session|.
+
+      <dt>|type| is the string "<code>role</code>"
+      <dd>
+         1. Let |selector| be |locator|["<code>value</code>"].
+
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using role=]
+            given |context nodes|, |selector|, |maximum returned node count| and
+            |session|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.

--- a/index.bs
+++ b/index.bs
@@ -3452,9 +3452,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
   1. If |match| is true:
 
     1. If |maximum returned node count| is not null and [=list/size=] of |returned
-      nodes| is greater or equal to |maximum returned node count|:
-
-      1. Return |returned nodes|.
+      nodes| is equal to |maximum returned node count|, [=break=].
 
     1. [=list/Append=] |context node| to |returned nodes|.
 
@@ -3465,9 +3463,6 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
   1. [=Try=] to [=collect nodes using accessibility attributes=] with |child nodes|,
      |selector|, |maximum returned node count|, and |returned nodes|.
-
-  1. If |maximum returned node count| is not null and [=list/size=] of |returned
-      nodes| is greater or equal to |maximum returned node count|, break.
 
 1. Return |returned nodes|.
 

--- a/index.bs
+++ b/index.bs
@@ -3454,7 +3454,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
     1. If |maximum returned node count| is not null and [=list/size=] of |returned
       nodes| is greater or equal to |maximum returned node count|:
 
-      1. Return [=success=] with data |returned nodes|.
+      1. Return |returned nodes|.
 
     1. [=list/Append=] |context node| to |returned nodes|.
 
@@ -3466,7 +3466,10 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
   1. [=Try=] to [=collect nodes using accessibility attributes=] with |child nodes|,
      |selector|, |maximum returned node count|, and |returned nodes|.
 
-  1. Return [=success=] with data |returned nodes|.
+  1. If |maximum returned node count| is not null and [=list/size=] of |returned
+      nodes| is greater or equal to |maximum returned node count|, break.
+
+1. Return |returned nodes|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3441,7 +3441,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
       1. Set |match| to false.
 
-  1. If |selector|'s <code>name</code> is present:
+  1. If |selector| [=map/contains=] "<code>name</code>":
 
     1. Let |name| be the [=accessible name=] of |context node|.
 

--- a/index.bs
+++ b/index.bs
@@ -3437,7 +3437,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
     1. Let |role| be the [=computed role=] of |context node|.
 
-    1. If |selector|'s <code>role</code> [=is|is not=] |role|:
+    1. If |selector|["<code>role</code>"] [=is|is not=] |role|:
 
       1. Set |match| to false.
 

--- a/index.bs
+++ b/index.bs
@@ -3463,7 +3463,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
     1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
 
-  1. Invoke [=collect nodes using accessibility attributes=] with |child nodes|,
+  1. [=Try=] to [=collect nodes using accessibility attributes=] with |child nodes|,
      |selector|, |maximum returned node count|, and |returned nodes|.
 
   1. Return [=success=] with data |returned nodes|.

--- a/index.bs
+++ b/index.bs
@@ -3433,7 +3433,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
   1. Let |match| be true.
 
-  1. If |selector|'s <code>role</code> is present:
+  1. If |selector| [=map/contains=] "<code>role</code>":
 
     1. Let |role| be the [=computed role=] of |context node|.
 

--- a/index.bs
+++ b/index.bs
@@ -269,9 +269,12 @@ spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
     text: toUppercase; url: ch03.pdf#G34078
-spec: WAI-ARIA; urlPrefix:https://w3c.github.io/aria/
+spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
   type: dfn
-    text: WAI-ARIA role; url: #introroles
+    text: accessible name; url: /#dfn-accessible-name
+spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
+  type: dfn
+    text: accessible role; url: /#roleMappingComputedRole
 </pre>
 
 <pre class="biblio">
@@ -2502,11 +2505,19 @@ To <dfn>await a navigation</dfn> given |context|, |request|, |wait condition|, a
 
 <pre class="cddl remote-cddl local-cddl">
 browsingContext.Locator = (
+   browsingContext.AccessibilityLocator /
    browsingContext.CssLocator /
    browsingContext.InnerTextLocator /
-   browsingContext.RoleLocator /
    browsingContext.XPathLocator
 )
+
+browsingContext.AccessibilityLocator = {
+   type: "accessibility",
+   value: {
+    ? name: text,
+    ? role: text,
+   }
+}
 
 browsingContext.CssLocator = {
    type: "css",
@@ -2519,11 +2530,6 @@ browsingContext.InnerTextLocator = {
    ? ignoreCase: bool
    ? matchType: "full" / "partial",
    ? maxDepth: js-uint,
-}
-
-browsingContext.RoleLocator = {
-   type: "role",
-   value: text
 }
 
 browsingContext.XPathLocator = {
@@ -3415,20 +3421,43 @@ and |session|:
 
 </div>
 
-<div algorithm="locate nodes using role">
-To <dfn>locate nodes using role</dfn> with given |context nodes|, |selector|,
-|maximum returned node count|, and |session|:
+<div algorithm="locate nodes using accessibility attributes">
+To <dfn>locate nodes using accessibility attributes</dfn> with given |context nodes|, |selector|,
+|maximum returned node count|, |session|, and |returned nodes|:
 
-1. If |selector| is the empty string, return [=error=] with [=error code=]
+1. If |selector|'s <code>role</code> and |selector|'s <code>name</code> are missing, return [=error=] with [=error code=]
    [=invalid selector=].
 
-1. Let |returned nodes| be an empty [=/list=].
+1. If |returned nodes| is null:
+
+  1. Set |returned nodes| to an empty [=/list=].
+
+1. If |maximum returned node count| is not null and [=list/size=] of |returned
+   nodes| is greater or equal to |maximum returned node count|:
+
+   1. Return [=success=] with data null.
 
 1. For each |context node| in |context nodes|:
 
-  1. Let |role| be the result of computing the [=WAI-ARIA role=] of |context node|.
+  1. Let |match| be true.
 
-  1. If |selector| [=is=] |role|:
+  1. If |selector|'s <code>role</code> is present:
+
+    1. Let |role| be the result of computing the [=accessible role=] of |context node|.
+
+    1. If |selector|'s <code>role</code> [=is|is not=] |role|:
+
+      1. Set |match| to false.
+
+  1. If |selector|'s <code>name</code> is present:
+
+    1. Let |name| be the result of computing the [=accessible name=] of |context node|.
+
+    1. If |selector|'s <code>name</code> [=is|is not=] |name|:
+
+      1. Set |match| to false.
+
+  1. If |match| is true:
 
     1. [=list/Append=] |context node| to |returned nodes|.
 
@@ -3437,16 +3466,8 @@ To <dfn>locate nodes using role</dfn> with given |context nodes|, |selector|,
 
     1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
 
-  1. Let |child node matches| be the result of [=locate nodes using role=]
-     with |child nodes|, |selector|, |maximum returned node count|, and |session|.
-
-  1. [=list/Extend=] |returned nodes| with |child node matches|.
-
-1. If |maximum returned node count| is not null, [=list/remove=] all entries
-   in |returned nodes| with an index greater than or equal to |maximum returned
-   node count|.
-
-1. Return [=success=] with data |returned nodes|.
+  1. Invoke [=locate nodes using accessibility attributes=] with |child nodes|,
+     |selector|, |maximum returned node count|, |session|, and |returned nodes|.
 
 </div>
 
@@ -3526,13 +3547,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |context nodes|, |selector|, |max depth|, |match type|,
             |ignore case|, |maximum returned node count| and |session|.
 
-      <dt>|type| is the string "<code>role</code>"
+      <dt>|type| is the string "<code>accessibility</code>"
       <dd>
          1. Let |selector| be |locator|["<code>value</code>"].
 
-         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using role=]
-            given |context nodes|, |selector|, |maximum returned node count| and
-            |session|.
+         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using accessibility attributes=]
+            given |context nodes|, |selector|, |maximum returned node count|,
+            |session|, and null.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.

--- a/index.bs
+++ b/index.bs
@@ -3562,7 +3562,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
       <dd>
          1. Let |selector| be |locator|["<code>value</code>"].
 
-         1. Let |result nodes| be a result of [=trying=] to [=locate nodes using accessibility attributes=]
+         1. Let |result nodes| be [=locate nodes using accessibility attributes=]
             given |context nodes|, |selector|, and |maximum returned node count|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less

--- a/index.bs
+++ b/index.bs
@@ -3445,7 +3445,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
     1. Let |name| be the [=accessible name=] of |context node|.
 
-    1. If |selector|'s <code>name</code> [=is|is not=] |name|:
+    1. If |selector|["<code>name</code>"] [=is|is not=] |name|:
 
       1. Set |match| to false.
 

--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,7 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
     text: accessible name; url: /#dfn-accessible-name
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
-    text: accessible role; url: /#roleMappingComputedRole
+    text: computed role; url: /#roleMappingComputedRole
 </pre>
 
 <pre class="biblio">
@@ -3435,7 +3435,7 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
   1. If |selector|'s <code>role</code> is present:
 
-    1. Let |role| be the [=accessible role=] of |context node|.
+    1. Let |role| be the [=computed role=] of |context node|.
 
     1. If |selector|'s <code>role</code> [=is|is not=] |role|:
 

--- a/index.bs
+++ b/index.bs
@@ -3421,21 +3421,13 @@ and |session|:
 
 </div>
 
-<div algorithm="locate nodes using accessibility attributes">
-To <dfn>locate nodes using accessibility attributes</dfn> with given |context nodes|, |selector|,
-|maximum returned node count|, |session|, and |returned nodes|:
-
-1. If |selector|'s <code>role</code> and |selector|'s <code>name</code> are missing, return [=error=] with [=error code=]
-   [=invalid selector=].
+<div algorithm="collect nodes using accessibility attributes">
+To <dfn>collect nodes using accessibility attributes</dfn> with given |context nodes|, |selector|,
+|maximum returned node count|, and |returned nodes|:
 
 1. If |returned nodes| is null:
 
   1. Set |returned nodes| to an empty [=/list=].
-
-1. If |maximum returned node count| is not null and [=list/size=] of |returned
-   nodes| is greater or equal to |maximum returned node count|:
-
-   1. Return [=success=] with data null.
 
 1. For each |context node| in |context nodes|:
 
@@ -3443,7 +3435,7 @@ To <dfn>locate nodes using accessibility attributes</dfn> with given |context no
 
   1. If |selector|'s <code>role</code> is present:
 
-    1. Let |role| be the result of computing the [=accessible role=] of |context node|.
+    1. Let |role| be the [=accessible role=] of |context node|.
 
     1. If |selector|'s <code>role</code> [=is|is not=] |role|:
 
@@ -3451,13 +3443,18 @@ To <dfn>locate nodes using accessibility attributes</dfn> with given |context no
 
   1. If |selector|'s <code>name</code> is present:
 
-    1. Let |name| be the result of computing the [=accessible name=] of |context node|.
+    1. Let |name| be the [=accessible name=] of |context node|.
 
     1. If |selector|'s <code>name</code> [=is|is not=] |name|:
 
       1. Set |match| to false.
 
   1. If |match| is true:
+
+    1. If |maximum returned node count| is not null and [=list/size=] of |returned
+      nodes| is greater or equal to |maximum returned node count|:
+
+      1. Return [=success=] with data |returned nodes|.
 
     1. [=list/Append=] |context node| to |returned nodes|.
 
@@ -3466,8 +3463,23 @@ To <dfn>locate nodes using accessibility attributes</dfn> with given |context no
 
     1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
 
-  1. Invoke [=locate nodes using accessibility attributes=] with |child nodes|,
-     |selector|, |maximum returned node count|, |session|, and |returned nodes|.
+  1. Invoke [=collect nodes using accessibility attributes=] with |child nodes|,
+     |selector|, |maximum returned node count|, and |returned nodes|.
+
+  1. Return [=success=] with data |returned nodes|.
+
+</div>
+
+<div algorithm="locate nodes using accessibility attributes">
+To <dfn>locate nodes using accessibility attributes</dfn> with given |context nodes|, |selector|, and
+|maximum returned node count|:
+
+1. If |selector|'s <code>role</code> and |selector|'s <code>name</code>
+   are missing, return [=error=] with [=error code=]
+   [=invalid selector=].
+
+1. Return the result of [=collect nodes using accessibility attributes=] with |context nodes|,
+    |selector|, |maximum returned node count|, and null.
 
 </div>
 
@@ -3552,8 +3564,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |selector| be |locator|["<code>value</code>"].
 
          1. Let |result nodes| be a result of [=trying=] to [=locate nodes using accessibility attributes=]
-            given |context nodes|, |selector|, |maximum returned node count|,
-            |session|, and null.
+            given |context nodes|, |selector|, and |maximum returned node count|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.

--- a/index.bs
+++ b/index.bs
@@ -3474,8 +3474,9 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 To <dfn>locate nodes using accessibility attributes</dfn> with given |context nodes|, |selector|, and
 |maximum returned node count|:
 
-1. If |selector|'s <code>role</code> and |selector|'s <code>name</code>
-   are missing, return [=error=] with [=error code=]
+1. If |selector| does not [=map/contain=] "<code>role</code>" and
+   |selector| does not [=map/contain=] "<code>name</code>", return
+   [=error=] with [=error code=]
    [=invalid selector=].
 
 1. Return the result of [=collect nodes using accessibility attributes=] with |context nodes|,


### PR DESCRIPTION
Based on: https://github.com/w3c/webdriver-bidi/pull/624
Issue: https://github.com/w3c/webdriver-bidi/issues/443


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/660.html" title="Last updated on Apr 15, 2024, 12:44 PM UTC (b0ee307)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/660/efb27e8...b0ee307.html" title="Last updated on Apr 15, 2024, 12:44 PM UTC (b0ee307)">Diff</a>