### PR TITLE
Add browsingContext.historyUpdated event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2333,6 +2333,7 @@ BrowsingContextEvent = (
   browsingContext.DomContentLoaded //
   browsingContext.DownloadWillBegin //
   browsingContext.FragmentNavigated //
+  browsingContext.HistoryUpdated //
   browsingContext.Load //
   browsingContext.NavigationAborted //
   browsingContext.NavigationFailed //
@@ -4360,6 +4361,38 @@ navigated</dfn> steps given |navigable| and |navigation status|:
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.fragmentNavigated</code>" and |related navigable|:
+
+  1. [=Emit an event=] with |session| and |body|.
+
+</div>
+
+#### The browsingContext.historyUpdated Event #### {#event-browsingContext-historyUpdated}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        browsingContext.HistoryUpdated = (
+         method: "browsingContext.historyUpdated",
+         params: {
+            url: text,
+         }
+        )
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updated</dfn> steps given |navigable|:
+
+1. Let |body| be a [=/map=] matching the
+    <code>browsingContext.HistoryUpdated</code> production, with the
+    <code>url</code> field set to |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=DOM>URL</a>.
+
+1. Let |related browsing contexts| be a [=/set=] containing |navigable|'s [=active browsing context=].
+
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>browsingContext.historyUpdated</code>" and |related browsing contexts|:
 
   1. [=Emit an event=] with |session| and |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -4388,10 +4388,10 @@ navigated</dfn> steps given |navigable| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updated</dfn> steps given |navigable|:
 
-1. Let |url| be the result of running the [=URL serializer=], 
+1. Let |url| be the result of running the [=URL serializer=],
    given |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=dom>URL</a>.
 
-1. Let |params| be a [=/map=] matching the <code>browsingContext.HistoryUpdatedParameters</code> production, 
+1. Let |params| be a [=/map=] matching the <code>browsingContext.HistoryUpdatedParameters</code> production,
    with the <code>url</code> field set to |url| and
    the <code>context<code> field set to |navigable|'s [=navigable id=].
 

--- a/index.bs
+++ b/index.bs
@@ -4388,8 +4388,11 @@ navigated</dfn> steps given |navigable| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updated</dfn> steps given |navigable|:
 
+1. Let |url| be the result of running the [=URL serializer=], 
+   given |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=dom>URL</a>.
+
 1. Let |params| be a [=/map=] matching the <code>browsingContext.HistoryUpdatedParameters</code> production, 
-   with the <code>url</code> field set to |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=DOM>URL</a> and
+   with the <code>url</code> field set to |url| and
    the <code>context<code> field set to |navigable|'s [=navigable id=].
 
 1. Let |body| be a [=/map=] matching the

--- a/index.bs
+++ b/index.bs
@@ -4393,7 +4393,7 @@ The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updat
 
 1. Let |params| be a [=/map=] matching the <code>browsingContext.HistoryUpdatedParameters</code> production,
    with the <code>url</code> field set to |url| and
-   the <code>context<code> field set to |navigable|'s [=navigable id=].
+   the <code>context</code> field set to |navigable|'s [=navigable id=].
 
 1. Let |body| be a [=/map=] matching the
    <code>browsingContext.HistoryUpdated</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -4373,11 +4373,14 @@ navigated</dfn> steps given |navigable| and |navigation status|:
    <dd>
       <pre class="cddl local-cddl">
         browsingContext.HistoryUpdated = (
-         method: "browsingContext.historyUpdated",
-         params: {
-            url: text,
-         }
+          method: "browsingContext.historyUpdated",
+          params: browsingContext.HistoryUpdatedParameters
         )
+
+        browsingContext.HistoryUpdatedParameters = {
+          context: browsingContext.BrowsingContext,
+          url: text
+        }
       </pre>
    </dd>
 </dl>
@@ -4385,9 +4388,13 @@ navigated</dfn> steps given |navigable| and |navigation status|:
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updated</dfn> steps given |navigable|:
 
+1. Let |params| be a [=/map=] matching the <code>browsingContext.HistoryUpdatedParameters</code> production, 
+   with the <code>url</code> field set to |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=DOM>URL</a> and
+   the <code>context<code> field set to |navigable|'s [=navigable id=].
+
 1. Let |body| be a [=/map=] matching the
-    <code>browsingContext.HistoryUpdated</code> production, with the
-    <code>url</code> field set to |navigable|'s [=active browsing context=]'s [=active document=]'s <a spec=DOM>URL</a>.
+   <code>browsingContext.HistoryUpdated</code> production, with the
+   <code>params</code> field set to |params|.
 
 1. Let |related browsing contexts| be a [=/set=] containing |navigable|'s [=active browsing context=].
 


### PR DESCRIPTION
This change adds `browsingContext.historyUpdated` event to notify the client when a history update happens.

Issue: https://github.com/w3c/webdriver-bidi/issues/502
HTML spec: https://github.com/whatwg/html/pull/10587


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/740.html" title="Last updated on Aug 29, 2024, 2:34 PM UTC (d1f691f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/740/287e9c6...d1f691f.html" title="Last updated on Aug 29, 2024, 2:34 PM UTC (d1f691f)">Diff</a>