### PR TITLE
Use `<code>` for references to a CDDL type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1893,9 +1893,9 @@ The <dfn export for=commands>session.end</dfn> command ends the current
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -1938,9 +1938,9 @@ Issue: This needs to be generalized to work with realms too.
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -2006,9 +2006,9 @@ Issue: This needs to be generalised to work with realms too.
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -2324,9 +2324,9 @@ WebDriver sessions and cleans up automation state in the remote browser instance
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -2543,9 +2543,9 @@ user context and all navigables in it without running
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -2608,9 +2608,9 @@ dimensions of a [=client window=].
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       browser.ClientWindowInfo
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -3091,9 +3091,9 @@ The <dfn export for=commands>browsingContext.activate</dfn> command activates an
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
      EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -3448,9 +3448,9 @@ The <dfn export for=commands>browsingContext.close</dfn> command closes a
 
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -3680,9 +3680,9 @@ command allows closing an open prompt
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -4316,9 +4316,9 @@ navigable.
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
       browsingContext.NavigateResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -4378,9 +4378,9 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command modifies 
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
      EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6607,9 +6607,9 @@ that's blocked by a [=network intercept=].
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6745,9 +6745,9 @@ response, but still provide the network response body.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6799,9 +6799,9 @@ response that's blocked by a [=network intercept=] at the
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6862,9 +6862,9 @@ fetch that's blocked by a [=network intercept=].
   </dd>
   <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6925,9 +6925,9 @@ lifecycle, and therefore emitting other events as it progresses.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -6975,9 +6975,9 @@ The <dfn export for=commands>network.removeIntercept</dfn> command removes a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -7024,9 +7024,9 @@ the network cache behavior for certain requests.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -7152,9 +7152,9 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -9570,9 +9570,9 @@ other handles or strong ECMAScript references.
    </dd>
    <dt>Return Type</dt>
    <dd>
-      <pre class="cddl">
+      <code>
          EmptyResult
-      </pre>
+      </code>
    </dd>
 </dl>
 
@@ -9627,9 +9627,9 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       script.EvaluateResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -9809,9 +9809,9 @@ the promise is returned.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
     script.EvaluateResult
-   </pre>
+    </code>
    </dd>
 </dl>
 
@@ -9992,9 +9992,9 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
       EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -11177,9 +11177,9 @@ Note: for a detailed description of the behavior of this command, see the
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
      EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -11232,9 +11232,9 @@ state associated with the current session.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
      EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 
@@ -11291,9 +11291,9 @@ to a set of file paths.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl">
+    <code>
      EmptyResult
-    </pre>
+    </code>
    </dd>
 </dl>
 


### PR DESCRIPTION
The spec wrapped the return type of commands in  `<pre class="cddl">`, even when the return type is actually a reference to CDDL type defined elsewhere.

The convention with IDL blocks is that any `<pre class="idl">` block creates a new IDL definition. I'd like to follow the same convention for CDDL.

On top of it, from a semantic perspective, such a reference is more "a fragment of computer code" (`<code>`) than "a block of preformatted text" (`<pre>`).

Note: when and if Bikeshed starts supporting CDDL, this could be replaced by something like `<a cddl-type>EmptyResult</a>` (or `{^EmptyResult^}` if the shorthand gets adopted).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/831.html" title="Last updated on Dec 12, 2024, 1:18 PM UTC (d2d44c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/831/b61fb78...d2d44c4.html" title="Last updated on Dec 12, 2024, 1:18 PM UTC (d2d44c4)">Diff</a>