### PR TITLE
editorial: fix authChallenges in ResponseData

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5289,7 +5289,7 @@ network.ResponseData = {
     headersSize: js-uint / null,
     bodySize: js-uint / null,
     content: network.ResponseContent,
-    ?authChallenge: network.AuthChallenge,
+    ?authChallenges: [+network.AuthChallenge],
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -5289,7 +5289,7 @@ network.ResponseData = {
     headersSize: js-uint / null,
     bodySize: js-uint / null,
     content: network.ResponseContent,
-    ?authChallenges: [+network.AuthChallenge],
+    ?authChallenges: [*network.AuthChallenge],
 };
 </pre>
 


### PR DESCRIPTION
Assuming this was overlooked at https://github.com/w3c/webdriver-bidi/pull/429. 
[The algorithm  for retrieving](https://w3c.github.io/webdriver-bidi/#get-the-response-data) (Step 14) it says it should be called `authChallenges` and not `authChallenge` also the [extract-challenges](https://w3c.github.io/webdriver-bidi/#extract-challenges) part return a list. 
This is further confirmed by the written WPT test setup - [here](https://github.com/web-platform-tests/wpt/commit/6de19dcd2e4657b1e378393fc1dc5b335860420d).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/674.html" title="Last updated on Feb 29, 2024, 10:33 AM UTC (ea9a08c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/674/2b10f89...ea9a08c.html" title="Last updated on Feb 29, 2024, 10:33 AM UTC (ea9a08c)">Diff</a>