### PR TITLE
Include stacktrace into log messages

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10854,7 +10854,7 @@ Define the following [=console steps=] with |method|, |args|, and
 
   1. Let |source| be the result of [=get the source=] given [=current Realm Record=].
 
-  1. If |method| is "<code>assert</code>", "<code>error</code>",
+  1. If |method| is "<code>assert</code>", "<code>error</code>", "<code>log</code>",
      "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
      stack trace=]. Otherwise let |stack| be null.
 


### PR DESCRIPTION
This would align behavior in Chrome and the spec and support the following use case:

As a user I want to filter out console messages from third party libraries. For this, I could use the URLs in the stack trace.

Related discussions:

- https://github.com/puppeteer/puppeteer/issues/13264
- https://github.com/whatwg/console/issues/203

Low-priority and we can discuss later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/807.html" title="Last updated on Jan 13, 2025, 10:51 AM UTC (a86f3e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/807/a9e13a5...a86f3e6.html" title="Last updated on Jan 13, 2025, 10:51 AM UTC (a86f3e6)">Diff</a>