### PR TITLE
Rename |is root| to |include parent id|

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2379,7 +2379,7 @@ TODO: make this return a list in document order
 
 <div algorithm>
 To <dfn>get the browsing context info</dfn> given |context|,
-|max depth| and |is root|:
+|max depth| and |include parent id|:
 
 1. Let |context id| be the [=browsing context id=] for |context|.
 
@@ -2419,7 +2419,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
 1. Let |context info| be a [=/map=] matching the
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
-   if |is root| is <code>false</code>, or unset otherwise, the <code>url</code>
+   if |include parent id| is <code>true</code>, or unset otherwise, the <code>url</code>
    field set to |url|, the <code>userContext</code> field set to
    |user context|'s [=user context id=], and the <code>children</code> field
    set to |child infos|.

--- a/index.bs
+++ b/index.bs
@@ -2419,7 +2419,7 @@ To <dfn>get the browsing context info</dfn> given |context|,
 1. Let |context info| be a [=/map=] matching the
    <code>browsingContext.Info</code> production with the <code>context</code>
    field set to |context id|, the <code>parent</code> field set to |parent id|
-   if |is root| is <code>true</code>, or unset otherwise, the <code>url</code>
+   if |is root| is <code>false</code>, or unset otherwise, the <code>url</code>
    field set to |url|, the <code>userContext</code> field set to
    |user context|'s [=user context id=], and the <code>children</code> field
    set to |child infos|.


### PR DESCRIPTION
|is root| makes it look like it indicates whether the context is a root of the context tree (parent id === null) but it actually indicates whether the |parent id| needs to be included into the resulting info object.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/726.html" title="Last updated on Jun 11, 2024, 2:23 PM UTC (a77d336)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/726/5614cf1...a77d336.html" title="Last updated on Jun 11, 2024, 2:23 PM UTC (a77d336)">Diff</a>