### PR TITLE
Remove IteratorRemoteValue from the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7721,7 +7721,6 @@ script.RemoteValue = (
   script.SetRemoteValue /
   script.WeakMapRemoteValue /
   script.WeakSetRemoteValue /
-  script.IteratorRemoteValue /
   script.GeneratorRemoteValue /
   script.ErrorRemoteValue /
   script.ProxyRemoteValue /
@@ -7796,12 +7795,6 @@ script.WeakMapRemoteValue = {
 
 script.WeakSetRemoteValue = {
   type: "weakset",
-  ? handle: script.Handle,
-  ? internalId: script.InternalId,
-}
-
-script.IteratorRemoteValue = {
-  type: "iterator",
   ? handle: script.Handle,
   ? internalId: script.InternalId,
 }
@@ -7891,8 +7884,6 @@ script.WindowProxyProperties = {
 Issue: Add WASM types?
 
 Issue: Should WindowProxy get attributes in a similar style to Node?
-
-Issue: Describe `script.IteratorRemoteValue` serialization.
 
 Issue: handle String / Number / etc. wrapper objects specially?
 


### PR DESCRIPTION
Currently, how IteratorRemoteValue is produced is not specified as per https://github.com/w3c/webdriver-bidi/issues/537

Additionally, a general iterator is any object with a next method as per https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator-interface and it is an interface that any object can implement.

Since there is currently no use case requiring serialization support of iterators, we propose removing IteratorRemoteValue from the spec.

The following use cases have been considered:

1) Evaluating an iterator from the client code (In puppeteer code):

```
сonst it = await page.evaluateHandle(() => produce an iterator)
await it.evaluate(it => it.next())
```

Conclusion: serialization as an object is sufficient, since the user knows if they are dealing with an iterator and additionally they can check for the presence of the next method if needed.

2) Logging an iterator object to console

We believe that serializing an iterator as an object would be sufficient.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/691.html" title="Last updated on Mar 20, 2024, 10:32 AM UTC (7d6750f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/691/efb27e8...7d6750f.html" title="Last updated on Mar 20, 2024, 10:32 AM UTC (7d6750f)">Diff</a>