### PR TITLE
Fix missing steps and fields in "report an error" in log module.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10988,6 +10988,8 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
 
 1. Let |settings| be |script|'s [=script/settings object=].
 
+1. Let |timestamp| be a [=time value=] representing the current date and time in UTC.
+
 1. Let |stack| be the [=stack trace for an exception=] with the exception
    corresponding to the error being reported.
 
@@ -10995,8 +10997,11 @@ ignore>line number</var>, <var ignore>column number</var>, |message| and
 
 1. Let |entry| be a [=/map=] matching the <code>log.JavascriptLogEntry</code> production,
    with <code>level</code> set to "<code>error</code>", <code>text</code> set to
-   |message|, <code>source</code> set to |source|, and the <code>timestamp</code>
-   field set to |timestamp|.
+   |message|, <code>source</code> set to |source|, <code>timestamp</code>
+   set to |timestamp|, and the <code>stackTrace</code> field set to |stack|.
+
+1. Let |body| be a [=/map=] matching the <code>log.EntryAdded</code> production, with
+     the <code>params</code> field set to |entry|.
 
 1. Let |related navigables| be the result of [=get related navigables=] given |settings|.
 


### PR DESCRIPTION
Missing steps common to the regular console steps, also in the `log` module:

- Creating the `timestamp` field.
- Creating `body` from `entry`.

Also, the `stack` value was created in its own step, but was not listed in the list of fields creating the specific `log.JavascriptLogEntry` production.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lauromoura/webdriver-bidi/pull/838.html" title="Last updated on Dec 30, 2024, 11:01 AM UTC (507c51a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/838/e08792b...lauromoura:507c51a.html" title="Last updated on Dec 30, 2024, 11:01 AM UTC (507c51a)">Diff</a>