### PR TITLE
Fix order of groups in script.Target

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8614,8 +8614,8 @@ script.ContextTarget = {
 }
 
 script.Target = (
-  script.RealmTarget /
-  script.ContextTarget
+  script.ContextTarget /
+  script.RealmTarget
 );
 </pre>
 


### PR DESCRIPTION
The [spec text defines that script.ContextTarget is matched first](https://w3c.github.io/webdriver-bidi/#get-a-realm-from-a-target). The CDDL spec also [picks groups in order](https://datatracker.ietf.org/doc/html/rfc8610#appendix-C:~:text=The%20choice%20uses%20PEG%20semantics%20as%0A%20%20%20discussed%20in%20Appendix%20A%3A%20the%20first%20choice%20that%20matches%20wins). Therefore, the ContextTarget needs to be defined first in the group.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/680.html" title="Last updated on Mar 7, 2024, 2:25 PM UTC (ebf8cbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/680/f7e2538...ebf8cbd.html" title="Last updated on Mar 7, 2024, 2:25 PM UTC (ebf8cbd)">Diff</a>