### PR TITLE
Fix "browser.setClientWindowRect" references to "browser.setClientWindowState"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2560,7 +2560,7 @@ The [=remote end steps=] with |command parameters| are:
 
 #### The browser.setClientWindowState Command #### {#command-browser-setClientWindowState}
 
-The <dfn export for=commands>browser.setClientWindowRect</dfn> command sets the
+The <dfn export for=commands>browser.setClientWindowState</dfn> command sets the
 dimensions of a [=client window=].
 
 <dl>
@@ -2598,7 +2598,7 @@ dimensions of a [=client window=].
    </dd>
 </dl>
 
-<div algorithm="remote end steps for browser.setClientWindowRect">
+<div algorithm="remote end steps for browser.setClientWindowState">
 
 The [=remote end steps=] with <var ignore>session</var> and |command parameters| are:
 


### PR DESCRIPTION
Follow-up for https://github.com/w3c/webdriver-bidi/pull/752 where we missed to rename two instances of `browser.setClientWindowRect` to the final command name.

@jgraham can you please review?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/785.html" title="Last updated on Sep 19, 2024, 6:29 PM UTC (f87455e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/785/d620065...whimboo:f87455e.html" title="Last updated on Sep 19, 2024, 6:29 PM UTC (f87455e)">Diff</a>