### PR TITLE
Add missing `invalid selector` error code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -618,6 +618,7 @@ with the following additional codes:
 
 <pre class="cddl local-cddl">
 ErrorCode = "invalid argument" /
+            "invalid selector" /
             "invalid session id" /
             "move target out of bounds" /
             "no such alert" /


### PR DESCRIPTION
The code is required for auto-generating types.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/682.html" title="Last updated on Mar 11, 2024, 10:49 AM UTC (e5faf41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/682/c99dd87...e5faf41.html" title="Last updated on Mar 11, 2024, 10:49 AM UTC (e5faf41)">Diff</a>