### PR TITLE
Deprecate the type field on Network.Initiator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5743,31 +5743,27 @@ To <dfn>deserialize header</dfn> given |protocol header|:
 
 <pre class="cddl local-cddl">
 network.Initiator = {
-    type: "parser" / "script" / "preflight" / "other",
     ? columnNumber: js-uint,
     ? lineNumber: js-uint,
     ? stackTrace: script.StackTrace,
-    ? request: network.Request
+    ? request: network.Request,
+    ? type: "parser" / "script" / "preflight" / "other"
 };
 </pre>
 
 The <code>network.Initiator</code> type represents the source of a network
 request.
 
+Note: The <code>type</code> field is included in the definition for backwards
+compatibility, but is no longer set by the [=get the initiator=] steps, and will
+be removed in a future revision of this specification. Its use is expected to be
+replaced by <code>initiatorType</code> and <code>destination</code> on
+<code>network.RequestData</code>.
+
 <div algorithm>
 To <dfn>get the initiator</dfn> given |request|:
 
 1. Let |request id| be |request|'s [=request id=].
-
-1. Let |type| be "<code>other</code>".
-
-1. If |request| is a [=CORS-Preflight Request=], set |type| to
-   "<code>preflight</code>".
-
-1. TODO: Get the |type|. It's not quite clear how this ought to work; the CDP
-   data depends on whether the navigation was kicked off by the parser or by
-   script (so e.g. inserting an image from script causes the initiator to be
-   "<code>script</code>"), but that doesn't correspond to anything in Fetch.
 
 1. If |request|'s [=request/initiator type=] is "<code>fetch</code>" or
    "<code>xmlhttprequest</code>":
@@ -5784,13 +5780,12 @@ To <dfn>get the initiator</dfn> given |request|:
   TODO: Chrome includes the current parser position as column number / line
   number for parser-inserted resources.
 
-1. Return a [=/map=] matching the <code>network.Initiator</code> production, with
-   the <code>type</code> field set to |type|, the <code>columnNumber</code>
-   field set to |column number| if it's not null, or omitted otherwise, the
-   <code>lineNumber</code> field set to |line number| if it's not null, or
-   omitted otherwise, the <code>stackTrace</code> field set to |stack trace| if
-   it's not null, or omitted otherwise, and the <code>request</code> field set
-   to |request id|.
+1. Return a [=/map=] matching the <code>network.Initiator</code> production, the
+   <code>columnNumber</code> field set to |column number| if it's not null, or
+   omitted otherwise, the <code>lineNumber</code> field set to |line number| if
+   it's not null, or omitted otherwise, the <code>stackTrace</code> field set to
+   |stack trace| if it's not null, or omitted otherwise, and the
+   <code>request</code> field set to |request id|.
 
 </div>
 


### PR DESCRIPTION
This marks the field as optional and no longer sets it, so the CDDL continues to match existing implementations, but it's no longer required to set it.