### PR TITLE
Update browsingContext.UserPromptOpened event parameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1662,17 +1662,6 @@ session.SystemProxyConfiguration = (
 
 </pre>
 
-#### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
-
-[=Remote end definition=] and [=local end definition=]
-
-<pre class="cddl remote-cddl local-cddl">
-session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
-</pre>
-
-The <code>session.UserPromptHandlerType</code> type represents the behavior
-of the user prompt handler.
-
 #### The session.UserPromptHandler Type #### {#type-session-UserPromptHandler}
 
 [=Remote end definition=] and [=local end definition=]
@@ -1689,6 +1678,17 @@ session.UserPromptHandler = {
 
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
+
+#### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
+</pre>
+
+The <code>session.UserPromptHandlerType</code> type represents the behavior
+of the user prompt handler.
 
 #### The session.SubscriptionRequest Type #### {#type-session-SubscriptionRequest}
 

--- a/index.bs
+++ b/index.bs
@@ -4632,7 +4632,7 @@ closed</dfn> steps given |window|, |type|, |accepted| and optional |user text|
 
         browsingContext.UserPromptOpenedParameters = {
           context: browsingContext.BrowsingContext,
-          handler: storage.UserPromptHandlerType,
+          handler: session.UserPromptHandlerType,
           message: text,
           type: browsingContext.UserPromptType,
           ? defaultValue: text

--- a/index.bs
+++ b/index.bs
@@ -1662,7 +1662,7 @@ session.SystemProxyConfiguration = (
 
 </pre>
 
-#### The session.UserPromptHandlerType #### {#type-session-UserPromptHandlerType}
+#### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
 
 [=Remote end definition=] and [=local end definition=]
 

--- a/index.bs
+++ b/index.bs
@@ -4623,7 +4623,7 @@ closed</dfn> steps given |window|, |type|, |accepted| and optional |user text|
 
         browsingContext.UserPromptOpenedParameters = {
           context: browsingContext.BrowsingContext,
-          handler: "accept" / "dismiss" / "ignore",
+          handler: storage.UserPromptHandlerType,
           message: text,
           type: browsingContext.UserPromptType,
           ? defaultValue: text

--- a/index.bs
+++ b/index.bs
@@ -1662,13 +1662,22 @@ session.SystemProxyConfiguration = (
 
 </pre>
 
-#### The session.UserPromptHandler Type #### {#type-session-UserPromptHandler}
+#### The session.UserPromptHandlerType #### {#type-session-UserPromptHandlerType}
 
 [=Remote end definition=] and [=local end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
 session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
+</pre>
 
+The <code>session.UserPromptHandlerType</code> type represents the behavior
+of the user prompt handler.
+
+#### The session.UserPromptHandler Type #### {#type-session-UserPromptHandler}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
 session.UserPromptHandler = {
   ? alert: session.UserPromptHandlerType,
   ? beforeUnload: session.UserPromptHandlerType,


### PR DESCRIPTION
Modifies the `handler` property of the event parameters to be of type `session.UserPromptHandlerType`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/738.html" title="Last updated on Jun 28, 2024, 4:45 PM UTC (6130c90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/738/05a283e...6130c90.html" title="Last updated on Jun 28, 2024, 4:45 PM UTC (6130c90)">Diff</a>