### PR TITLE
Replace HTML's "report the exception" with "report an exception".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7123,6 +7123,9 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
        |navigable|. Otherwise let |realm| be |environment settings|'
        [=realm execution context=]'s Realm component.
 
+    1. Let |exception reporting global| be be |environment settings|'
+       [=realm execution context=]'s Realm component's [=realm/global object=].
+
     1. Let |arguments| be |preload script|'s <code>arguments</code>.
 
     1. Let |deserialized arguments| be an empty list.
@@ -7140,13 +7143,13 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. Let |function declaration| be |preload script|'s <code>function declaration</code>.
 
-    1. Let (|script|, |function body evaluation status|) be the result of
+    1. Let (<var ignore>script</var>, |function body evaluation status|) be the result of
        [=evaluate function body=] with |function declaration|,
        |environment settings|, |base URL|, and |options|.
 
     1. If |function body evaluation status| is an [=abrupt completion=], then
-       [=report the exception=] given by |function body evaluation status|.\[[Value]]
-       for |script|.
+       [=report an exception=] given by |function body evaluation status|.\[[Value]]
+       for |exception reporting global|.
 
     1. Let |function object| be |function body evaluation status|.\[[Value]].
 
@@ -7154,7 +7157,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
        1. Let |error| be a new <a data-link-type="exception">TypeError</a> object in |realm|.
 
-       1. [=Report the exception=] |error|.
+       1. [=Report an exception=] |error| for |exception reporting global|.
 
     1. [=Prepare to run script=] with |environment settings|.
 
@@ -7164,7 +7167,8 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
     1. [=Clean up after running script=] with |environment settings|.
 
     1. If |evaluation status| is an [=abrupt completion=], then
-       [=report the exception=] given by |evaluation status|.\[[Value]] for |script|.
+       [=report an exception=] given by |evaluation status|.\[[Value]] for
+       |exception reporting global|.
 
 </div>
 


### PR DESCRIPTION
The former is deprecated. Currently, the environment settings object's realm's global is used (which is consistent with what the spec would previously have said before). It's possible this ought to use the sandbox's realm, but that realm is not currently used for the function evaluation itself right now -- and that's the function whence the error comes.

This is part of whatwg/html#10516.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/webdriver-bidi/pull/758.html" title="Last updated on Jul 30, 2024, 9:09 PM UTC (c1a8934)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/758/da20dfc...jeremyroman:c1a8934.html" title="Last updated on Jul 30, 2024, 9:09 PM UTC (c1a8934)">Diff</a>