### PR TITLE
Change originalOpener to be optional

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2344,7 +2344,7 @@ browsingContext.InfoList = [*browsingContext.Info]
 browsingContext.Info = {
   children: browsingContext.InfoList / null,
   context: browsingContext.BrowsingContext,
-  originalOpener: browsingContext.BrowsingContext / null,
+  ? originalOpener: browsingContext.BrowsingContext,
   url: text,
   userContext: browser.UserContext,
   ? parent: browsingContext.BrowsingContext / null,
@@ -2440,7 +2440,8 @@ To <dfn>get the browsing context info</dfn> given |context|,
    if |include parent id| is <code>true</code>, or unset otherwise, the <code>url</code>
    field set to |url|, the <code>userContext</code> field set to
    |user context|'s [=user context id=], <code>originalOpener</code>
-   field set to |opener id|, and the <code>children</code> field
+   field set to |opener id| if |opener id| is not <code>null</code>,
+   or unset otherwise, and the <code>children</code> field
    set to |child infos|.
 
 1. Return |context info|.


### PR DESCRIPTION
Since the opener Id would not be present on each context, we think it makes sense to actually define it as an optional non-nullable attribute.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/730.html" title="Last updated on Jun 14, 2024, 12:47 PM UTC (4302f62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/730/a86a0c7...4302f62.html" title="Last updated on Jun 14, 2024, 12:47 PM UTC (4302f62)">Diff</a>