### PR TITLE
Better CDDL for `session.SubscriptionRequest`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1645,8 +1645,8 @@ session.SystemProxyConfiguration = (
 
 <pre class="cddl remote-cddl">
 session.SubscriptionRequest = {
-  events: [*text],
-  ? contexts: [*browsingContext.BrowsingContext],
+  events: [+text],
+  ? contexts: [+browsingContext.BrowsingContext],
 }
 </pre>
 


### PR DESCRIPTION
Splitting from #628. As I think this make sense regardless of the outcome of that PR.
Motivation here is that the algorithms for both empty cases become no-op if the lists are empty -
For events: 
[Update the event map](https://w3c.github.io/webdriver-bidi/#update-the-event-map) 
Step 5 -> Step 7.1.1 is looped over a empty list.
For Contexts:
[Update the event map](https://w3c.github.io/webdriver-bidi/#update-the-event-map) 
Step 5 -> Step 8.3.2 is looped over a empty list.

The part about `contexts: []` becomes consistent with `addPreloadScript` and `addInterception` as they both fail on empty list.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/679.html" title="Last updated on Mar 6, 2024, 10:20 AM UTC (078b26b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/679/bf2dac3...078b26b.html" title="Last updated on Mar 6, 2024, 10:20 AM UTC (078b26b)">Diff</a>