### PR TITLE
Remove request field from network.Initiator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5765,7 +5765,7 @@ compatibility, but is no longer set by the [=get the initiator=] steps, and will
 be removed in a future revision of this specification. The
 <code>network.Initiator</code> is included in the
 <code>network.BeforeRequestSentParameters</code> which also contain the same
-request id, which makes the information redundant. See
+request id, making this information redundant. See
 [[#type-network-BaseParameters]].
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5745,8 +5745,8 @@ To <dfn>deserialize header</dfn> given |protocol header|:
 network.Initiator = {
     ? columnNumber: js-uint,
     ? lineNumber: js-uint,
-    ? stackTrace: script.StackTrace,
     ? request: network.Request,
+    ? stackTrace: script.StackTrace,
     ? type: "parser" / "script" / "preflight" / "other"
 };
 </pre>
@@ -5760,10 +5760,14 @@ be removed in a future revision of this specification. Its use is expected to be
 replaced by <code>initiatorType</code> and <code>destination</code> on
 <code>network.RequestData</code>.
 
+Note: The <code>request</code> field is included in the definition for backwards
+compatibility, but is no longer set by the [=get the initiator=] steps, and will
+be removed in a future revision of this specification. The network.Initiator is
+included in the BeforeRequestSentParameters which also contain the same request
+id, which makes the information redundant.
+
 <div algorithm>
 To <dfn>get the initiator</dfn> given |request|:
-
-1. Let |request id| be |request|'s [=request id=].
 
 1. If |request|'s [=request/initiator type=] is "<code>fetch</code>" or
    "<code>xmlhttprequest</code>":
@@ -5783,9 +5787,8 @@ To <dfn>get the initiator</dfn> given |request|:
 1. Return a [=/map=] matching the <code>network.Initiator</code> production, the
    <code>columnNumber</code> field set to |column number| if it's not null, or
    omitted otherwise, the <code>lineNumber</code> field set to |line number| if
-   it's not null, or omitted otherwise, the <code>stackTrace</code> field set to
-   |stack trace| if it's not null, or omitted otherwise, and the
-   <code>request</code> field set to |request id|.
+   it's not null, or omitted otherwise and the <code>stackTrace</code> field set
+   to |stack trace| if it's not null, or omitted otherwise.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5762,9 +5762,11 @@ replaced by <code>initiatorType</code> and <code>destination</code> on
 
 Note: The <code>request</code> field is included in the definition for backwards
 compatibility, but is no longer set by the [=get the initiator=] steps, and will
-be removed in a future revision of this specification. The network.Initiator is
-included in the BeforeRequestSentParameters which also contain the same request
-id, which makes the information redundant.
+be removed in a future revision of this specification. The
+<code>network.Initiator</code> is included in the
+<code>network.BeforeRequestSentParameters</code> which also contain the same
+request id, which makes the information redundant. See
+[[#type-network-BaseParameters]].
 
 <div algorithm>
 To <dfn>get the initiator</dfn> given |request|:


### PR DESCRIPTION
Just a follow up to my comment on https://github.com/w3c/webdriver-bidi/pull/813/files#r1843522432 

By definition at the moment the initiator cannot be empty, because request id is always defined. I'm proposing to remove it, it doesn't sound useful. We also did not emit it in Firefox FWIW. 

cc @jgraham


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/815.html" title="Last updated on Nov 22, 2024, 11:15 AM UTC (0cfac08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/815/46306e8...juliandescottes:0cfac08.html" title="Last updated on Nov 22, 2024, 11:15 AM UTC (0cfac08)">Diff</a>