### PR TITLE
Define algorithms for the HTML spec to call when a navigable is created or destroyed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10663,27 +10663,6 @@ as part of the standards process.
 
 ## HTML ##  {#patches-html}
 
-The [=a browsing context is discarded=] algorithm is modified to read as follows:
-
-<div algorithm>
-To discard a browsing context |browsingContext|, run these steps:
-
-1. If this is not a recursive invocation of this algorithm, call any <dfn export>browsing context
-   tree discarded</dfn> steps defined in other applicable specifications with |browsingContext|.
-
-1. Discard all {{Document}} objects for all the entries in |browsingContext|'s
-   [=session history=].
-
-1. If |browsingContext| is a [=top-level browsing context=], then [=remove a browsing context=]
-   |browsingContext|.
-
-</div>
-
-Issue: The actual patch might be better to split the algorithm into an outer algorithm that is
-called by external callers and an inner algorithm that's used for recursive calls. That's quite hard
-to express as a patch to the specification since it requires changing multiple parts.
-
-
 The [=report an error=] algorithm is modified with an additional step at the
 end:
 

--- a/index.bs
+++ b/index.bs
@@ -4136,14 +4136,14 @@ To <dfn>Emit a context created event</dfn> given |session| and |context|:
 
 </div>
 
+
 <div algorithm="remote end event trigger for browsingContext.contextCreated">
 
-The [=remote end event trigger=] is:
+The [=remote end event trigger=] is
+the <dfn export>WebDriver BiDi navigable created</dfn> steps given
+|navigable|:
 
-When the [=create a new browsing context=] algorithm is invoked, after the
-[=active document=] of the browsing context is set, run the following steps:
-
-1. Let |context| be the newly created browsing context.
+1. Let |context| be |navigable|'s [=active browsing context=].
 
 1. Let |related browsing contexts| be a [=/set=] containing |context|.
 
@@ -4183,9 +4183,9 @@ The [=remote end event trigger=] is:
 
 <div algorithm="remote end event trigger for browsingContext.contexDestroyed">
 
-Define the following [=browsing context tree discarded=] steps:
-
-1. Let |context| be the browsing context being discarded.
+The [=remote end event trigger=] is
+the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given
+<var ignore>navigable</var> and |context|:
 
 1. Let |params| be the result of [=get the browsing context info=], given
    |context|, null, and true.


### PR DESCRIPTION
This PR defines hooks for the HTML spec to use instead of patching the HTML spec. The hooks are defined for navigables as this more closely matches how the WebDriver BiDi spec uses the term browsing context. The destroyed hook gets the browsing context explicitly as the navigable might be disassociated from the active browser context at this point.

Issue: https://github.com/whatwg/html/issues/6194
HTML spec: https://github.com/whatwg/html/pull/10329


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/708.html" title="Last updated on Jun 4, 2024, 7:22 AM UTC (78e1bb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/708/c29a684...78e1bb1.html" title="Last updated on Jun 4, 2024, 7:22 AM UTC (78e1bb1)">Diff</a>