### PR TITLE
Fix links to Document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1099,7 +1099,7 @@ To <dfn>get related navigables</dfn> given an [=script/settings object=]
 
    1. Let |navigable| be null.
 
-   1. If |owner| is a [=Document=], set |navigable| to |owner|'s
+   1. If |owner| is a [=/Document=], set |navigable| to |owner|'s
       [=/node navigable=].
 
    1. If |navigable| is not null, append |navigable| to |related navigables|.
@@ -4447,7 +4447,7 @@ The [=remote end steps=] with |command parameters| are:
 
          1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
 
-      1. Run [=evaluate media queries and report changes=] for [=document=] currently loaded
+      1. Run [=evaluate media queries and report changes=] for [=/document=] currently loaded
          in a specified |navigable|.
 
 1. Return [=success=] with data null.
@@ -10135,7 +10135,7 @@ The [=remote end subscribe steps=] with [=subscribe priority=] 2, given
   1. Let |related navigables| be a new [=/set=].
 
   1. If the <a>associated <code>Document</code></a> of |settings|'
-     [=relevant global object=] is a [=Document=]:
+     [=relevant global object=] is a [=/Document=]:
 
      1. Let |navigable| be |settings|'s [=relevant global object=]'s
         <a>associated <code>Document</code></a>'s


### PR DESCRIPTION
This change fixes the following error caused by ambiguous links:

```
LINE ~4450: Multiple possible 'document' dfn refs.
Arbitrarily chose https://dom.spec.whatwg.org/#clone-a-node-document
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block: 
spec:dom; type:dfn; for:clone a node; text:document
spec:dom; type:dfn; for:/; text:document
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/833.html" title="Last updated on Dec 18, 2024, 5:36 PM UTC (f2d50b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/833/b61fb78...f2d50b4.html" title="Last updated on Dec 18, 2024, 5:36 PM UTC (f2d50b4)">Diff</a>