### PR TITLE
Update `browsingContext.locateNodes`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3386,16 +3386,18 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
   1. If |context node| implements {{Document}} or {{DocumentFragment}}:
 
+    Note: when traversing the document or document fragment, <code>max depth</code>
+    is not decreased intentionally to make the search result with
+    <code>document</code> and <code>document.documentElement</code> equivalent.
+
     1. Let |child nodes| be an empty [=/list=].
 
     1. For each node |child| in the <a spec=dom>children</a> of |context node|.
 
       1. [=list/Append=] |child| to |child nodes|.
 
-    1. Let |child max depth| be null if |max depth| is null, or |max depth| - 1 otherwise.
-
     1. [=Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
-      with |child nodes|, |selector|, |child max depth|, |match type|, |ignore case|, and |maximum returned node count|.
+      with |child nodes|, |selector|, |max depth|, |match type|, |ignore case|, and |maximum returned node count|.
 
   1. If |context node| does not implement {{HTMLElement}} then [=continue=].
 


### PR DESCRIPTION
Do not decrease max depth when traversing document or document fragment


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/713.html" title="Last updated on May 21, 2024, 6:53 AM UTC (d6ff4d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/713/34104f2...d6ff4d6.html" title="Last updated on May 21, 2024, 6:53 AM UTC (d6ff4d6)">Diff</a>