### PR TITLE
Fix return in preload script steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7548,7 +7548,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
        1. Let |navigable id| be |navigable|’s [=navigable/top-level traversable=]'s id.
 
-       1. If <code>contexts</code> does not [=list/contains|contain=] |navigable id|, return.
+       1. If |preload script|'s <code>contexts</code> does not [=list/contains|contain=] |navigable id|, continue.
 
     1. If |preload script|'s <code>sandbox</code> is not null, let |realm| be [=get
        or create a sandbox realm=] with |preload script|'s <code>sandbox</code> and


### PR DESCRIPTION
I believe the steps meant to continue checking other preload scripts if the current one does not match.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/802.html" title="Last updated on Oct 25, 2024, 12:35 PM UTC (059274d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/802/e8266d1...059274d.html" title="Last updated on Oct 25, 2024, 12:35 PM UTC (059274d)">Diff</a>