### PR TITLE
Extend locateNodes with a locator to get navigable's container element

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2967,7 +2967,7 @@ To <dfn>await a navigation</dfn> given |navigable|, |request|, |wait condition|,
 browsingContext.Locator = (
    browsingContext.AccessibilityLocator /
    browsingContext.CssLocator /
-   browsingContext.ContainerLocator /
+   browsingContext.ContextLocator /
    browsingContext.InnerTextLocator /
    browsingContext.XPathLocator
 )
@@ -2985,8 +2985,8 @@ browsingContext.CssLocator = {
    value: text
 }
 
-browsingContext.ContainerLocator = {
-  type: "container",
+browsingContext.ContextLocator = {
+  type: "context",
   value: {
     context: text,
   }
@@ -3792,7 +3792,7 @@ To <dfn>locate nodes using CSS</dfn> with given |navigable|, |context nodes|,
 </div>
 
 <div algorithm="locate the container element">
-To <dfn>locate the container element</dfn> with given |navigable|:
+To <dfn>locate the container element</dfn> given |navigable|:
 
 1. Let |returned nodes| be an empty [=/list=].
 
@@ -4070,7 +4070,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. Let |result nodes| be [=locate nodes using accessibility attributes=]
             given |context nodes|, |selector|, and |maximum returned node count|.
 
-      <dt>|type| is the string "<code>container</code>"
+      <dt>|type| is the string "<code>context</code>"
       <dd>
 
          1. If |start nodes parameter| is not null,
@@ -4078,9 +4078,16 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. Let |selector| be |locator|["<code>value</code>"].
 
-         1. Let |child navigable| be |selector|["<code>context</code>"].
+         1. Let |context id| be |selector|["<code>context</code>"].
+
+         1. Let |child navigable| be the result of [=trying=] to [=get a navigable=] with |context id|.
+
+         1. If |child navigable|'s [=navigable/parent=] is not |navigable|,
+            return [=error=] with [=error code=] "<code>invalid argument</code>".
 
          1. Let |result nodes| be [=locate the container element=] given |child navigable|.
+
+         1. Assert: For each |node| in |result nodes|, |node|'s [=/node navigable=] is |navigable|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.

--- a/index.bs
+++ b/index.bs
@@ -2988,7 +2988,7 @@ browsingContext.CssLocator = {
 browsingContext.ContextLocator = {
   type: "context",
   value: {
-    context: text,
+    context: browsingContext.BrowsingContext,
   }
 }
 

--- a/index.bs
+++ b/index.bs
@@ -2987,6 +2987,9 @@ browsingContext.CssLocator = {
 
 browsingContext.ContainerLocator = {
   type: "container",
+  value: {
+    context: text,
+  }
 }
 
 browsingContext.InnerTextLocator = {
@@ -4070,9 +4073,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
       <dt>|type| is the string "<code>container</code>"
       <dd>
 
-         1. Issue: throw errors if extra unused optional params are set?
+         1. If |start nodes parameter| is not null,
+            return [=error=] with [=error code=] "<code>invalid argument</code>".
 
-         1. Let |result nodes| be [=locate the container element=] given |navigable|.
+         1. Let |selector| be |locator|["<code>value</code>"].
+
+         1. Let |child navigable| be |selector|["<code>context</code>"].
+
+         1. Let |result nodes| be [=locate the container element=] given |child navigable|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.

--- a/index.bs
+++ b/index.bs
@@ -2967,6 +2967,7 @@ To <dfn>await a navigation</dfn> given |navigable|, |request|, |wait condition|,
 browsingContext.Locator = (
    browsingContext.AccessibilityLocator /
    browsingContext.CssLocator /
+   browsingContext.ContainerLocator /
    browsingContext.InnerTextLocator /
    browsingContext.XPathLocator
 )
@@ -2982,6 +2983,10 @@ browsingContext.AccessibilityLocator = {
 browsingContext.CssLocator = {
    type: "css",
    value: text
+}
+
+browsingContext.ContainerLocator = {
+  type: "container",
 }
 
 browsingContext.InnerTextLocator = {
@@ -3783,6 +3788,18 @@ To <dfn>locate nodes using CSS</dfn> with given |navigable|, |context nodes|,
 
 </div>
 
+<div algorithm="locate the container element">
+To <dfn>locate the container element</dfn> with given |navigable|:
+
+1. Let |returned nodes| be an empty [=/list=].
+
+1. If |navigable|'s [=navigable/container=] is not null,
+   append |navigable|'s [=navigable/container=] to |returned nodes|.
+
+1. Return |returned nodes|.
+
+</div>
+
 <div algorithm="locate nodes using XPath">
 
 To <dfn>locate nodes using XPath</dfn> with given |navigable|, |context nodes|,
@@ -4049,6 +4066,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. Let |result nodes| be [=locate nodes using accessibility attributes=]
             given |context nodes|, |selector|, and |maximum returned node count|.
+
+      <dt>|type| is the string "<code>container</code>"
+      <dd>
+
+         1. Issue: throw errors if extra unused optional params are set?
+
+         1. Let |result nodes| be [=locate the container element=] given |navigable|.
 
 1. Assert: |maximum returned node count| is null or [=list/size=] of |result nodes| is less
    than or equal to |maximum returned node count|.


### PR DESCRIPTION
This change adds a new locator called `context`: when called for a parent navigable, given a child navigable as a locator, it locates the container element for the child navigable that is located within the parent navigable. While providing the parent navigable is redundant and it can be computed based on the child navigable, the interface matches existing locators which all select a node within the parent navigable that matches the locator criteria. In this case, the criterion is the child navigable identifier. 

Providing start nodes to this locator would currently trigger an invalid argument error but eventually it could be supported if there is a use case.
 
Closes #794


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/811.html" title="Last updated on Dec 19, 2024, 11:28 AM UTC (0729b55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/811/4a85452...0729b55.html" title="Last updated on Dec 19, 2024, 11:28 AM UTC (0729b55)">Diff</a>