### PR TITLE
Make sure --upgrade results in a pip --upgrade

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -ex
 
-if ! [ -x "$(command -v bikeshed)" ] || [ "$1" = "--upgrade" ]; then
+if ! [ -x "$(command -v bikeshed)" ]; then
     echo 'Installing bikeshed'
     python3 -m pip install bikeshed
+elif [ "$1" = "--upgrade" ]; then
+    echo 'Upgrading bikeshed'
+    python3 -m pip install --upgrade bikeshed
 fi
 
 bikeshed update


### PR DESCRIPTION
I noticed that `--upgrade` was no upgrading Bikeshed for me locally resulting in errors like for bikeshed v3

```
FATAL ERROR: Something's gone wrong with the remote data; I can't read its timestamp. Please report this!
 ✘  Did not generate, due to fatal errors
 ```
