### PR TITLE
Add header validation in update response algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4751,7 +4751,17 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 
   1. For |header| in |command parameters|["<code>headers</code>"]:
 
-    1. Append [=deserialize header=] with |header| to |headers|.
+    1. Let |deserialized header| be [=deserialize header=] with |header|.
+
+    1. If |deserialized header|'s name does not match the [=field-name token=]
+       production, return [=error=] with [=error code=]
+      "<code>invalid argument</code>".
+
+    1. If |deserialized header|'s value does not match the [=header value=]
+       production, return [=error=] with [=error code=]
+      "<code>invalid argument</code>".
+
+    1. Append |deserialized header| to |headers|.
 
   1. Set |response|'s [=response/header list=] to |headers|.
 


### PR DESCRIPTION
Follow-up to #711, applies the same validation for headers in the update response algorithm


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/716.html" title="Last updated on May 23, 2024, 10:00 AM UTC (db314a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/716/cf436af...juliandescottes:db314a7.html" title="Last updated on May 23, 2024, 10:00 AM UTC (db314a7)">Diff</a>