### PR TITLE
Add missing "not" in "input.setFiles" algorithm check when "files" parameter is greater than 1.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10513,7 +10513,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
    return [=error=] with [=error code=] [=unable to set file input=].
 
 1. If the [=set/size=] of |files| is greater than 1 and |element|'s
-   <{input/multiple}> attribute is set, return [=error=] with [=error code=]
+   <{input/multiple}> attribute is not set, return [=error=] with [=error code=]
    [=unable to set file input=].
 
 1. Let |files| be the value of the |command parameters|["<code>files</code>"]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/673.html" title="Last updated on Feb 28, 2024, 2:35 PM UTC (30a63e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/673/05b9d66...lutien:30a63e5.html" title="Last updated on Feb 28, 2024, 2:35 PM UTC (30a63e5)">Diff</a>