### PR TITLE
Editorial: remove unused browsing context from navigable destroyed steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4263,8 +4263,7 @@ The [=remote end event trigger=] is:
 <div algorithm="remote end event trigger for browsingContext.contexDestroyed">
 
 The [=remote end event trigger=] is
-the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given
-|navigable| and <var ignore>browsing context</var>:
+the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|:
 
 1. Let |params| be the result of [=get the navigable info=], given
    |navigable|, null, and true.


### PR DESCRIPTION
HTML spec change: https://github.com/whatwg/html/pull/10490


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/751.html" title="Last updated on Jul 17, 2024, 10:49 AM UTC (f3af048)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/751/712c17f...f3af048.html" title="Last updated on Jul 17, 2024, 10:49 AM UTC (f3af048)">Diff</a>