### PR TITLE
Remove unused properties in pointerUp action

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10311,7 +10311,6 @@ specified sequence of user input actions.
       input.PointerUpAction = {
         type: "pointerUp",
         button: js-uint,
-        input.PointerCommonProperties
       }
 
       input.PointerDownAction = {


### PR DESCRIPTION
These properties are unused. See https://www.w3.org/TR/webdriver2/#dfn-dispatch-a-pointerup-action


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/667.html" title="Last updated on Feb 20, 2024, 2:01 PM UTC (e0a3bec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/667/42abefe...e0a3bec.html" title="Last updated on Feb 20, 2024, 2:01 PM UTC (e0a3bec)">Diff</a>