### PR TITLE
Update Bikeshed metadata: add editors, TR link, drop level

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,12 +1,15 @@
 <pre class=metadata>
 Title: WebDriver BiDi
 Shortname: webdriver-bidi
-Level: 1
+Level: None
 Status: ED
 Group: browser-testing-tools
 URL: https://w3c.github.io/webdriver-bidi/
+TR: https://www.w3.org/TR/webdriver-bidi/
 Repository: w3c/webdriver-bidi
-No Editor: true
+Editor: James Graham, Mozilla https://www.mozilla.org, w3cid 40334
+Editor: Alex Rudenko, Google https://www.google.com, w3cid 141088
+Editor: Maksim Sadym, Google https://www.google.com, w3cid 128970
 Abstract: This document defines the BiDirectional WebDriver Protocol, a mechanism for remote control of user agents.
 Boilerplate: conformance no
 Complain About: accidental-2119 yes, missing-example-ids yes


### PR DESCRIPTION
This adds spec editors, as discussed in #817, adds the link to the published TR draft, and drops the notion of level so that the spec gets published as `webdriver-bidi` instead of `webdriver-bidi-1` (levels can be introduced later on if that turns out to be needed).

PR to be merged after publication as First Public Working Draft, the TR link won't exist before that.