### PR TITLE
Expose initiatorType and destination on network.Request

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5829,6 +5829,8 @@ network.RequestData = {
     cookies: [*network.Cookie],
     headersSize: js-uint,
     bodySize: js-uint / null,
+    destination: text,
+    initiatorType: text,
     timings: network.FetchTimingInfo,
 };
 </pre>
@@ -5879,15 +5881,20 @@ To <dfn>get the request data</dfn> given |request|:
 
        1. Append the result of [=serialize cookie=] given |cookie| to |cookies|.
 
+1. Let |destination| be |request|'s [=request/destination=].
+
+1. Let |initiator type| be |request|'s [=request/initiator type=].
+
 1. Let |timings| be [=get the fetch timings=] with |request|.
 
 1. Return a map matching the <code>network.RequestData</code> production, with
    the <code>request</code> field set to |request id|, <code>url</code> field
    set to |url|, the <code>method</code> field set to |method|, the
    <code>headers</code> field set to |headers|, the |cookies| field set to
-   |cookies|, and the <code>headersSize</code> field set to |headers size|,
-   the <code>bodySize</code> field set to |body size|, and the
-   <code>timings</code> field set to |timings|.
+   |cookies|, the <code>headersSize</code> field set to |headers size|, the
+   <code>bodySize</code> field set to |body size|, the <code>destination</code>
+   field set to |destination|, the <code>initiatorType</code> field set to
+   |initiator type|, and the <code>timings</code> field set to |timings|.
 
 </div>
 


### PR DESCRIPTION
Currently we have network.Initiator, which exposes some detailed information about the stack trace that generated the request on network.beforeRequestSent, plus a `type` field that's not well defined.

Fetch exposes `initiatorType` and `destination` and these are already used by other standards e.g. performanceTiming. Having data that directly corresponds to those other specs makes a good deal of sense so that e.g. performance measurements using WebDriver have the same fields with the same information as the DOM measurement APIs.

With this change we could remove `Network.Initiator.type` since that's redundant with this data, but keep the field for extra information about the stack that generated a request.