### PR TITLE
Extract `browser.RemoveUserContextParameters` type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2153,10 +2153,12 @@ user context and all browsing contexts in it without running
       <pre class="cddl remote-cddl">
       browser.RemoveUserContext = (
         method: "browser.removeUserContext",
-        params: {
-          userContext: browser.UserContext
-        },
+        params: browser.RemoveUserContextParameters
       )
+
+      browser.RemoveUserContextParameters = {
+        userContext: browser.UserContext
+      }
       </pre>
    </dd>
    <dt>Return Type</dt>


### PR DESCRIPTION
Needed for autogenerating types and validators


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/671.html" title="Last updated on Feb 27, 2024, 12:40 PM UTC (1fc9975)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/671/a53d38d...1fc9975.html" title="Last updated on Feb 27, 2024, 12:40 PM UTC (1fc9975)">Diff</a>