### PR TITLE
Update handling of "devicePixelRatio" argument in "browsingContext.setViewport" command.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3961,9 +3961,6 @@ The [=remote end steps=] with |command parameters| are:
 
             Note: This will take an effect because of the patch of [[#patchs-determine-the-device-pixel-ratio]].
 
-         1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
-            in a specified |context|.
-
       1. Otherwise:
 
          1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
@@ -3974,8 +3971,8 @@ The [=remote end steps=] with |command parameters| are:
 
          1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
 
-         1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
-            in a specified |context|.
+      1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
+         in a specified |context|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -194,6 +194,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
     text: default view; url: nav-history-apis.html#dom-document-defaultview
+    text: descendant navigables; utl: document-sequences.html#descendant-navigables
     text: environment settings object's Realm; url: webappapis.html#environment-settings-object's-realm
     text: focused area of the document; url: document-sequences.html#focused-area-of-the-document
     text: getting all used history steps; url:browsing-the-web.html#getting-all-used-history-steps
@@ -3939,7 +3940,7 @@ The [=remote end steps=] with |command parameters| are:
    1. Let |device pixel ratio| be the |command
       parameters|["<code>devicePixelRatio</code>"].
 
-   1. For the |context| and all descendant traversables:
+   1. For the |context| and all [=descendant navigables=]:
 
       1. If |device pixel ratio| is not null:
 

--- a/index.bs
+++ b/index.bs
@@ -203,6 +203,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
     text: innerText getter steps; url:dom.html#dom-innertext
     text: input type; url: input.html#dom-input-type
+    text: navigable; for:window; url: document-sequences.html#window-navigable
     text: navigables; url: document-sequences.html#navigables
     text: navigation id; url: browsing-the-web.html#navigation-id
     text: origin-clean; url: canvas.html#concept-canvas-origin-clean
@@ -1328,7 +1329,7 @@ it is observed via WebDriver, so we avoid using this terminology.
 A [=user context=] has a <dfn export for="user context">user context id</dfn>,
 which is a unique string set upon the user context creation.
 
-A [=navigable=] has an <dfn export>associated user context</dfn>, which is a [=user
+A [=/navigable=] has an <dfn export>associated user context</dfn>, which is a [=user
 context=].
 
 When a new [=/top-level traversable=] is created its [=associated user context=]
@@ -2279,6 +2280,9 @@ BrowsingContextEvent = (
   browsingContext.UserPromptOpened
 )
 </pre>
+
+A [=remote end=] has a <dfn>device pixel ratio overrides</dfn> which is a weak map
+between [=navigables=] and device pixel ratio overrides. It is initially empty.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -3942,6 +3946,9 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For the |context| and all [=descendant navigables=]:
 
+      1. Let |navigable| be the [=/navigable=] whose [=navigable/active document=] is
+         |context|'s [=browsing context/active document=].
+
       1. If |device pixel ratio| is not null:
 
          1. When the [=select an image source from a source set=] are run, act as if
@@ -3950,7 +3957,7 @@ The [=remote end steps=] with |command parameters| are:
          1. For the purposes of the [=resolution media feature=], act as if
             the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
 
-         1. When the [=determine the device pixel ratio=] steps are run, return |device pixel ratio|.
+         1. [=map/Set=] [=device pixel ratio overrides=][|navigable|] to |device pixel ratio|.
 
          1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
             in a specified |context|.
@@ -3963,7 +3970,7 @@ The [=remote end steps=] with |command parameters| are:
          1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
             without any changes made by previous invocations of these steps.
 
-         1. When the [=determine the device pixel ratio=] steps are run, return the implemenation's default value.
+         1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
 
          1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
             in a specified |context|.
@@ -10692,3 +10699,10 @@ Other specifications can define <dfn>console steps</dfn>.
    arguments |name|, |printerArgs| and |options| (which is undefined if the
    argument is not provided), call any [=console steps=] defined in
    external specification with arguments |name|, |printerArgs|, and |options|.
+
+
+## CSS ## {#patchs-css}
+
+Insert the following steps at the start of the [=determine the device pixel ratio=] algorithm:
+
+1. If [=device pixel ratio overrides=] [=map/contains=] <var ignore>window</var>'s [=window/navigable=], return [=device pixel ratio overrides=][<var ignore>window</var>'s [=window/navigable=]].

--- a/index.bs
+++ b/index.bs
@@ -3959,6 +3959,8 @@ The [=remote end steps=] with |command parameters| are:
 
          1. [=map/Set=] [=device pixel ratio overrides=][|navigable|] to |device pixel ratio|.
 
+            Note: This will take an effect because of the patch of [[#patchs-determine-the-device-pixel-ratio]].
+
          1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
             in a specified |context|.
 
@@ -10702,6 +10704,8 @@ Other specifications can define <dfn>console steps</dfn>.
 
 
 ## CSS ## {#patchs-css}
+
+### Determine the device pixel ratio ### {#patchs-determine-the-device-pixel-ratio}
 
 Insert the following steps at the start of the [=determine the device pixel ratio=] algorithm:
 

--- a/index.bs
+++ b/index.bs
@@ -212,6 +212,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: report an error; url: webappapis.html#report-the-error
     text: run the animation frame callbacks; url: imagebitmap-and-animations.html#run-the-animation-frame-callbacks
     text: same origin domain; url: browsers.html#same-origin-domain
+    text: select an image source from a source set; url: images.html#select-an-image-source-from-a-source-set
     text: selected files; url: input.html#concept-input-type-file-selected
     text: session history entry; url: browsing-the-web.html#session-history-entry
     text: session history traversal queue; url: document-sequences.html#tn-session-history-traversal-queue
@@ -243,6 +244,7 @@ spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
 spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
     text: CSS pixel; url: #dom-window-devicepixelratio
+    text: evaluate media queries and report changes; url: #evaluate-media-queries-and-report-changes
     text: layout viewport; url: #layout-viewport
     text: scroll height; url: #dom-element-scrollheight
     text: scroll width; url: #dom-element-scrollwidth
@@ -275,6 +277,9 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
     text: computed role; url: /#roleMappingComputedRole
+spec: MEDIAQUARIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
+  type: dfn
+    text: resolution media feature; url: #resolution
 </pre>
 
 <pre class="biblio">
@@ -3927,19 +3932,40 @@ The [=remote end steps=] with |command parameters| are:
    1. Otherwise, set the |context|'s [=layout viewport=] to the
       implementation-defined default.
 
+1. Run the [[cssom-view-1#resizing-viewports]] steps.
+
 1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
 
    1. Let |device pixel ratio| be the |command
       parameters|["<code>devicePixelRatio</code>"].
 
-   1. If |device pixel ratio| is not null, change the size of the [=CSS Pixel=]
-      in |context|'s [=layout viewport=] such that it corresponds to |device
-      pixel ratio| in device pixels.
+   1. For the |context| and all descendant traversables:
 
-   1. Otherwise, set the size of the [=CSS Pixel=] in |context|'s [=layout
-      viewport=] to the implementation-defined default.
+      1. If |device pixel ratio| is not null:
 
-1. Run the [[cssom-view-1#resizing-viewports]] steps.
+         1. When the [=select an image source from a source set=] are run, act as if
+            the implementation's pixel density was set to |device pixel ratio| when selecting an image.
+
+         1. For the purposes of the [=resolution media feature=], act as if
+            the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
+
+         1. When the [=determine the device pixel ratio=] are run, return |device pixel ratio|.
+
+         1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
+            in a specified |context|.
+
+      1. Otherwise:
+
+         1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
+            without any changes made by previous invocations of these steps.
+
+         1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
+            without any changes made by previous invocations of these steps.
+
+         1. When the [=determine the device pixel ratio=] are run, return the implemenation's default value.
+
+         1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
+            in a specified |context|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -3962,7 +3962,7 @@ The [=remote end steps=] with |command parameters| are:
          1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
             without any changes made by previous invocations of these steps.
 
-         1. When the [=determine the device pixel ratio=] are run, return the implemenation's default value.
+         1. When the [=determine the device pixel ratio=] steps are run, return the implemenation's default value.
 
          1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
             in a specified |context|.

--- a/index.bs
+++ b/index.bs
@@ -3949,7 +3949,7 @@ The [=remote end steps=] with |command parameters| are:
          1. For the purposes of the [=resolution media feature=], act as if
             the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
 
-         1. When the [=determine the device pixel ratio=] are run, return |device pixel ratio|.
+         1. When the [=determine the device pixel ratio=] steps are run, return |device pixel ratio|.
 
          1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
             in a specified |context|.

--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
     text: computed role; url: /#roleMappingComputedRole
-spec: MEDIAQUARIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
+spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
 </pre>


### PR DESCRIPTION
Since the implementation of changing the CSS pixels is problematic for at least Chrome and Firefox (probably Safari as well?) and likely not required, the suggestion here is to rather emulate certain parts, e.g. image source set selection and media queries.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/693.html" title="Last updated on Apr 19, 2024, 1:32 PM UTC (8563aea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/693/88f2def...lutien:8563aea.html" title="Last updated on Apr 19, 2024, 1:32 PM UTC (8563aea)">Diff</a>