### PR TITLE
Update `browsingContext.locateNodes`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3394,6 +3394,8 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
     1. Let |child max depth| be null if |max depth| is null, or |max depth| - 1 otherwise.
 
+    1. If |child max depth| is equal to 0, then [=continue=].
+
     1. [=Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
       with |child nodes|, |selector|, |child max depth|, |match type|, |ignore case|, and |maximum returned node count|.
 


### PR DESCRIPTION
When maxDepth is 0 on non-html element node, ignore it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/712.html" title="Last updated on May 17, 2024, 1:12 PM UTC (67b389c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/712/34104f2...67b389c.html" title="Last updated on May 17, 2024, 1:12 PM UTC (67b389c)">Diff</a>