### PR TITLE
Introduce subscription IDs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -747,7 +747,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
-   1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, continue.
+   1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, [=continue=].
 
    1. If |subscription| is  [=subscription/global=] return true.
 

--- a/index.bs
+++ b/index.bs
@@ -718,7 +718,7 @@ if |subscription|'s [=subscription/contexts=] is an empty set.
 
 <div algorithm>
 
-The <dfn export>set of sessions for which an event is enabled</dfn>,
+The <dfn export>set of sessions for which an event is enabled</dfn>
 given |event name| and |navigables| is:
 
 1. Let |sessions| be a new [=/set=].
@@ -740,7 +740,7 @@ To determine if an <dfn export>event is enabled</dfn> given |session|,
 Note: |navigables| is a set because a [=shared worker=] can be associated
       with multiple contexts.
 
-1. Let |top-level traversables| be the result of [=get top-level traversables=] given |navigables|.
+1. Let |top-level traversables| be [=get top-level traversables=] given |navigables|.
 
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
@@ -749,9 +749,9 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
    1. If |subscription|'s [=subscription/contexts=] is an empty set,
       return true.
 
-   1. Let |subscription navigables| be the result of [=get navigables=] given |subscription|'s [=subscription/contexts=].
+   1. Let |subscription navigables| be [=get navigables=] given |subscription|'s [=subscription/contexts=].
 
-   1. Let |subscription top-level traversables| be the result of [=get top-level traversables=] given |subscription navigables|.
+   1. Let |subscription top-level traversables| be [=get top-level traversables=] given |subscription navigables|.
 
    1. Return true if the [=set/intersection=] of |top-level traversables| and
       |subscription top-level traversables| is not [=list/empty=].
@@ -782,9 +782,9 @@ given |event name| and |session| is:
 
    1. Otherwise:
 
-      1. Let |navigables| to the result of [=get navigables=] given |subscription|'s [=subscription/contexts=]:
+      1. Let |navigables| to [=get navigables=] given |subscription|'s [=subscription/contexts=]:
 
-      1. Let |top-level traversables| be the result of [=get top-level traversables=] with |navigables|.
+      1. Let |top-level traversables| be [=get top-level traversables=] with |navigables|.
 
       1. [=set/Append=] each item of |top-level traversables| to |result|.
 
@@ -1110,7 +1110,7 @@ To <dfn>get navigables</dfn> given a [=/list=] of context ids |navigable ids|:
 
 1. For each |navigable id| in |navigable ids|:
 
-   1. Let |navigable| be the [=/navigable=] with id |navigable id|,
+   1. Let |navigable| be the [=/navigable=] with id |navigable id|
       if such [=/navigable=] exists, and null otherwise.
 
    1. [=set/Append=] |navigable| to |result| if |navigable| is not null.
@@ -1909,9 +1909,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. If |context ids| is not empty:
 
-      1. Let |navigables| be the result of [=get navigables=] given |context ids|.
+      1. Let |navigables| be [=get navigables=] given |context ids|.
 
-      1. Set |newly subscribed navigables| be the result of [=get top-level traversables=] given |navigables|.
+      1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
 
    1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the remote end.
 

--- a/index.bs
+++ b/index.bs
@@ -709,8 +709,6 @@ occurred on the [=remote end=].
 A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
 which is a [=/list=] of [=subscriptions=].
 
-Issue: the list of subscriptions should be a map indexed by subscription
-IDs once unsubscribe by contexts is removed.
 
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string), <dfn for=subscription>event names</dfn> (a [=/set=] of event names)

--- a/index.bs
+++ b/index.bs
@@ -1903,7 +1903,7 @@ Issue: This needs to be generalised to work with realms too.
 <div algorithm="remote end steps for session.unsubscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. If |command parameters| matches the session.SubscriptionRequest production:
+1. If |command parameters| matches the <code>session.SubscriptionRequest</code> production:
 
    1. Let the |event names| be the value of the <code>events</code> field of
       |command parameters|.

--- a/index.bs
+++ b/index.bs
@@ -711,11 +711,12 @@ which is a [=/list=] of [=subscriptions=].
 
 
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
-<dfn for=subscription>subscription id</dfn> (a string), <dfn for=subscription>event names</dfn> (a [=/set=] of event names)
-and <dfn for=subscription>contexts</dfn> (a [=/set=] of context ids).
+<dfn for=subscription>subscription id</dfn> (a string),
+<dfn for=subscription>event names</dfn> (a [=/set=] of event names)
+and <dfn for=subscription>top-level traversable ids</dfn> (a [=/set=] of IDs of [=/top-level traversables=]).
 
 A [=subscription=] |subscription| is <dfn for="subscription">global</dfn>
-if |subscription|'s [=subscription/contexts=] is an empty set.
+if |subscription|'s [=subscription/top-level traversable ids=] is an empty set.
 
 <div algorithm>
 
@@ -749,9 +750,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription| is  [=subscription/global=] return true.
 
-   1. Let |subscription navigables| be [=get navigables=] given |subscription|'s [=subscription/contexts=].
-
-   1. Let |subscription top-level traversables| be [=get top-level traversables=] given |subscription navigables|.
+   1. Let |subscription top-level traversables| be [=get navigables=] given |subscription|'s [=subscription/top-level traversable ids=].
 
    1. Return true if the [=set/intersection=] of |top-level traversables| and
       |subscription top-level traversables| is not [=list/empty=].
@@ -782,9 +781,7 @@ given |event name| and |session| is:
 
    1. Otherwise:
 
-      1. Let |navigables| to [=get navigables=] given |subscription|'s [=subscription/contexts=]:
-
-      1. Let |top-level traversables| be [=get top-level traversables=] with |navigables|.
+      1. Let |top-level traversables| to [=get navigables=] given |subscription|'s [=subscription/top-level traversable ids=]:
 
       1. [=set/Append=] each item of |top-level traversables| to |result|.
 
@@ -1901,13 +1898,26 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let the |event names| be a [=/set=] containing |command parameters|["<code>events</code>"].
 
-1. Let the |context ids| be a [=/set=] containing the value of <code>contexts</code>
-   field of |command parameters| if it is present or an empty [=/set=] if it isn't.
+1. Let |newly subscribed navigables| be a [=/set=].
+
+1. Let |top-level traversable context ids| be a [=/set=].
+
+1. If |command parameters|[<code>contexts</code>] is not empty:
+
+   1. Let |navigables| be [=get navigables=] given |command parameters|[<code>contexts</code>].
+
+   1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
+
+   1. For each |navigable| in |newly subscribed navigables|:
+
+      1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable context ids|.
+
+1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
 
 1. Let |subscription| be a [=subscription=] with
    [=subscription/subscription id=] set to the string representation of a UUID,
    [=subscription/event names=] set to |event names|, and
-   [=subscription/contexts=] set to |context ids|.
+   [=subscription/top-level traversable ids=] set to |top-level traversable context ids|.
 
 1. Let |subscribe step events| be a new [=/map=].
 
@@ -1917,16 +1927,6 @@ The [=remote end steps=] with |session| and |command parameters| are:
      subscribe steps=], continue;
 
    1. Let |existing navigables| be a [=set of top-level traversables for which an event is enabled=] given |session| and |event name|.
-
-   1. Let |newly subscribed navigables| be a [=/set=].
-
-   1. If |context ids| is not empty:
-
-      1. Let |navigables| be [=get navigables=] given |context ids|.
-
-      1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
-
-   1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
 
    1. Set |subscribe step events|[|event name|] to [=set/difference=] of
       |newly subscribed navigables| and |existing navigables|.
@@ -1944,7 +1944,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
     1. Return true if |event one|'s [=subscribe priority=] is less than |event
        two|'s subscribe priority, or false otherwise.
 
-1. If |context ids| is null, let |include global| be true, otherwise let
+1. If |subscription| is [=subscription/global=], let |include global| be true, otherwise let
    |include global| be false.
 
 1. For each |event name| → |navigables| in |subscribe step events|:
@@ -1991,17 +1991,29 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |event names| be a [=/set=] of |command parameters|["<code>events</code>"].
 
-   1. Let |contexts| be a [=/set=] of |command parameters|["<code>contexts</code>"],
-      if |command parameters| [=map/contains=] "<code>contexts</code>", or an empty [=/set=] otherwise.
+   1. Let |top-level traversable context ids| be a [=/set=].
+
+   1. If |command parameters|[<code>contexts</code>] is not empty:
+
+      1. Let |navigables| be [=get navigables=] given |command parameters|[<code>contexts</code>].
+
+      1. Set |top-level traversables| be [=get top-level traversables=] given |navigables|.
+
+      1. For each |navigable| in |top-level traversables|:
+
+         1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable context ids|.
 
    1. Let |new subscriptions| to be a [=/list=].
 
    1. For each |subscription| of |session|'s [=subscriptions=]:
 
-      1. If [=set/intersection=] of |subscription|'s [=subscription/event names=] and |event names| is an empty [=/set=],
-         continue.
+      1. If [=set/intersection=] of |subscription|'s [=subscription/event names=] and |event names| is an empty [=/set=]:
 
-      1. If |contexts| is an empty [=/set=]:
+         1. [=list/append=] |subscription| to |new subscriptions|.
+
+         1. Continue.
+
+      1. If |top-level traversable context ids| is an empty [=/set=]:
 
         1. |=list/Remove=| all items [=list/contains|contained=] in |event names| from |subscription|'s [=subscription/event names=].
 
@@ -2023,7 +2035,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
           1. For each |event name| in |subscription|'s [=subscription/event names=]:
 
-              1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s [=subscription/contexts=].
+              1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s [=subscription/top-level traversable ids=].
 
           1. For each |event name| in |event names|:
 
@@ -2031,18 +2043,20 @@ The [=remote end steps=] with |session| and |command parameters| are:
                  continue.
 
               1. Set |event map|[|event name|] to the [=set/difference=]
-                 between |event map|[|event name|] and |contexts|.
+                 between |event map|[|event name|] and |top-level traversable context ids|.
 
               1. If |event map|[|event name|] is an empty [=/set=],
 
                 1. [=map/Remove=] |event map|[|event name|].
 
-          1. For each |event name| → |remaining contexts| in |event map|:
+          1. For each |event name| → |remaining top-level traversable ids| in |event map|:
 
-            1. Let |subscription| be a [=subscription=] with
+            1. Let |partial subscription| be a [=subscription=] with
                [=subscription/subscription id=] to |subscription|'s [=subscription/subscription id=],
                [=subscription/event names=] set to a new [=/set=] containing |event name|,
-               [=subscription/contexts=] set to |remaining contexts|.
+               [=subscription/top-level traversable ids=] set to |remaining top-level traversable ids|.
+
+            1. [=list/append=] |partial subscription| to |new subscriptions|.
 
    1. Set |session|'s [=subscriptions=] to |new subscriptions|.
 

--- a/index.bs
+++ b/index.bs
@@ -2016,7 +2016,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. If |top-level traversable context ids| is an empty [=/set=]:
 
-        1. |=list/Remove=| all items [=list/contains|contained=] in |event names| from |subscription|'s [=subscription/event names=].
+        1. [=list/Remove=] all items [=list/contains|contained=] in |event names| from |subscription|'s [=subscription/event names=].
 
         1. If |subscription|'s [=subscription/event names=] is not empty:
 

--- a/index.bs
+++ b/index.bs
@@ -394,7 +394,7 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 </div>
 
 <div algorithm>
-To <dfn for=set>create</dfn> a [=/set=], from a [=/list=] |input|:
+To <dfn>create a set</dfn>, given a [=/list=] |input|:
 
 1. Let |result| be an empty [=/set=].
 
@@ -1907,13 +1907,13 @@ Issue: This needs to be generalized to work with realms too.
 <div algorithm="remote end steps for session.subscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |event names| be [=set/create=] given |command parameters|["<code>events</code>"].
+1. Let the |event names| be [=/create a set=] given |command parameters|["<code>events</code>"].
 
 1. Let |subscription navigables| be a [=/set=].
 
 1. Let |top-level traversable context ids| be a [=/set=].
 
-1. Let |input context ids| be [=set/create=] given |command parameters|[<code>contexts</code>].
+1. Let |input context ids| be [=/create a set=] given |command parameters|[<code>contexts</code>].
 
 1. If |input context ids| is not empty:
 
@@ -2008,11 +2008,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| matches the <code>session.UnsubscribeByAttributesRequest</code> production:
 
-   1. Let |event names| be [=set/create=] given |command parameters|["<code>events</code>"].
+   1. Let |event names| be [=/create a set=] given |command parameters|["<code>events</code>"].
 
    1. Let |top-level traversable context ids| be a [=/set=].
 
-   1. Let |input context ids| be [=set/create=] given |command parameters|[<code>contexts</code>].
+   1. Let |input context ids| be [=/create a set=] given |command parameters|[<code>contexts</code>].
 
    1. If |input context ids| is not empty:
 
@@ -2087,7 +2087,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Otherwise:
 
-   1. Let |subscriptions| be [=set/create=] given of |command parameters|[<code>subscriptions</code>].
+   1. Let |subscriptions| be [=/create a set=] given of |command parameters|[<code>subscriptions</code>].
 
    1. Let |unknown subscription ids| to [=set/difference=] between |subscriptions| and |session|'s [=known subscription ids=].
 

--- a/index.bs
+++ b/index.bs
@@ -719,9 +719,8 @@ occurred on the [=remote end=].
 
 A [=BiDi session=] has <dfn for=event>subscriptions</dfn> which is a [=/list=] of [=subscriptions=].
 
-A [=BiDi session=] has <dfn for=event>internally removed subscription ids</dfn>
-which is a [=/set=] of [=subscription/subscription id=] that identifies IDs that
-were issued to the client but have been removed internally since then.
+A [=BiDi session=] has a <dfn for=event>known subscription ids</dfn> which is a [=/set=] of
+all [=subscription/subscription ids=] that have been issued to the [=local end=] but which have not yet been unsubscribed.
 
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string),
@@ -1951,6 +1950,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Append |subscription| to |session|'s [=subscriptions=].
 
+1. Append |subscription|'s [=subscription/subscription id=] to |session|'s [=known subscription ids=].
+
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
    than algorithm given two entries with keys |event name one| and |event
    name two|:
@@ -2088,9 +2089,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |subscriptions| be [=set/create=] given of |command parameters|[<code>subscriptions</code>].
 
-   1. Let |subscriptions to remove| be an empty [=/set=].
+   1. Let |unknown subscription ids| to [=set/difference=] between |subscriptions| and |session|'s [=known subscription ids=].
 
-   1. Let |found subscription ids| be an empty [=/set=].
+   1. If |unknown subscription ids| is not empty:
+
+      1. Return [=error=] with [=error code=] [=invalid argument=].
+
+   1. Let |subscriptions to remove| be an empty [=/set=].
 
    1. For each |subscription| in |session|'s [=subscriptions=]:
 
@@ -2098,18 +2103,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
          1. [=set/Append=] |subscription| to |subscriptions to remove|.
 
-         1. [=set/Append=] |subscription|'s [=subscription/subscription id=] to |found subscription ids|.
-
-   1. Let |not found subscriptions| be [=set/difference=] between |subscriptions| and |found subscription ids|.
-
-   1. Set |not found subscriptions| to [=set/difference=] between |not found subscriptions| and |session|'s [=internally removed subscription ids=].
-
-   1. If |not found subscriptions| is not empty:
-
-      1. Return [=error=] with [=error code=] [=invalid argument=].
-
-   1. Set |session|'s [=internally removed subscription ids=] to
-      [=set/difference=] between |session|'s [=internally removed subscription ids=] and |subscriptions|.
+   1. Set |session|'s [=known subscription ids=] to
+      [=set/difference=] between |session|'s [=known subscription ids=] and |subscriptions|.
 
    1. [=list/Remove=] each item in |subscriptions to remove| from |session|'s [=subscriptions=].
 
@@ -4777,8 +4772,6 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
         1. If |subscription|'s [=subscription/top-level traversable ids=] is empty:
 
            1. [=set/Append=] |subscription| to |subscriptions to remove|.
-
-           1. Append |subscription|'s [=subscription/subscription id=] to |session|'s [=internally removed subscription ids=].
 
   1. [=list/Remove=] |subscriptions to remove| from |session|'s [=subscriptions=].
 

--- a/index.bs
+++ b/index.bs
@@ -393,6 +393,17 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 
 </div>
 
+<div algorithm>
+To <dfn for=set>create</dfn> a [=/set=], from a [=/list=] |input|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each [=list/item=] |item| in |input|, [=set/append=] |item| to |result|.
+
+1. Return |result|.
+
+</div>
+
 # Protocol # {#protocol}
 
 This section defines the basic concepts of the WebDriver BiDi
@@ -1897,13 +1908,13 @@ Issue: This needs to be generalized to work with realms too.
 <div algorithm="remote end steps for session.subscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |event names| be a [=/set=] containing |command parameters|["<code>events</code>"].
+1. Let the |event names| be [=set/create=] given |command parameters|["<code>events</code>"].
 
 1. Let |subscription navigables| be a [=/set=].
 
 1. Let |top-level traversable context ids| be a [=/set=].
 
-1. Let |input context ids| be a [=/set=] of |command parameters|[<code>contexts</code>].
+1. Let |input context ids| be [=set/create=] given |command parameters|[<code>contexts</code>].
 
 1. If |input context ids| is not empty:
 
@@ -1996,11 +2007,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| matches the <code>session.UnsubscribeByAttributesRequest</code> production:
 
-   1. Let |event names| be a [=/set=] of |command parameters|["<code>events</code>"].
+   1. Let |event names| be [=set/create=] given |command parameters|["<code>events</code>"].
 
    1. Let |top-level traversable context ids| be a [=/set=].
 
-   1. Let |input context ids| be a [=/set=] of |command parameters|[<code>contexts</code>].
+   1. Let |input context ids| be [=set/create=] given |command parameters|[<code>contexts</code>].
 
    1. If |input context ids| is not empty:
 
@@ -2075,7 +2086,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Otherwise:
 
-   1. Let |subscriptions| be a [=/set=] of |command parameters|[<code>subscriptions</code>].
+   1. Let |subscriptions| be [=set/create=] given of |command parameters|[<code>subscriptions</code>].
 
    1. Let |subscriptions to remove| be an empty [=/set=].
 

--- a/index.bs
+++ b/index.bs
@@ -706,10 +706,9 @@ occurred on the [=remote end=].
    are run when multiple events are enabled at once, with lower integers
    indicating steps that run earlier.
 
-A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
-which is a [=/list=] of [=subscriptions=].
+A [=BiDi session=] has <dfn for=event>subscriptions</dfn> which is a [=/list=] of [=subscriptions=].
 
-A [=BiDi session=] has <dfn export for=event>internally removed subscription ids</dfn>
+A [=BiDi session=] has <dfn for=event>internally removed subscription ids</dfn>
 which is a [=/set=] of [=subscription/subscription id=] that identifies IDs that
 were issues to the client but have been removed internally since then.
 
@@ -723,8 +722,7 @@ if |subscription|'s [=subscription/top-level traversable ids=] is an empty set.
 
 <div algorithm>
 
-The <dfn export>set of sessions for which an event is enabled</dfn>
-given |event name| and |navigables| is:
+The <dfn export>set of sessions for which an event is enabled</dfn> given |event name| and |navigables| is:
 
 1. Let |sessions| be a new [=/set=].
 
@@ -753,7 +751,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription| is  [=subscription/global=] return true.
 
-   1. Let |subscription top-level traversables| be [=get navigables=] given |subscription|'s [=subscription/top-level traversable ids=].
+   1. Let |subscription top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
 
    1. Return true if the [=set/intersection=] of |top-level traversables| and
       |subscription top-level traversables| is not [=list/empty=].
@@ -764,7 +762,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 <div algorithm>
 
-The <dfn export>set of top-level traversables for which an event is enabled</dfn>,
+The <dfn export>set of top-level traversables for which an event is enabled</dfn>
 given |event name| and |session| is:
 
 1. Let |result| be a new [=/set=].
@@ -784,7 +782,7 @@ given |event name| and |session| is:
 
    1. Otherwise:
 
-      1. Let |top-level traversables| to [=get navigables=] given |subscription|'s [=subscription/top-level traversable ids=]:
+      1. Let |top-level traversables| to [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=]:
 
       1. [=set/Append=] each item of |top-level traversables| to |result|.
 
@@ -1104,7 +1102,7 @@ To <dfn>get related navigables</dfn> given an [=script/settings object=]
 
 <div algorithm>
 
-To <dfn>get navigables</dfn> given a [=/list=] of context ids |navigable ids|:
+To <dfn>get navigables by ids</dfn> given a [=/list=] of context ids |navigable ids|:
 
 1. Let |result| be an empty [=/set=].
 
@@ -1907,7 +1905,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters|[<code>contexts</code>] is not empty:
 
-   1. Let |navigables| be [=get navigables=] given |command parameters|[<code>contexts</code>].
+   1. Let |navigables| be [=get navigables by ids=] given |command parameters|[<code>contexts</code>].
 
    1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
 
@@ -1998,7 +1996,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. If |command parameters|[<code>contexts</code>] is not empty:
 
-      1. Let |navigables| be [=get navigables=] given |command parameters|[<code>contexts</code>].
+      1. Let |navigables| be [=get navigables by ids=] given |command parameters|[<code>contexts</code>].
 
       1. Set |top-level traversables| be [=get top-level traversables=] given |navigables|.
 

--- a/index.bs
+++ b/index.bs
@@ -1932,7 +1932,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. If the [=event=] with [=event name=] |event name| does not define [=remote end
      subscribe steps=], continue;
 
-   1. Let |existing navigables| be a [=set of top-level traversables for which an event is enabled=] given |session| and |event name|.
+   1. Let |existing navigables| be a [=set of top-level traversables for which an event is enabled=] with |session| and |event name|.
 
    1. Set |subscribe step events|[|event name|] to [=set/difference=] of
       |subscription navigables| and |existing navigables|.

--- a/index.bs
+++ b/index.bs
@@ -2007,7 +2007,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. If |contexts| is an empty [=/set=]:
 
-        1. |=list/Remove=| all |event names| from |subscription|'s [=subscription/event names=].
+        1. |=list/Remove=| all items [=list/contains|contained=] in |event names| from |subscription|'s [=subscription/event names=].
 
         1. If |subscription|'s [=subscription/event names=] is not empty:
 

--- a/index.bs
+++ b/index.bs
@@ -770,7 +770,7 @@ given |event name| and |session| is:
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
    1. If |subscription|'s [=subscription/event names=] [=set/contains|does not contain=] |event name|,
-      continue.
+      [=continue=].
 
    1. If |subscription|'s is [=subscription/global=]:
 

--- a/index.bs
+++ b/index.bs
@@ -710,11 +710,11 @@ A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
 which is a [=/list=] of [=subscriptions=].
 
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
-<dfn ignore>subscription id</dfn> (a string), <dfn ignore>event names</dfn> (a [=/set=] of event names)
-and <dfn ignore>contexts</dfn> (a [=/set=] of context ids).
+<dfn for=subscription>subscription id</dfn> (a string), <dfn for=subscription>event names</dfn> (a [=/set=] of event names)
+and <dfn for=subscription>contexts</dfn> (a [=/set=] of context ids).
 
 A [=subscription=] |subscription| is <dfn for="subscription">global</dfn>
-if |subscription|'s contexts is an empty set.
+if |subscription|'s [=subscription/contexts=] is an empty set.
 
 <div algorithm>
 
@@ -747,15 +747,15 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
-   1. If |subscription|'s event names do not [=set/contains=] |event name|, continue.
+   1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, continue.
 
-   1. If |subscription|'s contexts is an empty set,
+   1. If |subscription|'s [=subscription/contexts=] is an empty set,
       return true.
 
    1. For each |navigable| of |top-level traversables|:
 
-      1. If |subscription|'s contexts [=set/contains=] |navigable|'s [=navigable id=],
-         return true.
+      1. Return true if the [=set/intersection=] of |top-level traversables| and
+         |subscription|'s [=subscription/contexts=] is not [=list/empty=].
 
 1. Return false.
 
@@ -1829,8 +1829,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let the |context ids| be a [=/set=] containing the value of <code>contexts</code>
    field of |command parameters| if it is present or an empty [=/set=] if it isn't.
 
-1. Let |subscription| be a [=subscription=] with subscription id set to the string representation of a UUID,
-   event names set to |event names|, contexts set to |context ids|.
+1. Let |subscription| be a [=subscription=] with
+   [=subscription/subscription id=] set to the string representation of a UUID,
+   [=subscription/event names=] set to |event names|, and
+   [=subscription/contexts=]  set to |context ids|.
 
 1. Let |subscribe step events| be a new [=/map=].
 
@@ -1915,14 +1917,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. For each |subscription| of |session|'s [=subscriptions=]:
 
-      1. If [=set/intersection=] of |subscription|'s event names and |event names| is an empty [=/set=],
+      1. If [=set/intersection=] of |subscription|'s [=subscription/event names=] and |event names| is an empty [=/set=],
          continue.
 
       1. If |contexts| is an empty [=/set=]:
 
-        1. |=list/Remove=| all |event names| from |subscription|'s event names.
+        1. |=list/Remove=| all |event names| from |subscription|'s [=subscription/event names=].
 
-        1. If |subscription|'s event names is not empty:
+        1. If |subscription|'s [=subscription/event names=] is not empty:
 
           1. [=list/append=] |subscription| to |new subscriptions|.
 
@@ -1936,9 +1938,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
           1. Let |event map| be an empty [=/map=].
 
-          1. For each |event name| in |subscription|'s event names:
+          1. For each |event name| in |subscription|'s [=subscription/event names=]:
 
-              1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s contexts.
+              1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s [=subscription/contexts=].
 
           1. For each |event name| in |event names|:
 
@@ -1953,8 +1955,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
           1. For each |event name| → |remaining contexts| in |event map|:
 
-            1. Let |subscription| be a [=subscription=] with subscription id to |subscription|'s subscription id,
-               event names set to a new [=/set=] containing |event name|, contexts set to |remaining contexts|.
+            1. Let |subscription| be a [=subscription=] with
+               [=subscription/subscription id=] to |subscription|'s [=subscription/subscription id=],
+               [=subscription/event names=] set to a new [=/set=] containing |event name|,
+               [=subscription/contexts=] set to |remaining contexts|.
 
    1. Set |session|'s [=subscriptions=] to |new subscriptions|.
 

--- a/index.bs
+++ b/index.bs
@@ -2076,7 +2076,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Otherwise:
 
-   1. Let |subscriptions| be [=set/create=] a [=/set=] given of |command parameters|[<code>subscriptions</code>].
+   1. Let |subscriptions| be [=set/create=] a [=/set=] with |command parameters|[<code>subscriptions</code>].
 
    1. Let |unknown subscription ids| to [=set/difference=] between |subscriptions| and |session|'s [=known subscription ids=].
 

--- a/index.bs
+++ b/index.bs
@@ -747,7 +747,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, continue.
 
-   1. If |subscription|is  [=subscription/global=] return true.
+   1. If |subscription| is  [=subscription/global=] return true.
 
    1. Let |subscription navigables| be [=get navigables=] given |subscription|'s [=subscription/contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -1841,7 +1841,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. If the [=event=] with [=event name=] |event name| does not define [=remote end
      subscribe steps=], continue;
 
-   1. Let |existing navigables| be a set of navigables for which either a global
+   1. Let |existing navigables| be a [=/set=] of navigables for which either a global
       subscription is defined or a subscription listing navigables's top-level navigable's id.
 
       TODO: define the step above better.
@@ -1907,11 +1907,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| matches the <code>session.SubscriptionRequest</code> production:
 
-   1. Let the |event names| be the value of the <code>events</code> field of
-      |command parameters|.
+   1. Let |event names| be a [=/set=] of |command parameters|["<code>events</code>"].
 
-   1. Let the |contexts| be the value of the <code>contexts</code>
-      field of |command parameters| if it is present or an empty [=/set=] if it isn't.
+   1. Let |contexts| be a [=/set=] of |command parameters|["<code>contexts</code>"],
+      if it is present or an empty [=/set=] if it isn't.
 
    1. Let |new subscriptions| to be a [=/list=].
 
@@ -1964,10 +1963,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Otherwise:
 
-   1. Let the |subscriptions| be |command parameters|[<code>subscriptions</code>].
+   1. Let |subscriptions| be a [=/set=] of |command parameters|[<code>subscriptions</code>].
 
-   1. Remove all subscriptions from |session|'s [=subscriptions=] whose
-      subscription id is one of |subscriptions|.
+   1. Let |items to remove| be an empty [=/list=].
+
+   1. For each |subscription| in |session|'s [=subscriptions=],
+      append |subscription| to |items to remove| if |subscriptions|
+      [=set/contains=] |subscription|'s [=subscription/subscription id=].
+
+   1. [=list/Remove=] |items to remove| from |session|'s [=subscriptions=].
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -740,10 +740,7 @@ To determine if an <dfn export>event is enabled</dfn> given |session|,
 Note: |navigables| is a set because a [=shared worker=] can be associated
       with multiple contexts.
 
-1. Let |top-level traversables| be an empty [=/set=].
-
-1. For each |navigable| of |navigables|,
-   append |navigable|'s [=navigable/top-level traversable=] to |top-level traversables|.
+1. Let |top-level traversables| be the result of [=get top-level traversables=] given |navigables|.
 
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
@@ -752,10 +749,12 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
    1. If |subscription|'s [=subscription/contexts=] is an empty set,
       return true.
 
-   1. For each |navigable| of |top-level traversables|:
+   1. Let |subscription navigables| be the result of [=get navigables=] given |subscription|'s [=subscription/contexts=].
 
-      1. Return true if the [=set/intersection=] of |top-level traversables| and
-         |subscription|'s [=subscription/contexts=] is not [=list/empty=].
+   1. Let |subscription top-level traversables| be the result of [=get top-level traversables=] given |subscription navigables|.
+
+   1. Return true if the [=set/intersection=] of |top-level traversables| and
+      |subscription top-level traversables| is not [=list/empty=].
 
 1. Return false.
 
@@ -763,7 +762,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 <div algorithm>
 
-The <dfn export>set of navigables for which an event is enabled</dfn>,
+The <dfn export>set of top-level traversables for which an event is enabled</dfn>,
 given |event name| and |session| is:
 
 1. Let |result| be a new [=/set=].
@@ -775,17 +774,19 @@ given |event name| and |session| is:
 
    1. If |subscription|'s is [=subscription/global=]:
 
-      1. For each |navigable| in remote end's [=/navigables=]:
+      1. For each |traversable| in remote end's [=/top-level traversables=]:
 
-        1. [=set/Append=] |navigable| to |result|.
+        1. [=set/Append=] |traversable| to |result|.
 
       1. Break.
 
-   1. For each |context id| in |subscription|'s [=subscription/contexts=]:
+   1. Otherwise:
 
-      1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |context id|.
+      1. Let |navigables| to the result of [=get navigables=] given |subscription|'s [=subscription/contexts=]:
 
-      1. [=set/Append=] |navigable| to |result| if |navigable| is not null.
+      1. Let |top-level traversables| be the result of [=get top-level traversables=] with |navigables|.
+
+      1. [=set/Append=] each item of |top-level traversables| to |result|.
 
 1. Return |result|.
 
@@ -1098,6 +1099,37 @@ To <dfn>get related navigables</dfn> given an [=script/settings object=]
 
 
 1. Return |related navigables|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>get navigables</dfn> given a [=/list=] of context ids |navigable ids|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each |navigable id| in |navigable ids|:
+
+   1. Let |navigable| be the [=/navigable=] with id |navigable id|,
+      if such [=/navigable=] exists, and null otherwise.
+
+   1. [=set/Append=] |navigable| to |result| if |navigable| is not null.
+
+1. Return |result|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>get top-level traversables</dfn> given a [=/list=] of [=/navigables=] |navigables|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each |navigable| in |navigables|:
+
+   1. [=set/Append=] |navigable|'s [=navigable/top-level traversable=] to |result|.
+
+1. Return |result|.
 
 </div>
 
@@ -1871,12 +1903,17 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. If the [=event=] with [=event name=] |event name| does not define [=remote end
      subscribe steps=], continue;
 
-   1. Let |existing navigables| be a [=set of navigables for which an event is enabled=] given |session| and |event name|.
+   1. Let |existing navigables| be a [=set of top-level traversables for which an event is enabled=] given |session| and |event name|.
 
-   1. Let |newly subscribed navigables| be all [=/navigables=] in the remote end if |context ids| is empty,
-      or navigables identified by ids in |context ids|.
+   1. Let |newly subscribed navigables| be a [=/set=].
 
-   TODO: clarify the above step.
+   1. If |context ids| is not empty:
+
+      1. Let |navigables| be the result of [=get navigables=] given |context ids|.
+
+      1. Set |newly subscribed navigables| be the result of [=get top-level traversables=] given |navigables|.
+
+   1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the remote end.
 
    1. Set |subscribe step events|[|event name|] to [=set/difference=] of
       |newly subscribed navigables| and |existing navigables|.

--- a/index.bs
+++ b/index.bs
@@ -1930,7 +1930,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
 
-   1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the remote end.
+   1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
 
    1. Set |subscribe step events|[|event name|] to [=set/difference=] of
       |newly subscribed navigables| and |existing navigables|.

--- a/index.bs
+++ b/index.bs
@@ -1992,7 +1992,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. Let |event names| be a [=/set=] of |command parameters|["<code>events</code>"].
 
    1. Let |contexts| be a [=/set=] of |command parameters|["<code>contexts</code>"],
-      if it is present or an empty [=/set=] if it isn't.
+      if |command parameters| [=map/contains=] "<code>contexts</code>", or an empty [=/set=] otherwise.
 
    1. Let |new subscriptions| to be a [=/list=].
 

--- a/index.bs
+++ b/index.bs
@@ -393,17 +393,6 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 
 </div>
 
-<div algorithm>
-To <dfn>create a set</dfn>, given a [=/list=] |input|:
-
-1. Let |result| be an empty [=/set=].
-
-1. For each [=list/item=] |item| in |input|, [=set/append=] |item| to |result|.
-
-1. Return |result|.
-
-</div>
-
 # Protocol # {#protocol}
 
 This section defines the basic concepts of the WebDriver BiDi
@@ -1907,13 +1896,13 @@ Issue: This needs to be generalized to work with realms too.
 <div algorithm="remote end steps for session.subscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |event names| be [=/create a set=] given |command parameters|["<code>events</code>"].
+1. Let the |event names| be [=set/create=] a [=/set=] given |command parameters|["<code>events</code>"].
 
 1. Let |subscription navigables| be a [=/set=].
 
 1. Let |top-level traversable context ids| be a [=/set=].
 
-1. Let |input context ids| be [=/create a set=] given |command parameters|[<code>contexts</code>].
+1. Let |input context ids| be [=set/create=] a [=/set=] given |command parameters|[<code>contexts</code>].
 
 1. If |input context ids| is not empty:
 
@@ -2008,11 +1997,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| matches the <code>session.UnsubscribeByAttributesRequest</code> production:
 
-   1. Let |event names| be [=/create a set=] given |command parameters|["<code>events</code>"].
+   1. Let |event names| be [=set/create=] a [=/set=] given |command parameters|["<code>events</code>"].
 
    1. Let |top-level traversable context ids| be a [=/set=].
 
-   1. Let |input context ids| be [=/create a set=] given |command parameters|[<code>contexts</code>].
+   1. Let |input context ids| be [=set/create=] a [=/set=] given |command parameters|[<code>contexts</code>].
 
    1. If |input context ids| is not empty:
 
@@ -2087,7 +2076,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Otherwise:
 
-   1. Let |subscriptions| be [=/create a set=] given of |command parameters|[<code>subscriptions</code>].
+   1. Let |subscriptions| be [=set/create=] a [=/set=] given of |command parameters|[<code>subscriptions</code>].
 
    1. Let |unknown subscription ids| to [=set/difference=] between |subscriptions| and |session|'s [=known subscription ids=].
 

--- a/index.bs
+++ b/index.bs
@@ -2079,7 +2079,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |not found subscriptions| be [=set/difference=] between |subscriptions| and |found subscription ids|.
 
-   1. Set |not found subscriptions| be [=set/difference=] between |found subscription ids| and |session|'s [=internally removed subscription ids=].
+   1. Set |not found subscriptions| to [=set/difference=] between |found subscription ids| and |session|'s [=internally removed subscription ids=].
 
    1. If |not found subscriptions| is not empty:
 

--- a/index.bs
+++ b/index.bs
@@ -706,35 +706,17 @@ occurred on the [=remote end=].
    are run when multiple events are enabled at once, with lower integers
    indicating steps that run earlier.
 
-A [=BiDi session=] has a <dfn export for=event>global event set</dfn>
-which is a [=/set=] containing the event names for events that are enabled for all
-navigables. This initially contains the [=event name=] for events that
-are <dfn export for=event>in the default event set</dfn>.
+A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
+which is a [=/list=] of [=subscriptions=].
 
-A [=BiDi session=] has a <dfn export for=event>navigable event map</dfn>,
-which is a [=/map=] with [=/top-level traversable=] keys and values
-that are a [=/set=] of [=event name=]s for events that are enabled in the given
-navigable.
+A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
+<dfn ignore>subscription id</dfn> (a string), <dfn ignore>event names</dfn> (a [=/set=] of event names)
+and <dfn ignore>contexts</dfn> (a [=/set=] of context ids).
 
 <div algorithm>
 
-To obtain a list of <dfn>event enabled navigables</dfn> given
-|session| and |event name|:
-
-1. Let |navigables| be an empty [=/set=].
-
-1. For each |navigable| → |events| of |session|'s [=navigable event map=]:
-
-  1. If |events| contains |event name|, append |navigable| to |navigables|
-
-1. Return |navigables|.
-
-</div>
-
-<div algorithm>
-
-The <dfn export>set of sessions for which an event is enabled</dfn> given |event
-name| and |navigables| is:
+The <dfn export>set of sessions for which an event is enabled</dfn>,
+given |event name| and |navigables| is:
 
 1. Let |sessions| be a new [=/set=].
 
@@ -757,45 +739,22 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 1. Let |top-level traversables| be an empty [=/set=].
 
-1. For each |navigable| of |navigables|, append |navigable|'s [=navigable/top-level traversable=] to |top-level traversables|.
+1. For each |navigable| of |navigables|,
+   append |navigable|'s [=navigable/top-level traversable=] to |top-level traversables|.
 
-1. Let |event map| be the [=navigable event map=] for |session|.
+1. For each |subscription| in |session|'s [=subscriptions=]:
 
-1. For each |navigable| of |top-level traversables|:
+   1. If |subscription|'s event names do not [=set/contains=] |event name|, continue.
 
-  1. If |event map| [=map/contains=] |navigable|, let |navigable events|
-    be |event map|[|navigable|].  Otherwise let |navigable events| be null.
+   1. If |subscription|'s contexts is an empty set,
+      return true.
 
-  1. If |navigable events| is not null, and |navigable events|
-     [=list/contains=] |event name|, return true.
+   1. For each |navigable| of |top-level traversables|:
 
-1. If the [=global event set=] for |session| [=list/contains=] |event name| return
-   true.
+      1. If |subscription|'s contexts [=set/contains=] |navigable|'s [=navigable id=],
+         return true.
 
 1. Return false.
-
-</div>
-
-<div algorithm>
-To <dfn>obtain a set of event names</dfn> given an |name|:
-
-1. Let |events| be an empty [=/set=].
-
-1. If |name| contains a U+002E (period):
-
-  1. If |name| is the [=event name=] for an event, append |name| to |events|
-     and return [=success=] with data |events|.
-
-  1. Return an [=error=] with [=error code=] [=invalid argument=]
-
-1. Otherwise |name| is interpreted as representing all the events in a
-   module. If |name| is not a [=module name=] return an [=error=] with
-   [=error code=] [=invalid argument=].
-
-1. Append the [=event name=] for each [=event=] in the module with name |name| to
-   |events|.
-
-1. Return [=success=] with data |events|.
 
 </div>
 
@@ -1482,113 +1441,6 @@ To <dfn>cleanup remote end state</dfn>.
 
 </div>
 
-<div algorithm>
-To <dfn>update the event map</dfn>, given
-|session|, |requested event names|, |navigables|, and |enabled|:
-
-Note: The return value of this algorithm is a map between event names and
-navigables. When the events are being enabled, the navigables in the return value
-are those for which the event are now enabled but were not previously. When
-events are disabled, the return value is always empty.
-
-1. Let |global event set| be a [=set/clone=] of the [=global event set=] for
-   |session|.
-
-1. Let |event map| be a new [=/map=].
-
-1. For each |key| → |value| of the [=navigable event map=] for
-   |session|:
-
-  1. Set |event map|[|key|] to a [=set/clone=] of |value|.
-
-1. Let |event names| be an empty [=/set=].
-
-1. For each entry |name| in |requested event names|,
-   let |event names| be the union of |event names| and the result of
-   [=trying=] to [=obtain a set of event names=] with |name|.
-
-1. Let |enabled events| be a new [=/map=].
-
-1. If |navigables| is null:
-
-    1. If |enabled| is true:
-
-      1. For each |event name| of |event names|:
-
-         1. If |global event set| doesn't contain |event name|:
-
-           1. Let |already enabled navigables| be the [=event enabled navigables=]
-            given |session| and |event name|.
-
-           1. Add |event name| to |global event set|.
-
-           1. For each |navigable| of |already enabled navigables|, remove |event
-              name| from |event map|[|navigable|].
-
-           1. Let |newly enabled contexts| be a list of all [=/top-level traversable=]
-            that are not contained in |already enabled navigables|,
-
-           1. Set |enabled events|[|event name|] to |newly enabled contexts|.
-
-    1. If |enabled| is false:
-
-      1. For each |event name| in |event names|:
-
-        1. If |global event set| [=list/contains=] |event name|, remove |event
-           name| from |global event set|. Otherwise return [=error=] with
-           [=error code=] [=invalid argument=].
-
-1. Otherwise, if |navigables| is not null:
-
-  1. Let |targets| be an empty [=/map=].
-
-  1. For each |navigable id| in |navigables|:
-
-    1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
-       with |navigable id|.
-
-    1. Let |top-level traversable| be the [=navigable/top-level traversable=] for |navigable|.
-
-    1. If |event map| does not contain |top-level traversable|, set |event
-       map|[|top-level traversable|] to a new [=/set=].
-
-    1. Set |targets|[|top-level traversable|] to |event map|[|top-level traversable|].
-
-  1. For each |event name| in |event names|:
-
-    1. If |enabled| is true and |global event set| contains |event name|, continue.
-
-    1. For each |navigable| → |target| in |targets|:
-
-      1. If |enabled| is true and |target| does not contain |event name|:
-
-        1. Add |event name| to |target|.
-
-        1. If |enabled events| does not contain |event name|, set |enabled
-           events|[|event name|] to a new [=/set=].
-
-        1. Append |navigable| to |enabled events|[|event name|].
-
-      1. If |enabled| is false:
-
-        1. If |target| contains |event name|, remove |event name| from
-           |target|. Otherwise return [=error=] with [=error code=] [=invalid
-           argument=].
-
-1. Set the [=global event set=] for |session| to |global event set|.
-
-1. Set the [=navigable event map=] for |session| to |event map|.
-
-1. Return [=success=] with data |enabled events|.
-
-Note: Implementations that do additional work when an event is enabled,
-e.g. subscribing to the relevant engine-internal events, will likely perform
-those additional steps when updating the event map. This specification uses
-a model where hooks are always called and then the event map is used to
-filter only those that ought to be returned to the local end.
-
-</div>
-
 ### Types ### {#module-session-types}
 
 #### The session.CapabilitiesRequest Type #### {#type-session-CapabilitiesRequest}
@@ -1733,6 +1585,14 @@ session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
 The <code>session.UserPromptHandlerType</code> type represents the behavior
 of the user prompt handler.
 
+#### The session.Subscription Type #### {#type-session-Subscription}
+
+<pre class="cddl remote-cddl local-cddl">
+session.Subscription = text
+</pre>
+
+The <code>session.Subscription</code> type represents a unique subscription identifier.
+
 #### The session.SubscriptionRequest Type #### {#type-session-SubscriptionRequest}
 
 <pre class="cddl remote-cddl">
@@ -1744,6 +1604,17 @@ session.SubscriptionRequest = {
 
 The <code>session.SubscriptionRequest</code> type represents a request to
 subscribe to or unsubscribe from a specific set of events.
+
+#### The session.UnsubscribeRequest Type #### {#type-session-UnsubscribeRequest}
+
+<pre class="cddl remote-cddl">
+session.UnsubscribeRequest = {
+  subscriptions: [+session.Subscription],
+}
+</pre>
+
+The <code>session.UnsubscribeRequest</code> type represents a request to
+remove event subscriptions identified by subscription IDs.
 
 ### Commands ### {#module-session-commands}
 
@@ -1938,31 +1809,45 @@ Issue: This needs to be generalized to work with realms too.
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <code>
-      EmptyResult
-      </code>
+      <pre class="cddl local-cddl">
+        session.SubscriptionRequestResult = {
+          subscription: session.Subscription,
+        }
+      </pre>
    </dd>
 </dl>
 
 <div algorithm="remote end steps for session.subscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |list of event names| be the value of the <code>events</code> field of
+1. Let the |event names| be a [=/set=] containing the value of <code>events</code> field of
    |command parameters|
 
-1. Let the |list of navigables| be the value of the <code>contexts</code>
-   field of |command parameters| if it is present or null if it isn't.
+1. Let the |context ids| be a [=/set=] containing the value of <code>contexts</code>
+   field of |command parameters| if it is present or an empty [=/set=] if it isn't.
 
-1. Let |enabled events| be the result of [=trying=] to [=update the event map=]
-   with |session|, |list of event names| , |list of navigables| and
-   enabled true.
+1. Let |subscription| be a [=subscription=] with subscription id set to the string representation of a UUID,
+   event names set to |event names|, contexts set to |context ids|.
 
 1. Let |subscribe step events| be a new [=/map=].
 
-1. For each |event name| → |navigables| in |enabled events|:
+1. For each |event name| in the |event names|:
 
-  1. If the [=event=] with [=event name=] |event name| defines [=remote end
-     subscribe steps=], set |subscribe step events|[|event name|] to |navigables|.
+   1. If the [=event=] with [=event name=] |event name| does not define [=remote end
+     subscribe steps=], continue;
+
+   1. Let |existing navigables| be a set of navigables for which either a global
+      subscription is defined or a subscription listing navigables's top-level navigable's id.
+
+      TODO: define the step above better.
+
+   1. Let |newly subscribed navigables| be all top-level navigables if |context ids| is empty,
+      or navigables identified by ids in |context ids|.
+
+   1. Set |subscribe step events|[|event name|] to navigables that are included in |newly subscribed navigables|
+      and not included in |existing navigables|.
+
+1. Append |subscription| to |session|'s [=subscriptions=].
 
 1. [=map/Sort in ascending order=] |subscribe step events| using the following less
    than algorithm given two entries with keys |event name one| and |event
@@ -1975,7 +1860,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
     1. Return true if |event one|'s [=subscribe priority=] is less than |event
        two|'s subscribe priority, or false otherwise.
 
-1. If |list of navigables| is null, let |include global| be true, otherwise let
+1. If |context ids| is null, let |include global| be true, otherwise let
    |include global| be false.
 
 1. For each |event name| → |navigables| in |subscribe step events|:
@@ -2000,7 +1885,7 @@ Issue: This needs to be generalised to work with realms too.
      <pre class="cddl remote-cddl">
      session.Unsubscribe = (
        method: "session.unsubscribe",
-       params: session.SubscriptionRequest
+       params: session.SubscriptionRequest / session.UnsubscribeRequest,
      )
      </pre>
    </dd>
@@ -2015,14 +1900,67 @@ Issue: This needs to be generalised to work with realms too.
 <div algorithm="remote end steps for session.unsubscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |list of event names| be the value of the <code>events</code> field of
-   |command parameters|.
+1. If |command parameters| matches the session.SubscriptionRequest production:
 
-1. Let the |list of contexts| be the value of the <code>contexts</code>
-   field of |command parameters| if it is present or null if it isn't.
+   1. Let the |event names| be the value of the <code>events</code> field of
+      |command parameters|.
 
-1. [=Try=] to [=update the event map=] with |session|,
-   |list of event names|, |list of contexts| and enabled false.
+   1. Let the |contexts| be the value of the <code>contexts</code>
+      field of |command parameters| if it is present or an empty [=/set=] if it isn't.
+
+   1. Let |new subscriptions| to be a [=/list=].
+
+   1. For each |subscription| of |session|'s [=subscriptions=]:
+
+      1. If [=set/intersection=] of |subscription|'s event names and |event names| is an empty [=/set=],
+         continue.
+
+      1. If |contexts| is an empty [=/set=]:
+
+        1. |=list/Remove=| all |event names| from |subscription|'s event names.
+
+        1. If |subscription|'s event names is not empty:
+
+          1. [=list/append=] |subscription| to |new subscriptions|.
+
+      1. Otherwise:
+
+        1. If |subscription|'s contexts is an empty [=/set=]:
+
+          1. TODO: global subscription and context unsubscription? Expected behavior?
+
+        1. Otherwise:
+
+          1. Let |event map| be an empty [=/map=].
+
+          1. For each |event name| in |subscription|'s event names:
+
+              1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s contexts.
+
+          1. For each |event name| in |event names|:
+
+              1. If |event map|[|event name|] does not exist,
+                 continue.
+
+              1. Remove |contexts| from |event map|[|event name|].
+
+              1. If |event map|[|event name|] is an empty [=/set=],
+
+                1. [=map/Remove=] |event map|[|event name|].
+
+          1. For each |event name| → |remaining contexts| in |event map|:
+
+            1. Let |subscription| be a [=subscription=] with subscription id to |subscription|'s subscription id,
+               event names set to a new [=/set=] containing |event name|, contexts set to |remaining contexts|.
+
+   1. Set |session|'s [=subscriptions=] to |new subscriptions|.
+
+1. Otherwise:
+
+   1. Let the |subscriptions| be |command parameters|[<code>subscriptions</code>].
+
+   1. Remove all subscribtions from |session|'s [=subscriptions=] whose
+      subscription id is one of |subscriptions|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -742,7 +742,7 @@ To determine if an <dfn export>event is enabled</dfn> given |session|,
 Note: |navigables| is a set because a [=shared worker=] can be associated
       with multiple contexts.
 
-1. Let |top-level traversables| be [=get top-level traversables=] given |navigables|.
+1. Let |top-level traversables| be [=get top-level traversables=] with |navigables|.
 
 1. For each |subscription| in |session|'s [=subscriptions=]:
 
@@ -750,7 +750,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription| is [=subscription/global=] return true.
 
-   1. Let |subscription top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
+   1. Let |subscription top-level traversables| be [=get navigables by ids=] with |subscription|'s [=subscription/top-level traversable ids=].
 
    1. If the [=set/intersection=] of |top-level traversables| and
       |subscription top-level traversables| is not [=list/empty=] return true.
@@ -781,7 +781,7 @@ given |event name| and |session| is:
 
    1. Otherwise:
 
-      1. Let |top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
+      1. Let |top-level traversables| be [=get navigables by ids=] with |subscription|'s [=subscription/top-level traversable ids=].
 
       1. [=set/Append=] each item of |top-level traversables| to |result|.
 
@@ -1906,13 +1906,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |input context ids| is not empty:
 
-   1. Let |navigables| be [=get navigables by ids=] given |input context ids|.
+   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
 
    1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
 
       1. Return [=error=] with [=error code=] [=invalid argument=].
 
-   1. Set |subscription navigables| be [=get top-level traversables=] given |navigables|.
+   1. Set |subscription navigables| be [=get top-level traversables=] with |navigables|.
 
    1. For each |navigable| in |subscription navigables|:
 
@@ -2005,13 +2005,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. If |input context ids| is not empty:
 
-      1. Let |navigables| be [=get navigables by ids=] given |input context ids|.
+      1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
 
       1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
 
          1. Return [=error=] with [=error code=] [=invalid argument=].
 
-      1. Set |top-level traversables| be [=get top-level traversables=] given |navigables|.
+      1. Set |top-level traversables| be [=get top-level traversables=] with |navigables|.
 
       1. For each |navigable| in |top-level traversables|:
 

--- a/index.bs
+++ b/index.bs
@@ -709,7 +709,6 @@ occurred on the [=remote end=].
 A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
 which is a [=/list=] of [=subscriptions=].
 
-
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string),
 <dfn for=subscription>event names</dfn> (a [=/set=] of event names)
@@ -2069,6 +2068,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. For each |subscription| in |session|'s [=subscriptions=],
       append |subscription| to |items to remove| if |subscriptions|
       [=set/contains=] |subscription|'s [=subscription/subscription id=].
+
+   1. If |items to remove| is empty:
+
+      1. Return [=error=] with [=error code=] [=invalid argument=].
 
    1. [=list/Remove=] |items to remove| from |session|'s [=subscriptions=].
 

--- a/index.bs
+++ b/index.bs
@@ -753,8 +753,8 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. Let |subscription top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
 
-   1. Return true if the [=set/intersection=] of |top-level traversables| and
-      |subscription top-level traversables| is not [=list/empty=].
+   1. If the [=set/intersection=] of |top-level traversables| and
+      |subscription top-level traversables| is not [=list/empty=] return true.
 
 1. Return false.
 

--- a/index.bs
+++ b/index.bs
@@ -709,6 +709,9 @@ occurred on the [=remote end=].
 A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
 which is a [=/list=] of [=subscriptions=].
 
+Issue: the list of subscriptions should be a map indexed by subscription
+IDs once unsubscribe by contexts is removed.
+
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string), <dfn for=subscription>event names</dfn> (a [=/set=] of event names)
 and <dfn for=subscription>contexts</dfn> (a [=/set=] of context ids).

--- a/index.bs
+++ b/index.bs
@@ -778,7 +778,7 @@ given |event name| and |session| is:
 
         1. [=set/Append=] |traversable| to |result|.
 
-      1. Break.
+      1. [=Break=].
 
    1. Otherwise:
 

--- a/index.bs
+++ b/index.bs
@@ -1916,7 +1916,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
 
 1. Let |subscription| be a [=subscription=] with
-   [=subscription/subscription id=] set to the string representation of a UUID,
+   [=subscription/subscription id=] set to the string representation of a [[!RFC9562|UUID]],
    [=subscription/event names=] set to |event names|, and
    [=subscription/top-level traversable ids=] set to |top-level traversable context ids|.
 

--- a/index.bs
+++ b/index.bs
@@ -1997,7 +1997,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| matches the <code>session.UnsubscribeByAttributesRequest</code> production:
 
-   1. Let |event names| be [=set/create=] a [=/set=] given |command parameters|["<code>events</code>"].
+   1. Let |event names| be [=set/create|create a set=] with |command parameters|["<code>events</code>"].
 
    1. Let |top-level traversable context ids| be a [=/set=].
 

--- a/index.bs
+++ b/index.bs
@@ -709,6 +709,10 @@ occurred on the [=remote end=].
 A [=BiDi session=] has a <dfn export for=event>subscriptions</dfn>
 which is a [=/list=] of [=subscriptions=].
 
+A [=BiDi session=] has <dfn export for=event>internally removed subscription ids</dfn>
+which is a [=/set=] of [=subscription/subscription id=] that identifies IDs that
+were issues to the client but have been removed internally since then.
+
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string),
 <dfn for=subscription>event names</dfn> (a [=/set=] of event names)
@@ -2063,17 +2067,30 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |subscriptions| be a [=/set=] of |command parameters|[<code>subscriptions</code>].
 
-   1. Let |items to remove| be an empty [=/list=].
+   1. Let |subscriptions to remove| be an empty [=/set=].
 
-   1. For each |subscription| in |session|'s [=subscriptions=],
-      append |subscription| to |items to remove| if |subscriptions|
-      [=set/contains=] |subscription|'s [=subscription/subscription id=].
+   1. Let |found subscription ids| be an empty [=/set=].
 
-   1. If |items to remove| is empty:
+   1. For each |subscription| in |session|'s [=subscriptions=]:
+
+      1. If |subscriptions| [=set/contains=] |subscription|'s [=subscription/subscription id=]:
+
+         1. [=set/Append=] |subscription| to |subscriptions to remove|.
+
+         1. [=set/Append=] |subscription|'s [=subscription/subscription id=] to |found subscription ids|.
+
+   1. Let |not found subscriptions| be [=set/difference=] between |subscriptions| and |found subscription ids|.
+
+   1. Set |not found subscriptions| be [=set/difference=] between |found subscription ids| and |session|'s [=internally removed subscription ids=].
+
+   1. If |not found subscriptions| is not empty:
 
       1. Return [=error=] with [=error code=] [=invalid argument=].
 
-   1. [=list/Remove=] |items to remove| from |session|'s [=subscriptions=].
+   1. Set |session|'s [=internally removed subscription ids=] to
+      [=set/difference=] between |session|'s [=internally removed subscription ids=] |subscriptions|.
+
+   1. [=list/Remove=] each item in |subscriptions to remove| from |session|'s [=subscriptions=].
 
 1. Return [=success=] with data null.
 
@@ -4727,6 +4744,22 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
    given "<code>browsingContext.contextDestroyed</code>" and |related navigables|:
 
   1. [=Emit an event=] with |session| and |body|.
+
+  1. Let |subscriptions to remove| be a [=/set=].
+
+  1. For each |subscription| in |session|'s [=subscriptions=]:
+
+     1. If |subscription|'s [=subscription/top-level traversable ids=] [=set/contains=] |navigable|'s [=navigable id=];
+
+        1. [=set/Remove=] |navigable|'s [=navigable id=] from |subscription|'s [=subscription/top-level traversable ids=].
+
+        1. If |subscription|'s [=subscription/top-level traversable ids=] is empty:
+
+           1. [=set/Append=] |subscription| to |subscriptions to remove|.
+
+           1. Append |subscription|'s [=subscription/subscription id=] to |session|'s [=internally removed subscription ids=].
+
+  1. [=list/Remove=] |subscriptions to remove| from |session|'s [=subscriptions=].
 
 Issue: It's unclear if we ought to only fire this event for browsing
 contexts that have active documents; navigation can also cause contexts to

--- a/index.bs
+++ b/index.bs
@@ -782,7 +782,7 @@ given |event name| and |session| is:
 
    1. Otherwise:
 
-      1. Let |top-level traversables| to [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=]:
+      1. Let |top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
 
       1. [=set/Append=] each item of |top-level traversables| to |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -1903,9 +1903,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |top-level traversable context ids| be a [=/set=].
 
-1. If |command parameters|[<code>contexts</code>] is not empty:
+1. Let |input context ids| be a [=/set=] of |command parameters|[<code>contexts</code>].
 
-   1. Let |navigables| be [=get navigables by ids=] given |command parameters|[<code>contexts</code>].
+1. If |input context ids| is not empty:
+
+   1. Let |navigables| be [=get navigables by ids=] given |input context ids|.
+
+   1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
+
+      1. Return [=error=] with [=error code=] [=invalid argument=].
 
    1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
 
@@ -1994,9 +2000,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |top-level traversable context ids| be a [=/set=].
 
-   1. If |command parameters|[<code>contexts</code>] is not empty:
+   1. Let |input context ids| be a [=/set=] of |command parameters|[<code>contexts</code>].
 
-      1. Let |navigables| be [=get navigables by ids=] given |command parameters|[<code>contexts</code>].
+   1. If |input context ids| is not empty:
+
+      1. Let |navigables| be [=get navigables by ids=] given |input context ids|.
+
+      1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
+
+         1. Return [=error=] with [=error code=] [=invalid argument=].
 
       1. Set |top-level traversables| be [=get top-level traversables=] given |navigables|.
 

--- a/index.bs
+++ b/index.bs
@@ -761,6 +761,36 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
 </div>
 
+<div algorithm>
+
+The <dfn export>set of navigables for which an event is enabled</dfn>,
+given |event name| and |session| is:
+
+1. Let |result| be a new [=/set=].
+
+1. For each |subscription| in |session|'s [=subscriptions=]:
+
+   1. If |subscription|'s [=subscription/event names=] [=set/contains|does not contain=] |event name|,
+      continue.
+
+   1. If |subscription|'s is [=subscription/global=]:
+
+      1. For each |navigable| in remote end's [=/navigables=]:
+
+        1. [=set/Append=] |navigable| to |result|.
+
+      1. Break.
+
+   1. For each |context id| in |subscription|'s [=subscription/contexts=]:
+
+      1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |context id|.
+
+      1. [=set/Append=] |navigable| to |result| if |navigable| is not null.
+
+1. Return |result|.
+
+</div>
+
 # Transport # {#transport}
 
 Message transport is provided using the WebSocket protocol.
@@ -1832,7 +1862,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 1. Let |subscription| be a [=subscription=] with
    [=subscription/subscription id=] set to the string representation of a UUID,
    [=subscription/event names=] set to |event names|, and
-   [=subscription/contexts=]  set to |context ids|.
+   [=subscription/contexts=] set to |context ids|.
 
 1. Let |subscribe step events| be a new [=/map=].
 
@@ -1841,16 +1871,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. If the [=event=] with [=event name=] |event name| does not define [=remote end
      subscribe steps=], continue;
 
-   1. Let |existing navigables| be a [=/set=] of navigables for which either a global
-      subscription is defined or a subscription listing navigables's top-level navigable's id.
+   1. Let |existing navigables| be a [=set of navigables for which an event is enabled=] given |session| and |event name|.
 
-      TODO: define the step above better.
-
-   1. Let |newly subscribed navigables| be all top-level navigables if |context ids| is empty,
+   1. Let |newly subscribed navigables| be all [=/navigables=] in the remote end if |context ids| is empty,
       or navigables identified by ids in |context ids|.
 
-   1. Set |subscribe step events|[|event name|] to navigables that are included in |newly subscribed navigables|
-      and not included in |existing navigables|.
+   TODO: clarify the above step.
+
+   1. Set |subscribe step events|[|event name|] to [=set/difference=] of
+      |newly subscribed navigables| and |existing navigables|.
 
 1. Append |subscription| to |session|'s [=subscriptions=].
 
@@ -1946,7 +1975,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
               1. If |event map|[|event name|] does not exist,
                  continue.
 
-              1. Remove |contexts| from |event map|[|event name|].
+              1. Set |event map|[|event name|] to the [=set/difference=]
+                 between |event map|[|event name|] and |contexts|.
 
               1. If |event map|[|event name|] is an empty [=/set=],
 

--- a/index.bs
+++ b/index.bs
@@ -749,7 +749,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, [=continue=].
 
-   1. If |subscription| is  [=subscription/global=] return true.
+   1. If |subscription| is [=subscription/global=] return true.
 
    1. Let |subscription top-level traversables| be [=get navigables by ids=] given |subscription|'s [=subscription/top-level traversable ids=].
 
@@ -1899,7 +1899,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let the |event names| be a [=/set=] containing |command parameters|["<code>events</code>"].
 
-1. Let |newly subscribed navigables| be a [=/set=].
+1. Let |subscription navigables| be a [=/set=].
 
 1. Let |top-level traversable context ids| be a [=/set=].
 
@@ -1913,13 +1913,13 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. Return [=error=] with [=error code=] [=invalid argument=].
 
-   1. Set |newly subscribed navigables| be [=get top-level traversables=] given |navigables|.
+   1. Set |subscription navigables| be [=get top-level traversables=] given |navigables|.
 
-   1. For each |navigable| in |newly subscribed navigables|:
+   1. For each |navigable| in |subscription navigables|:
 
       1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable context ids|.
 
-1. Otherwise, |newly subscribed navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
+1. Otherwise, set |subscription navigables| to a [=/set=] of all [=navigable/top-level traversables=] in the [=remote end=].
 
 1. Let |subscription| be a [=subscription=] with
    [=subscription/subscription id=] set to the string representation of a [[!RFC9562|UUID]],
@@ -1936,7 +1936,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. Let |existing navigables| be a [=set of top-level traversables for which an event is enabled=] given |session| and |event name|.
 
    1. Set |subscribe step events|[|event name|] to [=set/difference=] of
-      |newly subscribed navigables| and |existing navigables|.
+      |subscription navigables| and |existing navigables|.
 
 1. Append |subscription| to |session|'s [=subscriptions=].
 
@@ -2091,14 +2091,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |not found subscriptions| be [=set/difference=] between |subscriptions| and |found subscription ids|.
 
-   1. Set |not found subscriptions| to [=set/difference=] between |found subscription ids| and |session|'s [=internally removed subscription ids=].
+   1. Set |not found subscriptions| to [=set/difference=] between |not found subscriptions| and |session|'s [=internally removed subscription ids=].
 
    1. If |not found subscriptions| is not empty:
 
       1. Return [=error=] with [=error code=] [=invalid argument=].
 
    1. Set |session|'s [=internally removed subscription ids=] to
-      [=set/difference=] between |session|'s [=internally removed subscription ids=] |subscriptions|.
+      [=set/difference=] between |session|'s [=internally removed subscription ids=] and |subscriptions|.
 
    1. [=list/Remove=] each item in |subscriptions to remove| from |session|'s [=subscriptions=].
 

--- a/index.bs
+++ b/index.bs
@@ -710,7 +710,7 @@ A [=BiDi session=] has <dfn for=event>subscriptions</dfn> which is a [=/list=] o
 
 A [=BiDi session=] has <dfn for=event>internally removed subscription ids</dfn>
 which is a [=/set=] of [=subscription/subscription id=] that identifies IDs that
-were issues to the client but have been removed internally since then.
+were issued to the client but have been removed internally since then.
 
 A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string),

--- a/index.bs
+++ b/index.bs
@@ -1902,8 +1902,7 @@ Issue: This needs to be generalized to work with realms too.
 <div algorithm="remote end steps for session.subscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. Let the |event names| be a [=/set=] containing the value of <code>events</code> field of
-   |command parameters|
+1. Let the |event names| be a [=/set=] containing |command parameters|["<code>events</code>"].
 
 1. Let the |context ids| be a [=/set=] containing the value of <code>contexts</code>
    field of |command parameters| if it is present or an empty [=/set=] if it isn't.

--- a/index.bs
+++ b/index.bs
@@ -747,8 +747,7 @@ Note: |navigables| is a set because a [=shared worker=] can be associated
 
    1. If |subscription|'s [=subscription/event names=] do not [=set/contains=] |event name|, continue.
 
-   1. If |subscription|'s [=subscription/contexts=] is an empty set,
-      return true.
+   1. If |subscription|is  [=subscription/global=] return true.
 
    1. Let |subscription navigables| be [=get navigables=] given |subscription|'s [=subscription/contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -713,6 +713,9 @@ A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn ignore>subscription id</dfn> (a string), <dfn ignore>event names</dfn> (a [=/set=] of event names)
 and <dfn ignore>contexts</dfn> (a [=/set=] of context ids).
 
+A [=subscription=] |subscription| is <dfn for="subscription">global</dfn>
+if |subscription|'s contexts is an empty set.
+
 <div algorithm>
 
 The <dfn export>set of sessions for which an event is enabled</dfn>,
@@ -1925,9 +1928,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. Otherwise:
 
-        1. If |subscription|'s contexts is an empty [=/set=]:
+        1. If |subscription| is [=subscription/global=]:
 
-          1. TODO: global subscription and context unsubscription? Expected behavior?
+          1. [=list/append=] |subscription| to |new subscriptions|.
 
         1. Otherwise:
 

--- a/index.bs
+++ b/index.bs
@@ -1670,16 +1670,30 @@ session.SubscriptionRequest = {
 The <code>session.SubscriptionRequest</code> type represents a request to
 subscribe to or unsubscribe from a specific set of events.
 
-#### The session.UnsubscribeRequest Type #### {#type-session-UnsubscribeRequest}
+#### The session.UnsubscribeByIDRequest Type #### {#type-session-UnsubscribeByIDRequest}
 
 <pre class="cddl remote-cddl">
-session.UnsubscribeRequest = {
+session.UnsubscribeByIDRequest = {
   subscriptions: [+session.Subscription],
 }
 </pre>
 
-The <code>session.UnsubscribeRequest</code> type represents a request to
+The <code>session.UnsubscribeByIDRequest</code> type represents a request to
 remove event subscriptions identified by subscription IDs.
+
+#### The session.UnsubscribeByAttributesRequest Type #### {#type-session-UnsubscribeByAttributesRequest}
+
+Note: contexts param is deprecated and will be removed in the future versions.
+
+<pre class="cddl remote-cddl">
+session.UnsubscribeByAttributesRequest = {
+  events: [+text],
+  ? contexts: [+browsingContext.BrowsingContext],
+}
+</pre>
+
+The <code>session.UnsubscribeByAttributesRequest</code> type represents a request to
+unsubscribe using subscription attributes.
 
 ### Commands ### {#module-session-commands}
 
@@ -1950,13 +1964,16 @@ either globally or for a set of navigables.
 
 Issue: This needs to be generalised to work with realms too.
 
+Note: contexts parameter in UnsubscribeByAttributesRequest is deprecated
+and will be removed in the future versions.
+
 <dl>
    <dt>Command Type</dt>
    <dd>
      <pre class="cddl remote-cddl">
      session.Unsubscribe = (
        method: "session.unsubscribe",
-       params: session.SubscriptionRequest / session.UnsubscribeRequest,
+       params: session.UnsubscribeByAttributesRequest / session.UnsubscribeByIDRequest,
      )
      </pre>
    </dd>
@@ -1971,7 +1988,7 @@ Issue: This needs to be generalised to work with realms too.
 <div algorithm="remote end steps for session.unsubscribe">
 The [=remote end steps=] with |session| and |command parameters| are:
 
-1. If |command parameters| matches the <code>session.SubscriptionRequest</code> production:
+1. If |command parameters| matches the <code>session.UnsubscribeByAttributesRequest</code> production:
 
    1. Let |event names| be a [=/set=] of |command parameters|["<code>events</code>"].
 
@@ -2000,6 +2017,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
           1. [=list/append=] |subscription| to |new subscriptions|.
 
         1. Otherwise:
+
+          Note: unsubscribe by contexts is deprecated and will be removed in the future versions.
 
           1. Let |event map| be an empty [=/map=].
 

--- a/index.bs
+++ b/index.bs
@@ -1962,7 +1962,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let the |subscriptions| be |command parameters|[<code>subscriptions</code>].
 
-   1. Remove all subscribtions from |session|'s [=subscriptions=] whose
+   1. Remove all subscriptions from |session|'s [=subscriptions=] whose
       subscription id is one of |subscriptions|.
 
 1. Return [=success=] with data null.

--- a/index.bs
+++ b/index.bs
@@ -2053,7 +2053,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
           1. For each |event name| → |remaining top-level traversable ids| in |event map|:
 
             1. Let |partial subscription| be a [=subscription=] with
-               [=subscription/subscription id=] to |subscription|'s [=subscription/subscription id=],
+               [=subscription/subscription id=] set to |subscription|'s [=subscription/subscription id=],
                [=subscription/event names=] set to a new [=/set=] containing |event name|,
                [=subscription/top-level traversable ids=] set to |remaining top-level traversable ids|.
 


### PR DESCRIPTION
This PR implements subscription IDs which can be used to unsubscribe from events. The specification is refactored
to operate on a list of subscriptions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/828.html" title="Last updated on Dec 20, 2024, 11:23 AM UTC (8c602d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/828/2a8cb22...8c602d0.html" title="Last updated on Dec 20, 2024, 11:23 AM UTC (8c602d0)">Diff</a>