### PR TITLE
Add network.setCacheBehavior command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1446,9 +1446,9 @@ To <dfn>cleanup remote end state</dfn>.
 
 1. [=map/Clear=] the [=before request sent map=].
 
-1. Set the [=default cache bypass=] to false.
+1. Set the [=default cache behavior=] to "<code>default</code>".
 
-1. [=set/Empty=] the [=navigable cache bypass set=].
+1. [=map/Clear=] the [=navigable cache behavior map=].
 
 </div>
 
@@ -4733,12 +4733,12 @@ A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
 empty map.  It's used to track the network events for which a
 <code>network.beforeRequestSent</code> event has already been sent.
 
-A [=remote end=] has a <dfn>default cache bypass</dfn> which is a boolean. It is
-initially false.
+A [=remote end=] has a <dfn>default cache behavior</dfn> which is a string. It is
+initially "<code>default</code>".
 
-A [=remote end=] has a <dfn>navigable cache bypass set</dfn> which is initially an
-empty weak set. It's used to track the [=/top-level traversables=] in which
-network caches are bypassed.
+A [=remote end=] has a <dfn>navigable cache behavior map</dfn> which is a weak
+map between [=/top-level traversables=] and strings representing cache
+behavior. It is initially empty.
 
 ### Network Intercepts ### {#network-intercepts}
 
@@ -6577,22 +6577,22 @@ requests will be affected.
 
 </div>
 
-#### The network.setCacheBypass Command ####  {#command-network-setCacheBypass}
+#### The network.setCacheBehavior Command ####  {#command-network-setCacheBehavior}
 
-The <dfn export for=commands>network.setCacheBypass</dfn> command bypasses the
-network cache for certain requests.
+The <dfn export for=commands>network.setCacheBehavior</dfn> command configures
+the network cache behavior for certain requests.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.SetCacheBypass = (
-        method: "network.setCacheBypass",
-        params: network.SetCacheBypassParameters
+      network.SetCacheBehavior = (
+        method: "network.setCacheBehavior",
+        params: network.SetCacheBehaviorParameters
       )
 
-      network.SetCacheBypassParameters = {
-        bypass: bool,
+      network.SetCacheBehaviorParameters = {
+        cacheBehavior: "default" / "bypass",
         ? contexts: [+browsingContext.BrowsingContext]
       }
     </pre>
@@ -6606,7 +6606,7 @@ network cache for certain requests.
 </dl>
 
 <div algorithm>
-The <dfn export>WebDriver BiDi bypass cache</dfn> steps given |request| are:
+The <dfn export>WebDriver BiDi cache behavior</dfn> steps given |request| are:
 
 1. Let |context| be null.
 
@@ -6618,53 +6618,78 @@ The <dfn export>WebDriver BiDi bypass cache</dfn> steps given |request| are:
      settings|' [=environment settings object/global object=], set |context| to
      the [=top-level browsing context=] for that browsing context.
 
-1. If |context| is not null and [=navigable cache bypass set=] [=set/contains=]
-   |context|, return true.
+1. If |context| is not null and [=navigable cache behavior map=] [=set/contains=]
+   |context|, return [=navigable cache behavior map=][|context|].
 
-1.  Return [=default cache bypass=].
+1. Return [=default cache behavior=].
 
 </div>
 
-<div algorithm="remote end steps for network.setCacheBypass">
+<div algorithm="remote end steps for network.setCacheBehavior">
 The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
 
-1. Let |bypass| be |command parameters|["<code>bypass</code>"].
+1. Let |behavior| be |command parameters|["<code>cacheBehavior</code>"].
 
 1. If |command parameters| does not [=map/contain=] "<code>contexts</code>":
 
- 1. Set the [=default cache bypass=] to |bypass|.
+  1. Set the [=default cache behavior=] to |behavior|.
 
- 1. If |bypass| is true, perform implementation-defined steps to disable any
-    implementation-specific resource caches for network requests. Otherwise
-    re-enable any implementation-specific resource caches for all contexts.
+  1. [=map/Clear=] [=navigable cache behavior map=].
 
- 1. Return [=success=] with data null.
+  1. Switch on the value of behavior:
+    <dl>
+      <dt>"<code>bypass</code>"
+      <dd>Perform implementation-defined steps to disable any
+        implementation-specific resource caches for all future
+        network requests.
+      <dt>"<code>default</code>"
+      <dd>Perform implementation-defined steps to enable any
+        implementation-specific resource caches that are usually enabled in the
+        current [=remote end=] configuration for all future network requests.
+    </dl>
+
+  1. Return [=success=] with data null.
 
 1. Let |contexts| be an empty [=/set=].
 
 1. For each |context id| of |command parameters|["<code>contexts</code>"]:
 
- 1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+  1. Let |context| be the result of [=trying=] to [=get a browsing context=]
     with |context id|.
 
- 1. If |context| is not a [=top-level browsing context=], return [=error=]
-    with [=error code=] [=invalid argument=].
+  1. If |context| is not a [=top-level browsing context=], return [=error=]
+     with [=error code=] [=invalid argument=].
 
- 1. [=list/Append=] |context| to |contexts|.
+  1. [=list/Append=] |context| to |contexts|.
 
 1. For each |context| in |contexts|:
 
-  1. If |bypass| is true:
+    1. If [=navigable cache behavior map=] [=map/contains=] |context|, and
+       [=navigable cache behavior map=][|context|] is equal to |behavior| then
+       continue.
 
-    1. [=set/append=] |context| to [=navigable cache bypass set=].
+    1. Switch on the value of behavior:
+      <dl>
+        <dt>"<code>bypass</code>"
+        <dd>Perform implementation-defined steps to disable any implementation-specific
+          resource caches for network requests originating from any browsing
+          context for which |context| is the [=top-level browsing context=].
+        <dt>"<code>default</code>"
+        <dd>Perform implementation-defined steps to enable any
+          implementation-specific resource caches that are usually enabled in the
+          current [=remote end=] configuration for network requests
+          originating from any browsing context for which |context| is the
+          [=top-level browsing context=].
+      </dl>
 
-    1. Perform implementation-defined steps to disable any implementation-specific
-       resource caches for network requests originating from |context|.
+    1. If |behavior| is equal to [=default cache behavior=]:
 
-  1. Otherwise, if [=navigable cache bypass set=] [=set/contains=]
-     |context|, [=set/remove=] |context| from [=navigable cache bypass set=] and
-     re-enable any implementation-specific resource caches for network requests
-     originating from |context|.
+      1. If [=navigable cache behavior map=] [=map/contains=] |context|,
+         [=map/remove=] [=navigable cache behavior map=][|context|].
+
+    1. Otherwise:
+
+      1. Set [=navigable cache behavior map=][|context|] to |behavior|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -1450,6 +1450,10 @@ To <dfn>cleanup remote end state</dfn>.
 
 1. [=map/Clear=] the [=navigable cache behavior map=].
 
+1. 1. Perform implementation-defined steps to enable any
+   implementation-specific resource caches that are usually enabled in the
+   current [=remote end=] configuration.
+
 </div>
 
 <div algorithm>
@@ -6640,12 +6644,11 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
     <dl>
       <dt>"<code>bypass</code>"
       <dd>Perform implementation-defined steps to disable any
-        implementation-specific resource caches for all future
-        network requests.
+        implementation-specific resource caches.
       <dt>"<code>default</code>"
       <dd>Perform implementation-defined steps to enable any
         implementation-specific resource caches that are usually enabled in the
-        current [=remote end=] configuration for all future network requests.
+        current [=remote end=] configuration.
     </dl>
 
   1. Return [=success=] with data null.

--- a/index.bs
+++ b/index.bs
@@ -4706,7 +4706,7 @@ NetworkCommand = (
   network.FailRequest //
   network.ProvideResponse //
   network.RemoveIntercept //
-  network.SetCacheBehavior //
+  network.SetCacheBehavior
 )
 
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -6577,7 +6577,7 @@ the network cache behaviour for certain requests.
 
       network.SetCacheModeParameters = {
         mode: "no-store" / null,
-        ? contexts: [browsingContext.BrowsingContext]
+        ? contexts: [+browsingContext.BrowsingContext]
       }
     </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -4706,7 +4706,7 @@ NetworkCommand = (
   network.FailRequest //
   network.ProvideResponse //
   network.RemoveIntercept //
-  network.SetCacheBypass //
+  network.SetCacheBehavior //
 )
 
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -4689,7 +4689,8 @@ NetworkCommand = (
   network.ContinueWithAuth //
   network.FailRequest //
   network.ProvideResponse //
-  network.RemoveIntercept
+  network.RemoveIntercept //
+  network.SetCacheMode //
 )
 
 </pre>
@@ -4715,6 +4716,13 @@ NetworkEvent = (
 A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
 empty map.  It's used to track the network events for which a
 <code>network.beforeRequestSent</code> event has already been sent.
+
+A [=remote end=] has a <dfn>default cache mode override</dfn> which is null or a
+string. It is initially null.
+
+A [=remote end=] has a <dfn>cache mode override map</dfn> which is initially an
+empty weak map. It's used to track the cache mode to use for requests from
+specific browsing contexts.
 
 ### Network Intercepts ### {#network-intercepts}
 
@@ -4971,7 +4979,6 @@ request in addition to the context.
 
 <div algorithm>
 To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
-
 
 1. Let |request data| be the result of [=get the request data=] with |request|.
 
@@ -6554,6 +6561,90 @@ requests will be affected.
 
 </div>
 
+#### The network.setCacheMode Command ####  {#command-network-setCacheMode}
+
+The <dfn export for=commands>network.removeSetCacheMode</dfn> command overrides
+the network cache behaviour for certain requests.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.SetCacheMode = (
+        method: "network.setCacheMode",
+        params: network.SetCacheModeParameters
+      )
+
+      network.SetCacheModeParameters = {
+        mode: "no-store" / null,
+        ? contexts: [browsingContext.BrowsingContext]
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl">
+      EmptyResult
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The <dfn export>WebDriver BiDi update request cache mode</dfn> steps given
+|request| are:
+
+1. Let |context| be null.
+
+1. If |request|'s [=request/window=] is an [=environment settings object=]:
+
+  1. Let |environment settings| be |request|'s [=request/window=]
+
+  1. If there is a [=/browsing context=] whose [=active window=] is |environment
+     settings|' [=environment settings object/global object=], set |context| to
+     the [=top-level browsing context=] for that context.
+
+1. If |context| is not null:
+
+  1. If [=cache mode override map=] [=map/contains=] |context|, set
+     |request|&apos;s [=request/cache mode=] to [=cache mode override
+     map=][|context|] and return.
+
+1. If [=default cache mode override=] is not null, set
+     |request|&apos;s [=request/cache mode=] to [=default cache mode override=].
+
+</div>
+
+<div algorithm="remote end steps for network.setCacheMode">
+The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
+
+1. Let |mode| be |command parameters|["<code>mode</code>"].
+
+1. If |command parameters| does not [=map/contain=] "<code>contexts</code>", set
+   the [=default cache mode override=] to |mode| and return [=success=] with
+   data null.
+
+1. Let |contexts| be an empty [=/list=].
+
+1. For each |context id| of |command parameters|["<code>contexts</code>"]:
+
+  1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+     with |context id|.
+
+  1. If |context| is not a [=top-level browsing context=], return [=error=]
+     with [=error code=] [=invalid argument=].
+
+  1. [=list/Append=] |context| to |contexts|.
+
+1. For each |context| in |contexts|:
+
+  1. If |mode| is null and [=cache mode override map=] [=map/contains=]
+     |context| [=map/remove=] |context| from [=cache mode override map=].
+
+  1. Otherwise, set [=cache mode override map=][|context|] to |mode|.
+
+1. Return [=success=] with data null.
+
+</div>
 
 ### Events ### {#module-network-event}
 

--- a/index.bs
+++ b/index.bs
@@ -6563,7 +6563,7 @@ requests will be affected.
 
 #### The network.setCacheMode Command ####  {#command-network-setCacheMode}
 
-The <dfn export for=commands>network.removeSetCacheMode</dfn> command overrides
+The <dfn export for=commands>network.setCacheMode</dfn> command overrides
 the network cache behaviour for certain requests.
 
 <dl>
@@ -6606,11 +6606,11 @@ The <dfn export>WebDriver BiDi update request cache mode</dfn> steps given
 1. If |context| is not null:
 
   1. If [=cache mode override map=] [=map/contains=] |context|, set
-     |request|&apos;s [=request/cache mode=] to [=cache mode override
+     |request|'s [=request/cache mode=] to [=cache mode override
      map=][|context|] and return.
 
 1. If [=default cache mode override=] is not null, set
-     |request|&apos;s [=request/cache mode=] to [=default cache mode override=].
+     |request|'s [=request/cache mode=] to [=default cache mode override=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1450,7 +1450,7 @@ To <dfn>cleanup remote end state</dfn>.
 
 1. [=map/Clear=] the [=navigable cache behavior map=].
 
-1. 1. Perform implementation-defined steps to enable any
+1. Perform implementation-defined steps to enable any
    implementation-specific resource caches that are usually enabled in the
    current [=remote end=] configuration.
 
@@ -4241,6 +4241,10 @@ the <dfn export>WebDriver BiDi navigable created</dfn> steps given
 
 1. Let |context| be |navigable|'s [=active browsing context=].
 
+1. If the [=context cache behavior=] with |context| is "<code>bypass</code>",
+   then perform implementation-defined steps to disable any implementation-specific
+   resource caches for network requests originating from |context|.
+
 1. Set |context|'s [=original opener=] to |opener navigable|'s [=active browsing context=],
    if |opener navigable| is provided.
 
@@ -6624,6 +6628,18 @@ The <dfn export>WebDriver BiDi cache behavior</dfn> steps given |request| are:
 
 1. If |context| is not null and [=navigable cache behavior map=] [=set/contains=]
    |context|, return [=navigable cache behavior map=][|context|].
+
+1. Return [=default cache behavior=].
+
+</div>
+
+<div algorithm>
+The <dfn>context cache behavior</dfn> steps given |context| are:
+
+1. Set |top-level context| to the [=top-level browsing context=] for |context|.
+
+1. If [=navigable cache behavior map=] [=map/contains=] |top-level context|, return
+   [=navigable cache behavior map=][|top-level context|].
 
 1. Return [=default cache behavior=].
 

--- a/index.bs
+++ b/index.bs
@@ -4690,7 +4690,7 @@ NetworkCommand = (
   network.FailRequest //
   network.ProvideResponse //
   network.RemoveIntercept //
-  network.SetCacheMode //
+  network.SetCacheBypass //
 )
 
 </pre>
@@ -4717,12 +4717,12 @@ A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
 empty map.  It's used to track the network events for which a
 <code>network.beforeRequestSent</code> event has already been sent.
 
-A [=remote end=] has a <dfn>default cache mode override</dfn> which is null or a
-string. It is initially null.
+A [=remote end=] has a <dfn>default cache bypass</dfn> which is a boolean. It is
+initially false.
 
-A [=remote end=] has a <dfn>cache mode override map</dfn> which is initially an
-empty weak map. It's used to track the cache mode to use for requests from
-specific browsing contexts.
+A [=remote end=] has a <dfn>navigable cache bypass set</dfn> which is initially an
+empty weak set. It's used to track the [=/top-level traversables=] in which
+network caches are bypassed.
 
 ### Network Intercepts ### {#network-intercepts}
 
@@ -6561,22 +6561,22 @@ requests will be affected.
 
 </div>
 
-#### The network.setCacheMode Command ####  {#command-network-setCacheMode}
+#### The network.setCacheBypass Command ####  {#command-network-setCacheBypass}
 
-The <dfn export for=commands>network.setCacheMode</dfn> command overrides
-the network cache behaviour for certain requests.
+The <dfn export for=commands>network.setCacheBypass</dfn> command bypasses the
+network cache for certain requests.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.SetCacheMode = (
-        method: "network.setCacheMode",
-        params: network.SetCacheModeParameters
+      network.SetCacheBypass = (
+        method: "network.setCacheBypass",
+        params: network.SetCacheBypassParameters
       )
 
-      network.SetCacheModeParameters = {
-        mode: "no-store" / null,
+      network.SetCacheBypassParameters = {
+        bypass: bool,
         ? contexts: [+browsingContext.BrowsingContext]
       }
     </pre>
@@ -6590,8 +6590,7 @@ the network cache behaviour for certain requests.
 </dl>
 
 <div algorithm>
-The <dfn export>WebDriver BiDi update request cache mode</dfn> steps given
-|request| are:
+The <dfn export>WebDriver BiDi bypass cache</dfn> steps given |request| are:
 
 1. Let |context| be null.
 
@@ -6601,46 +6600,55 @@ The <dfn export>WebDriver BiDi update request cache mode</dfn> steps given
 
   1. If there is a [=/browsing context=] whose [=active window=] is |environment
      settings|' [=environment settings object/global object=], set |context| to
-     the [=top-level browsing context=] for that context.
+     the [=top-level browsing context=] for that browsing context.
 
-1. If |context| is not null:
+1. If |context| is not null and [=navigable cache bypass set=] [=set/contains=]
+   |context|, return true.
 
-  1. If [=cache mode override map=] [=map/contains=] |context|, set
-     |request|'s [=request/cache mode=] to [=cache mode override
-     map=][|context|] and return.
-
-1. If [=default cache mode override=] is not null, set
-     |request|'s [=request/cache mode=] to [=default cache mode override=].
+1.  Return [=default cache bypass=].
 
 </div>
 
-<div algorithm="remote end steps for network.setCacheMode">
+<div algorithm="remote end steps for network.setCacheBypass">
 The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
 
-1. Let |mode| be |command parameters|["<code>mode</code>"].
+1. Let |bypass| be |command parameters|["<code>bypass</code>"].
 
-1. If |command parameters| does not [=map/contain=] "<code>contexts</code>", set
-   the [=default cache mode override=] to |mode| and return [=success=] with
-   data null.
+1. If |command parameters| does not [=map/contain=] "<code>contexts</code>":
 
-1. Let |contexts| be an empty [=/list=].
+ 1. Set the [=default cache bypass=] to |bypass|.
+
+ 1. If |bypass| is true, perform implementation-defined steps to disable any
+    implementation-specific resource caches for network requests. Otherwise
+    re-enable any implementation-specific resource caches for all contexts.
+
+ 1. Return [=success=] with data null.
+
+1. Let |contexts| be an empty [=/set=].
 
 1. For each |context id| of |command parameters|["<code>contexts</code>"]:
 
-  1. Let |context| be the result of [=trying=] to [=get a browsing context=]
-     with |context id|.
+ 1. Let |context| be the result of [=trying=] to [=get a browsing context=]
+    with |context id|.
 
-  1. If |context| is not a [=top-level browsing context=], return [=error=]
-     with [=error code=] [=invalid argument=].
+ 1. If |context| is not a [=top-level browsing context=], return [=error=]
+    with [=error code=] [=invalid argument=].
 
-  1. [=list/Append=] |context| to |contexts|.
+ 1. [=list/Append=] |context| to |contexts|.
 
 1. For each |context| in |contexts|:
 
-  1. If |mode| is null and [=cache mode override map=] [=map/contains=]
-     |context| [=map/remove=] |context| from [=cache mode override map=].
+  1. If |bypass| is true:
 
-  1. Otherwise, set [=cache mode override map=][|context|] to |mode|.
+    1. [=set/append=] |context| to [=navigable cache bypass set=].
+
+    1. Perform implementation-defined steps to disable any implementation-specific
+       resource caches for network requests originating from |context|.
+
+  1. Otherwise, if [=navigable cache bypass set=] [=set/contains=]
+     |context|, [=set/remove=] |context| from [=navigable cache bypass set=] and
+     re-enable any implementation-specific resource caches for network requests
+     originating from |context|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -1435,7 +1435,20 @@ To <dfn>cleanup the session</dfn> given |session|:
 
 1. [=Close the WebSocket connections=] with |session|.
 
+1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
+
 1. Perform any implementation-specific cleanup steps.
+
+</div>
+
+<div algorithm>
+To <dfn>cleanup remote end state</dfn>.
+
+1. [=map/Clear=] the [=before request sent map=].
+
+1. Set the [=default cache bypass=] to false.
+
+1. [=set/Empty=] the [=navigable cache bypass set=].
 
 </div>
 
@@ -2323,6 +2336,9 @@ BrowsingContextEvent = (
 
 A [=remote end=] has a <dfn>device pixel ratio overrides</dfn> which is a weak map
 between [=navigables=] and device pixel ratio overrides. It is initially empty.
+
+Note: this map is not cleared when the final session ends i.e. device pixel
+ratio overrides outlive any WebDriver session.
 
 ### Types ### {#module-browsingcontext-types}
 


### PR DESCRIPTION
This currently only allows setting the request cache mode to 'no-store' which bypasses the cache entirely. If we have future use cases for setting different cache modes, this appraoch would be extensible to those use cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/721.html" title="Last updated on Jul 3, 2024, 6:12 PM UTC (331e65f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/721/05a283e...331e65f.html" title="Last updated on Jul 3, 2024, 6:12 PM UTC (331e65f)">Diff</a>