### PR TITLE
Do not compute accessible role and name for non-Element nodes in the accessibility locator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3384,19 +3384,6 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
 1. For each |context node| in |context nodes|:
 
-  1. If |context node| implements {{Document}} or {{DocumentFragment}}:
-
-    1. Let |child nodes| be an empty [=/list=].
-
-    1. For each node |child| in the <a spec=dom>children</a> of |context node|.
-
-      1. [=list/Append=] |child| to |child nodes|.
-
-    1. [=Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
-      with |child nodes|, |selector|, |max depth|, |match type|, |ignore case|, and |maximum returned node count|.
-
-  1. If |context node| does not implement {{HTMLElement}} then [=continue=].
-
   1. Let |node inner text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
 
@@ -3410,7 +3397,7 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
     1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
        <a spec=dom>children</a> of |context node|:
 
-      1. [=list/Append=] |child| to |child nodes|.
+      1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
 
     1. If [=list/size=] of |child nodes| is equal to 0 or |max depth| is equal to 0,
        perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -3384,7 +3384,18 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
 1. For each |context node| in |context nodes|:
 
-  1. If |context node| does not implement {{HTMLElement}}, [=break=].
+  1. If |context node| implements {{Document}} or {{DocumentFragment}}:
+
+    1. Let |child nodes| be an empty [=/list=].
+
+    1. For each node |child| in the <a spec=dom>children</a> of |context node|.
+
+      1. [=list/Append=] |child| to |child nodes|.
+
+    1. [=Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
+      with |child nodes|, |selector|, |max depth|, |match type|, |ignore case|, and |maximum returned node count|.
+
+  1. If |context node| does not implement {{HTMLElement}} then [=continue=].
 
   1. Let |node inner text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
@@ -3399,7 +3410,7 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
     1. Let |child nodes| be an empty [=/list=] and, for each node |child| in the
        <a spec=dom>children</a> of |context node|:
 
-      1. If |child| implements {{Element}}, [=list/append=] |child| to |child nodes|.
+      1. [=list/Append=] |child| to |child nodes|.
 
     1. If [=list/size=] of |child nodes| is equal to 0 or |max depth| is equal to 0,
        perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -3384,6 +3384,8 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
 1. For each |context node| in |context nodes|:
 
+  1. If |context node| does not implement {{HTMLElement}}, [=break=].
+
   1. Let |node inner text| be the result of calling the [=innerText getter steps=] with
      |context node| as the [=this=] value.
 
@@ -3442,21 +3444,25 @@ To <dfn>collect nodes using accessibility attributes</dfn> with given |context n
 
   1. Let |match| be true.
 
-  1. If |selector| [=map/contains=] "<code>role</code>":
+  1. If |context node| implements {{Element}}:
 
-    1. Let |role| be the [=computed role=] of |context node|.
+    1. If |selector| [=map/contains=] "<code>role</code>":
 
-    1. If |selector|["<code>role</code>"] [=is|is not=] |role|:
+      1. Let |role| be the [=computed role=] of |context node|.
 
-      1. Set |match| to false.
+      1. If |selector|["<code>role</code>"] [=is|is not=] |role|:
 
-  1. If |selector| [=map/contains=] "<code>name</code>":
+        1. Set |match| to false.
 
-    1. Let |name| be the [=accessible name=] of |context node|.
+    1. If |selector| [=map/contains=] "<code>name</code>":
 
-    1. If |selector|["<code>name</code>"] [=is|is not=] |name|:
+      1. Let |name| be the [=accessible name=] of |context node|.
 
-      1. Set |match| to false.
+      1. If |selector|["<code>name</code>"] [=is|is not=] |name|:
+
+        1. Set |match| to false.
+
+  1. Otherwise, set |match| to false.
 
   1. If |match| is true:
 


### PR DESCRIPTION
This PR updates the accessibility locator algorithm to avoid getting accessible name and role on non-element nodes while allowing to descend into non-element nodes' subtrees.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/702.html" title="Last updated on Apr 30, 2024, 6:14 AM UTC (22f61d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/702/f3f93f5...22f61d4.html" title="Last updated on Apr 30, 2024, 6:14 AM UTC (22f61d4)">Diff</a>