### PR TITLE
`browsingContext.traverseHistory` only for top-level navigables

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4096,6 +4096,9 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
    with |command parameters|["<code>context</code>"].
 
+1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
+   [=error code=] [=invalid argument=].
+
 1. Assert: |navigable| is not null.
 
 1. Let |delta| be |command parameters|["<code>delta</code>"].


### PR DESCRIPTION
Allow `browsingContext.traverseHistory` command only for top-level browsing contexts.

[**Session history traversal queue**](https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-all-used-history-steps) and [**get all used history steps**](https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-all-used-history-steps) are defined only for the [**traversable navigable**](https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable), which in our case is the top-level browsing context. ([Key difference](https://html.spec.whatwg.org/multipage/document-sequences.html#infrastructure-for-sequences-of-documents) between *navigables* and *traversable navigables* is the [*session history traversal queue*](https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-traversal-queue)).

Current API and WPT test [`webdriver/tests/bidi/browsing_context/traverse_history/context.py::test_iframe`](https://github.com/web-platform-tests/wpt/blob/54ce43a90a73a25c05cb669e5abc7929039baab4/webdriver/tests/bidi/browsing_context/traverse_history/context.py#L32) can be a bit confusing, e.g. in the follwoing scenario:
1. There is a page with 2 iframes (`iframe_1`, `iframe_2`) with `initial_url` both.
2. `iframe_1` is navigated to `some_url`.
3. `iframe_2` is navigated to `another_url`.
at this point the **session history traversal queue** is:
* "1": some initial state
* "2": `iframe_1` -> `some_url`
* "3": `iframe_2` -> `another_url`
4. `browsingContext.traverseHistory` is called on `iframe_1` with `delta: -1`.

**Specified behavior:**
5. **session history traversal queue** is stepped back to step "2", effectively `iframe_1` is kept on `some_url` and `iframe_2` stepped back to `initial_url`.

**Expected behavior:**
5. `iframe_1` is stepped back to `initial_url` and `iframe_2` is kept pointing to `another_url`.

The WebDriver Classic spec also operates only the *current top-level browsing context*: https://w3c.github.io/webdriver/#back

WPT test to be added afterwards.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/770.html" title="Last updated on Sep 13, 2024, 10:01 AM UTC (1b632fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/770/0575bf7...1b632fb.html" title="Last updated on Sep 13, 2024, 10:01 AM UTC (1b632fb)">Diff</a>