### PR TITLE
Enable auto-publication as Working Draft to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -11,3 +11,7 @@ jobs:
     - uses: w3c/spec-prod@v2
       with:
         GH_PAGES_BRANCH: gh-pages
+        W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+        W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-browser-tools-testing/2024OctDec/0003.html
+        W3C_BUILD_OVERRIDE: |
+          status: WD


### PR DESCRIPTION
Note: the publication token for Echdina referenced in the workflow was set as a repository secret.