### PR TITLE
Improve check for cancel event in "input.setFiles" command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10522,10 +10522,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |selected files| be |element|'s [=selected files=].
 
 1. If the [=set/size=] of the [=set/intersection=] of |files| and |selected
-   files| is equal to the [=set/size=] of |selected files|, [=queue an element
-   task=] on the [=user interaction task source=] given |element| to fire an
-   event named <code>cancel</code> at |element|, with the <code>bubbles</code>
-   attribute initialized to true.
+   files| is equal to the [=set/size=] of |selected files| and equal to the
+   [=set/size=] of |files|, [=queue an element task=] on the [=user interaction task source=]
+   given |element| to fire an event named <code>cancel</code> at |element|, with
+   the <code>bubbles</code> attribute initialized to true.
 
    Note: Cancellation in a browser is typically determined by changes in file
    selection. In other words, if there is no change, a "cancel" event is sent.


### PR DESCRIPTION
With only checking if the size of `intersection` is equal to the size of `selected files`, we miss the case when the `files` can contain additional items.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/675.html" title="Last updated on Mar 1, 2024, 9:56 AM UTC (9ab3aad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/675/bf2dac3...lutien:9ab3aad.html" title="Last updated on Mar 1, 2024, 9:56 AM UTC (9ab3aad)">Diff</a>