### PR TITLE
Fix broken fragment references in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,7 @@ spec: RFC8610; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8610
 spec: RFC6265
   type: dfn
     text: Cookie; url: https://httpwg.org/specs/rfc6265.html
-    text: Cookie store; url: https://httpwg.org/specs/rfc6265.html
+    text: Cookie store; url: https://httpwg.org/specs/rfc6265.html#storage-model
 spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-05
   type: dfn
     text: Lax; url: section-4.1.2.7

--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webdriver/test
 </pre>
 
 <pre class=anchors>
-spec: RFC6455; urlPrefix: https://tools.ietf.org/html/rfc6455
+spec: RFC6455; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455
   type: dfn
     text: WebSocket URI; url: section-3
     text: Establishes a WebSocket Connection; url: section-4.1
@@ -34,23 +34,23 @@ spec: RFC6455; urlPrefix: https://tools.ietf.org/html/rfc6455
     text: Fail the WebSocket Connection; url: section-7.1.7
     text: Status Codes; url: section-7.4
     text: Handling Errors in UTF-8-Encoded Data; url: section-8.1
-spec: RFC8610; urlPrefix: https://tools.ietf.org/html/rfc8610
+spec: RFC8610; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455#section-3
   type: dfn
     text: match a CDDL specification; url: appendix-C
 spec: RFC6265; urlPrefix: https://httpwg.org/specs/rfc6265.html
   type: dfn
-    text: Cookie; url: section-5.3
-    text: Cookie store; url: section-5.3
-spec: RFC6265bis; urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05
+    text: Cookie; url: storage-model
+    text: Cookie store; url: storage-model
+spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-05
   type: dfn
     text: Lax; url: section-4.1.2.7
     text: Strict; url: section-4.1.2.7
 spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
   type: dfn
-    text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithm
+    text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithms
     text: actions; url: actions
     text: actions options; url: dfn-actions-options
-    text: active sessions; url: dfn-active-session
+    text: active sessions; url: dfn-active-sessions
     text: additional WebDriver capability; url: dfn-additional-webdriver-capability
     text: additional capability deserialization algorithm; url: dfn-additional-capability-deserialization-algorithm
     text: capability name; url: dfn-capability-name
@@ -70,16 +70,16 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: draw a bounding box from the framebuffer; url: dfn-draw-a-bounding-box-from-the-framebuffer
     text: endpoint node; url: dfn-endpoint-node
     text: error code; url: dfn-error-code
-    text: error; url: dfn-errors
+    text: error; url: errors
     text: extract an action sequence; url: dfn-extract-an-action-sequence
     text: get a node; url: dfn-get-a-node
     text: get element origin; url: dfn-get-element-origin
     text: get or create a node reference; url: dfn-get-or-create-a-node-reference
     text: get the input state; url: dfn-get-the-input-state
-    text: getting a property; url: dfn-get-a-property
+    text: getting a property; url: dfn-getting-properties
     text: http session; url: dfn-http-session
     text: input cancel list; url: dfn-input-cancel-list
-    text: intermediary node; url: dfn-intermediary-node
+    text: intermediary node; url: dfn-intermediary-nodes
     text: invalid argument; url: dfn-invalid-argument
     text: invalid selector; url: dfn-invalid-selector
     text: invalid session id; url: dfn-invalid-session-id
@@ -92,7 +92,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: no such frame; url: dfn-no-such-frame
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
-    text: process capabilities; url: dfn-processing-capabilities
+    text: process capabilities; url: dfn-capabilities-processing
     text: readiness state; url: dfn-readiness-state
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
@@ -112,7 +112,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: unsupported operation; url: dfn-unsupported-operation
     text: web element reference; url: dfn-web-element-reference
     text: webdriver-active flag; url: dfn-webdriver-active-flag
-    text: window handle; url: dfn-window-handle
+    text: window handle; url: dfn-window-handles
 spec: CONSOLE; urlPrefix: https://console.spec.whatwg.org
   type: dfn
     text: formatter; url: formatter
@@ -136,7 +136,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     text: Date.prototype.toISOString; url: sec-date.prototype.toisostring
     text: Date; url: sec-date-constructor
     text: EnumerableOwnPropertyNames; url: sec-enumerableownpropertynames
-    text: Get; url: sec-get
+    text: Get; url: sec-get-o-p
     text: GetIterator; url: sec-getiterator
     text: HasProperty; url: sec-hasproperty
     text: IsArray; url: sec-isarray
@@ -184,7 +184,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: activation notification; url: interaction.html#activation-notification
     text: active window; url: document-sequences.html#nav-window
     text: alert; url: timers-and-user-prompts.html#dom-alert
-    text: close; url: window-object.html#close-a-browsing-context
+    text: close; url: document-sequences.html#close-a-top-level-traversable
     text: disabled; url: form-control-infrastructure.html#concept-fe-disabled
     text: File Upload state; url: input.html#file-upload-state-(type=file)
     text: confirm; url: timers-and-user-prompts.html#dom-confirm
@@ -192,18 +192,17 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: create a new top-level traversable; url: document-sequences.html#creating-a-new-top-level-traversable
-    text: default classic script fetch options; url: webappapis.html#default-classic-script-fetch-options
+    text: default script fetch options; url: webappapis.html#default-script-fetch-options
     text: default view; url: nav-history-apis.html#dom-document-defaultview
-    text: descendant navigables; utl: document-sequences.html#descendant-navigables
+    text: descendant navigables; url: document-sequences.html#descendant-navigables
     text: environment settings object's Realm; url: webappapis.html#environment-settings-object's-realm
-    text: focused area of the document; url: document-sequences.html#focused-area-of-the-document
+    text: focused area of the document; url: interaction.html#focused-area-of-the-document
     text: getting all used history steps; url:browsing-the-web.html#getting-all-used-history-steps
-    text: handled; url: webappapis.html#concept-error-handled
     text: hidden; url: document-sequences.html#system-visibility-state
     text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
     text: innerText getter steps; url:dom.html#dom-innertext
     text: input type; url: input.html#dom-input-type
-    text: navigable; for:window; url: document-sequences.html#window-navigable
+    text: navigable; for:window; url: nav-history-apis.html#window-navigable
     text: navigables; url: document-sequences.html#navigables
     text: navigation id; url: browsing-the-web.html#navigation-id
     text: origin-clean; url: canvas.html#concept-canvas-origin-clean
@@ -218,7 +217,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: session history entry; url: browsing-the-web.html#session-history-entry
     text: session history traversal queue; url: document-sequences.html#tn-session-history-traversal-queue
     text: session history; url: history.html#session-history
-    text: set up a window environment settings object; url: window-object.html#set-up-a-window-environment-settings-object
+    text: set up a window environment settings object; url: nav-history-apis.html#set-up-a-window-environment-settings-object
     text: set up a worker environment settings object; url: workers.html#set-up-a-worker-environment-settings-object
     text: set up a worklet environment settings object; url: worklets.html#set-up-a-worklet-environment-settings-object
     text: shared worker; url: workers.html#shared-workers
@@ -238,7 +237,7 @@ spec: RESOURCE-TIMING; urlPrefix: https://w3c.github.io/resource-timing/
 spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
   type: dfn
     text: get time origin timestamp; url: dfn-get-time-origin-timestamp
-spec: RFC4648; urlPrefix: https://tools.ietf.org/html/rfc4648
+spec: RFC4648; urlPrefix: https://datatracker.ietf.org/doc/html/rfc4648
   type: dfn
     text: Base64 Encode; url: section-4
 spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
@@ -7574,7 +7573,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
-    1. Let |options| be the [=default classic script fetch options=].
+    1. Let |options| be the [=default script fetch options=].
 
     1. Let |function declaration| be |preload script|'s <code>function declaration</code>.
 
@@ -9709,7 +9708,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
-1. Let |options| be the [=default classic script fetch options=].
+1. Let |options| be the [=default script fetch options=].
 
 1. Let (<var ignore>script</var>, |function body evaluation status|) be the
    result of [=evaluate function body=] with |function declaration|,
@@ -9834,7 +9833,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |result ownership| be the value of the <code>resultOwnership</code> field of
    |command parameters|, if present, or <code>none</code> otherwise.
 
-1. Let |options| be the [=default classic script fetch options=].
+1. Let |options| be the [=default script fetch options=].
 
 1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
@@ -11361,7 +11360,7 @@ end:
 1. Call any <dfn>error reporting steps</dfn> defined in external specifications
    with <var ignore>script</var>, <var ignore>line</var>, <var
    ignore>col</var>, <var ignore>message</var>, and true if the error is
-   [=handled=], or false otherwise.
+   handled, or false otherwise.
 
 </div>
 ## Console ##  {#patches-console}

--- a/index.bs
+++ b/index.bs
@@ -37,10 +37,10 @@ spec: RFC6455; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455
 spec: RFC8610; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8610
   type: dfn
     text: match a CDDL specification; url: appendix-C
-spec: RFC6265; urlPrefix: https://httpwg.org/specs/rfc6265.html
+spec: RFC6265
   type: dfn
-    text: Cookie; url: storage-model
-    text: Cookie store; url: storage-model
+    text: Cookie; url: https://httpwg.org/specs/rfc6265.html
+    text: Cookie store; url: https://httpwg.org/specs/rfc6265.html
 spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-05
   type: dfn
     text: Lax; url: section-4.1.2.7

--- a/index.bs
+++ b/index.bs
@@ -34,7 +34,7 @@ spec: RFC6455; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455
     text: Fail the WebSocket Connection; url: section-7.1.7
     text: Status Codes; url: section-7.4
     text: Handling Errors in UTF-8-Encoded Data; url: section-8.1
-spec: RFC8610; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455#section-3
+spec: RFC8610; urlPrefix: https://datatracker.ietf.org/doc/html/rfc8610
   type: dfn
     text: match a CDDL specification; url: appendix-C
 spec: RFC6265; urlPrefix: https://httpwg.org/specs/rfc6265.html


### PR DESCRIPTION
This fixes broken and obsolete fragment references in the spec.

Most updates are straightforward. A few notes:
- `tools.ietf.org` now redirects to `datatracker.ietf.org`
- The update drops any link to "handled" in HTML. Not sure where the term was defined but it no longer seems to exist.
- "default classic script fetch options" is "default script fetch options" in practice. If "classic" matters, then that term no longer exists!

Not done as part of this update, but some of the references can likely be handled directly by Bikeshed without having to define more brittle anchors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/818.html" title="Last updated on Nov 28, 2024, 8:05 PM UTC (49bdc4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/818/46306e8...49bdc4a.html" title="Last updated on Nov 28, 2024, 8:05 PM UTC (49bdc4a)">Diff</a>