### PR TITLE
Rename `innerText` to `innertext`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2511,7 +2511,7 @@ browsingContext.CssLocator = {
 }
 
 browsingContext.InnerTextLocator = {
-   type: "innerText",
+   type: "innertext",
    value: text,
    ? ignoreCase: bool
    ? matchType: "full" / "partial",
@@ -3477,7 +3477,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
             given |current context target|, |context nodes|, |selector|, |maximum returned
             nodes| and |session|.
 
-      <dt>|type| is the string "<code>innerText</code>"
+      <dt>|type| is the string "<code>innertext</code>"
       <dd>
          1. Let |selector| be |locator|["<code>value</code>"].
 


### PR DESCRIPTION
to align with other types, which are always in low case. Eg `arraybuffer` or `typedarray`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/685.html" title="Last updated on Mar 11, 2024, 2:45 PM UTC (27ce361)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/685/430df16...27ce361.html" title="Last updated on Mar 11, 2024, 2:45 PM UTC (27ce361)">Diff</a>