### PR TITLE
Update obsolete UUID RFC reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -921,7 +921,7 @@ given |resource name|:
    "<code>/session/</code>" prefix.
 
 1. If |session id| is not the string representation of a
-   [[!RFC4122|UUID]], return null.
+   [[!RFC9562|UUID]], return null.
 
 1. Return |session id|.
 
@@ -2429,7 +2429,7 @@ To <dfn>await a navigation</dfn> given |context|, |request|, |wait condition|, a
 |history handling| (default: "<code>default</code>") and |ignore cache| (default: false):
 
 1. Let |navigation id| be the string representation of a
-   [[!RFC4122|UUID]] based on truly random, or pseudo-random numbers.
+   [[!RFC9562|UUID]] based on truly random, or pseudo-random numbers.
 
 1. Let |navigable| be the [=/navigable=] whose [=navigable/active
    document=] is |context|'s [=browsing context/active document=].
@@ -5985,7 +5985,7 @@ The <dfn export for=commands>network.addIntercept</dfn> command adds a
 <div algorithm="remote end steps for network.addRequestIntercept">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |intercept| be the string representation of a [[!RFC4122|UUID]].
+1. Let |intercept| be the string representation of a [[!RFC9562|UUID]].
 
 1. Let |url patterns| be the <code>urlPatterns</code> field of |command
    parameters| if present, or an empty [=/list=] otherwise.
@@ -6843,7 +6843,7 @@ before any author-defined script have run.
 TODO: Extend this to scripts in other kinds of realms.
 
 A [=BiDi session=] has a <dfn>preload script map</dfn> which is a [=/map=] in
-which the keys are [[!RFC4122|UUID]]s, and the values are [=structs=] with an <a
+which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with an <a
 for=struct>item</a> named <code>function declaration</code>, which is a string,
 <code>arguments</code>, <code>contexts</code>, which is a list or null, and an item named <code>sandbox</code> which is a string
 or null.
@@ -8088,7 +8088,7 @@ To <dfn>set internal ids if needed</dfn> given |serialization internal map|,
     1. If |previously serialized remote value| does not have a field
        <code>internalId</code>, run the following steps:
 
-      1. Let |internal id| be the string representation of a [[!RFC4122|UUID]]
+      1. Let |internal id| be the string representation of a [[!RFC9562|UUID]]
          based on truly random, or pseudo-random numbers.
 
       1. Set the <code>internalId</code> field of
@@ -8834,7 +8834,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |sandbox| be the value of the "<code>sandbox</code>" field in |command
    parameters|, if present, or null otherwise.
 
-1. Let |script| be the string representation of a [[!RFC4122|UUID]].
+1. Let |script| be the string representation of a [[!RFC9562|UUID]].
 
 1. Let |preload script map| be |session|'s [=preload script map=].
 


### PR DESCRIPTION
This PR solves the build error:

```
$./scripts/build.sh
LINK ERROR: Obsolete biblio ref: [rfc4122] is replaced by [rfc9562]. Either update the reference, or use [rfc4122 obsolete] if this is an intentionally-obsolete reference.
```

by replacing referenced to rfc4122 with [rfc9562](https://datatracker.ietf.org/doc/rfc9562/).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 8, 2024, 9:50 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL]([object Object])

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't find 'RFC9562' in bibliography data. Did you mean:
  atsc52
  bcp72
  csp2
  css2
  rfc2119
LINK ERROR: Multiple possible 'implementation-defined' dfn refs.
Arbitrarily chose https://infra.spec.whatwg.org/#implementation-defined
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:infra; type:dfn; text:implementation-defined
spec:ecmascript; type:dfn; text:implementation-defined
[=implementation-defined=]
LINK ERROR: Multiple possible 'document' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#concept-document
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:dom; type:dfn; text:document
spec:css-style-attr; type:dfn; text:document
[=Document=]
LINK ERROR: Multiple possible 'canvas' dfn refs.
Arbitrarily chose https://svgwg.org/svg2-draft/coords.html#TermCanvas
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:svg2; type:dfn; text:canvas
spec:css2; type:dfn; text:canvas
[=canvas=]
LINK ERROR: Multiple possible 'document' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#concept-document
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:dom; type:dfn; text:document
spec:css-style-attr; type:dfn; text:document
[=document=]
LINK ERROR: Multiple possible 'code point' dfn refs.
Arbitrarily chose https://infra.spec.whatwg.org/#code-point
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:infra; type:dfn; text:code point
spec:i18n-glossary; type:dfn; text:code point
[=code point=]
LINK ERROR: Multiple possible 'TypeError' exception refs.
Arbitrarily chose https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-typeerror
To auto-select one of the following refs, insert one of these lines into a &lt;pre class=link-defaults> block:
spec:ecmascript; type:exception; text:TypeError
spec:webidl; type:exception; text:TypeError
&lt;a bs-line-number="6910" data-link-type="exception" data-lt="TypeError">TypeError&lt;/a>
 ✘  Did not generate, due to errors exceeding the allowed error level.
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webdriver-bidi%23709.)._
</details>
