### PR TITLE
Editorial: remove algorithm to get parent navigable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2804,17 +2804,6 @@ The <code>browsingContext.Info</code> type represents the properties of a
 navigable.
 
 <div algorithm>
-To <dfn>get the parent navigable</dfn> given |navigable|:
-
-1. Let |parent navigable| be |navigable|'s [=navigable/parent=].
-
-1. If |parent navigable| is null, then return null.
-
-1. Return |parent navigable|.
-
-</div>
-
-<div algorithm>
 To <dfn>get the child navigables</dfn> given |navigable|:
 
 TODO: make this return a list in document order
@@ -2833,7 +2822,7 @@ To <dfn>get the navigable info</dfn> given |navigable|,
 
 1. Let |navigable id| be the [=navigable id=] for |navigable|.
 
-1. Let |navigable| be [=get the parent navigable=] given |navigable|.
+1. Let |navigable| be |navigable|'s [=navigable/parent=].
 
 1. If |navigable| is not null let |parent id| be the
    [=navigable id=] of |navigable|. Otherwise let
@@ -4680,9 +4669,8 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
     <code>browsingContext.ContextDestroyed</code> production, with the
     <code>params</code> field set to |params|.
 
-1. Let |related navigables| be a [=/set=] containing the result of
-   [=get the parent navigable=] with |navigable|, if that is not
-   null, or an empty [=/set=] otherwise.
+1. Let |related navigables| be a [=/set=] containing |navigable|'s [=navigable/parent=],
+   if that is not null, or an empty [=/set=] otherwise.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related navigables|:


### PR DESCRIPTION
I think "get the parent navigable" was previously defining steps to get a parent browsing context but after the rewrite of the spec to use navigables, the steps are basically https://html.spec.whatwg.org/#nav-parent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/827.html" title="Last updated on Dec 4, 2024, 4:04 PM UTC (7a67b4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/827/20f1248...7a67b4a.html" title="Last updated on Dec 4, 2024, 4:04 PM UTC (7a67b4a)">Diff</a>