### PR TITLE
Fix the subscribe command result type and the spec text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1462,7 +1462,8 @@ SessionCommand = (
 <pre class="cddl local-cddl">
 SessionResult = (
    session.NewResult /
-   session.StatusResult
+   session.StatusResult /
+   session.SubscribeResult
 )
 </pre>
 
@@ -1886,7 +1887,7 @@ Issue: This needs to be generalized to work with realms too.
    <dt>Result Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        session.SubscriptionRequestResult = {
+        session.SubscribeResult = {
           subscription: session.Subscription,
         }
       </pre>
@@ -1960,7 +1961,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
   1. Run the [=remote end subscribe steps=] for the [=event=] with [=event name=]
      |event name| given |session|, |navigables| and |include global|.
 
-1. Return [=success=] with data null.
+1. Let |body| be a new [=/map=] matching the <code>session.SubscribeResult</code> production,
+   with the <code>subscription</code> field set to |subscription|'s [=subscription/subscription id=].
+
+1. Return [=success=] with data |body|.
 
 </div>
 


### PR DESCRIPTION
In https://github.com/w3c/webdriver-bidi/pull/828 I forgot to properly return the subscription ID. I adjusted the type name to match result naming scheme in other commands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/842.html" title="Last updated on Jan 7, 2025, 11:56 AM UTC (3e6a01d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/842/78a53cc...3e6a01d.html" title="Last updated on Jan 7, 2025, 11:56 AM UTC (3e6a01d)">Diff</a>