### PR TITLE
Fix build by referencing css22 instead of css2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2046,7 +2046,7 @@ BrowserResult = (
 
 Each [=/top-level traversable=] is associated with a single <dfn>client
 window</dfn> which represents a rectangular area containing the
-<a spec=css2>viewport</a> that will be used to render that [=/top-level
+<a spec=css22>viewport</a> that will be used to render that [=/top-level
 traversable=]'s [=active document=] when its [=visibility state=] is
 "<code>visible</code>", as well as any browser-specific user interface elements
 associated with displaying the traversable (e.g. any URL bar, toolbars, or OS


### PR DESCRIPTION
I guess the spec ID was changed due to https://drafts.csswg.org/css2/#css2.2-v-css2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/816.html" title="Last updated on Nov 15, 2024, 6:29 PM UTC (f75673b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/816/3754ad3...f75673b.html" title="Last updated on Nov 15, 2024, 6:29 PM UTC (f75673b)">Diff</a>