### PR TITLE
Add WebExtension Module to global CDDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -430,7 +430,8 @@ CommandData = (
   NetworkCommand //
   ScriptCommand //
   SessionCommand //
-  StorageCommand
+  StorageCommand //
+  WebExtensionsCommand
 )
 
 EmptyParams = {
@@ -469,7 +470,8 @@ ResultData = (
   NetworkResult /
   ScriptResult /
   SessionResult /
-  StorageResult
+  StorageResult /
+  WebExtensionsResult
 )
 
 EmptyResult = {


### PR DESCRIPTION
This was missed during the mergin. Caught by our TypeScript auto generated types fully typed out.

CC @chrmod


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/822.html" title="Last updated on Dec 2, 2024, 2:05 PM UTC (32916c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/822/84f89ff...32916c5.html" title="Last updated on Dec 2, 2024, 2:05 PM UTC (32916c5)">Diff</a>