### PR TITLE
Fix algorithm to get related navigables for workers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1086,18 +1086,24 @@ To <dfn>get related navigables</dfn> given an [=script/settings object=]
 
 1. Let |related navigables| be an empty [=/set=].
 
-1. Let |navigable| be null.
+1. If |settings|' [=relevant global object=] is a {{Window}}:
 
-1. If |settings|' [=relevant global object=] is a {{Window}}, set |navigable|
-   to [=relevant global object=]'s <a>associated <code>Document</code></a>'s
-   [=/node navigable=].
+   1. Let |navigable| be [=relevant global object=]'s <a>associated
+      <code>Document</code></a>'s [=/node navigable=].
 
-   Otherwise if the [=realm/global object=] specified by |settings| is a
+   1. If |navigable| is not null, append |navigable| to |related navigables|.
+
+1. Otherwise if the [=realm/global object=] specified by |settings| is a
    {{WorkerGlobalScope}}, for each |owner| in the [=realm/global object=]'s
-   [=owner set=], if |owner| is a [=Document=], set |navigable| to |owner|'s
-   [=/node navigable=].
+   [=owner set=]:
 
-1. If |navigable| is not null, append |navigable| to |related navigables|.
+   1. Let |navigable| be null.
+
+   1. If |owner| is a [=Document=], set |navigable| to |owner|'s
+      [=/node navigable=].
+
+   1. If |navigable| is not null, append |navigable| to |related navigables|.
+
 
 1. Return |related navigables|.
 


### PR DESCRIPTION
With the current algorithm, we will only get one navigable for each worker, whereas workers can have a set of related owners (think shared workers, service workers).

This PR rearranges the algorithm to add each of the related navigables for a worker to the navigables set.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/824.html" title="Last updated on Dec 3, 2024, 9:49 AM UTC (dfb9f76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/824/79cd4f6...juliandescottes:dfb9f76.html" title="Last updated on Dec 3, 2024, 9:49 AM UTC (dfb9f76)">Diff</a>