### PR TITLE
Unsubscribe by attributes should check that all events and context ids exist in subscriptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2054,21 +2054,47 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |new subscriptions| to be a [=/list=].
 
+   1. Let |match| be false.
+
    1. For each |subscription| of |session|'s [=subscriptions=]:
+
+      1. If |match| is true:
+
+         1. [=list/append=] |subscription| to |new subscriptions|.
+
+         1. [=Continue=].
 
       1. If [=set/intersection=] of |subscription|'s [=subscription/event names=] and |event names| is an empty [=/set=]:
 
          1. [=list/append=] |subscription| to |new subscriptions|.
 
-         1. Continue.
+         1. [=Continue=].
 
       1. If |top-level traversable context ids| is an empty [=/set=]:
 
-        1. [=list/Remove=] all items [=list/contains|contained=] in |event names| from |subscription|'s [=subscription/event names=].
+         1. If |subscription|'s [=subscription/top-level traversable ids=] [=set/size=] is not zero:
 
-        1. If |subscription|'s [=subscription/event names=] is not empty:
+            1. [=list/append=] |subscription| to |new subscriptions|.
 
-          1. [=list/append=] |subscription| to |new subscriptions|.
+            1. [=Continue=].
+
+         1. Let |subscription event names| be [=set/clone=] of |subscription|'s [=subscription/event names=].
+
+         1. For each |event name| of |event names|:
+
+            1. If |subscription event names| [=set/contains=] |event name|:
+
+               1. [=list/Remove=] |event name| from |event names|.
+
+               1. [=list/Remove=] |event name| from |subscription event names|.
+
+         1. If |event names| [=set/size=] is zero, set |match| to true.
+
+         1. If |subscription event names| is not empty:
+
+            1. Set |subscription|'s [=subscription/event names=] to |subscription event names|.
+
+            1. [=list/append=] |subscription| to |new subscriptions|.
 
       1. Otherwise:
 
@@ -2080,23 +2106,41 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
           Note: unsubscribe by contexts is deprecated and will be removed in the future versions.
 
+          1. If [=set/intersection=] of |event names| and |subscription|'s [=subscription/event names=]|'s [=set/size=]
+             does not equal |event names|'s [=set/size=]:
+
+             1. [=list/append=] |subscription| to |new subscriptions|.
+
+             1. [=Continue=].
+
           1. Let |event map| be an empty [=/map=].
 
           1. For each |event name| in |subscription|'s [=subscription/event names=]:
 
               1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s [=subscription/top-level traversable ids=].
 
+          1. Let |context ids to remove| be an empty [=/set=].
+
           1. For each |event name| in |event names|:
 
               1. If |event map|[|event name|] does not exist,
-                 continue.
+                 [=continue=].
 
-              1. Set |event map|[|event name|] to the [=set/difference=]
-                 between |event map|[|event name|] and |top-level traversable context ids|.
+              1. For each |top-level traversable id| of |top-level traversable context ids|:
+
+                 1. If |event map|[|event name|] [=set/contains=] |top-level traversable id|:
+
+                    1. [=list/Append=] |top-level traversable id| to |context ids to remove|.
+
+                    1. [=list/Remove=] |top-level traversable id| from |event map|[|event name|].
 
               1. If |event map|[|event name|] is an empty [=/set=],
 
                 1. [=map/Remove=] |event map|[|event name|].
+
+          1. For each |top-level traversable id| of |context ids to remove|:
+
+             1. [=list/Remove=] |top-level traversable id| from |top-level traversable context ids|.
 
           1. For each |event name| → |remaining top-level traversable ids| in |event map|:
 
@@ -2106,6 +2150,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
                [=subscription/top-level traversable ids=] set to |remaining top-level traversable ids|.
 
             1. [=list/append=] |partial subscription| to |new subscriptions|.
+
+          1. If |top-level traversable context ids| is empty, set |match| to true.
+
+   1. If |match| is false, return [=error=] with [=error code=] [=invalid argument=].
 
    1. Set |session|'s [=subscriptions=] to |new subscriptions|.
 

--- a/index.bs
+++ b/index.bs
@@ -2136,9 +2136,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
             1. [=list/append=] |partial subscription| to |new subscriptions|.
 
-   1. If |matched events| does not equal |event names|, return [=error=] with [=error code=] [=invalid argument=].
+   1. If |matched events| is not [=set/equal=] to |event names|, return [=error=] with [=error code=] [=invalid argument=].
 
-   1. If |top-level traversable context ids| is not empty and |matched contexts| does not equal
+   1. If |top-level traversable context ids| is not empty and |matched contexts| is not [=set/equal=] to
       |top-level traversable context ids|, return [=error=] with [=error code=] [=invalid argument=].
 
    1. Set |session|'s [=subscriptions=] to |new subscriptions|.

--- a/index.bs
+++ b/index.bs
@@ -2054,15 +2054,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |new subscriptions| to be a [=/list=].
 
-   1. Let |match| be false.
+   1. Let |matched events| to be a [=/set=].
+
+   1. Let |matched contexts| to be a [=/set=].
 
    1. For each |subscription| of |session|'s [=subscriptions=]:
-
-      1. If |match| is true:
-
-         1. [=list/append=] |subscription| to |new subscriptions|.
-
-         1. [=Continue=].
 
       1. If [=set/intersection=] of |subscription|'s [=subscription/event names=] and |event names| is an empty [=/set=]:
 
@@ -2072,7 +2068,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       1. If |top-level traversable context ids| is an empty [=/set=]:
 
-         1. If |subscription|'s [=subscription/top-level traversable ids=] [=set/size=] is not zero:
+         1. If |subscription| is not [=subscription/global=]:
 
             1. [=list/append=] |subscription| to |new subscriptions|.
 
@@ -2084,17 +2080,17 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
             1. If |subscription event names| [=set/contains=] |event name|:
 
-               1. [=list/Remove=] |event name| from |event names|.
+               1. [=list/Append=] |event name| to |matched events|.
 
                1. [=list/Remove=] |event name| from |subscription event names|.
 
-         1. If |event names| [=set/size=] is zero, set |match| to true.
-
          1. If |subscription event names| is not empty:
 
-            1. Set |subscription|'s [=subscription/event names=] to |subscription event names|.
+            1. Let |cloned subscription| be a [=subscription=] with
+               [=subscription/subscription id=] set to |subscription|'s [=subscription/subscription id=],
+               [=subscription/event names=] set to a new [=/set=] containing |subscription event names|.
 
-            1. [=list/append=] |subscription| to |new subscriptions|.
+            1. [=list/append=] |cloned subscription| to |new subscriptions|.
 
       1. Otherwise:
 
@@ -2106,20 +2102,11 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
           Note: unsubscribe by contexts is deprecated and will be removed in the future versions.
 
-          1. If [=set/intersection=] of |event names| and |subscription|'s [=subscription/event names=]|'s [=set/size=]
-             does not equal |event names|'s [=set/size=]:
-
-             1. [=list/append=] |subscription| to |new subscriptions|.
-
-             1. [=Continue=].
-
           1. Let |event map| be an empty [=/map=].
 
           1. For each |event name| in |subscription|'s [=subscription/event names=]:
 
               1. Set |event map|[|event name|] to [=set/clone=] of |subscription|'s [=subscription/top-level traversable ids=].
-
-          1. Let |context ids to remove| be an empty [=/set=].
 
           1. For each |event name| in |event names|:
 
@@ -2130,17 +2117,15 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
                  1. If |event map|[|event name|] [=set/contains=] |top-level traversable id|:
 
-                    1. [=list/Append=] |top-level traversable id| to |context ids to remove|.
+                    1. [=list/Append=] |top-level traversable id| to |matched contexts|.
+
+                    1. [=list/Append=] |event name| to |matched events|.
 
                     1. [=list/Remove=] |top-level traversable id| from |event map|[|event name|].
 
               1. If |event map|[|event name|] is an empty [=/set=],
 
                 1. [=map/Remove=] |event map|[|event name|].
-
-          1. For each |top-level traversable id| of |context ids to remove|:
-
-             1. [=list/Remove=] |top-level traversable id| from |top-level traversable context ids|.
 
           1. For each |event name| → |remaining top-level traversable ids| in |event map|:
 
@@ -2151,9 +2136,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
             1. [=list/append=] |partial subscription| to |new subscriptions|.
 
-          1. If |top-level traversable context ids| is empty, set |match| to true.
+   1. If |matched events| does not equal |event names|, return [=error=] with [=error code=] [=invalid argument=].
 
-   1. If |match| is false, return [=error=] with [=error code=] [=invalid argument=].
+   1. If |top-level traversable context ids| is not empty and |matched contexts| does not equal
+      |top-level traversable context ids|, return [=error=] with [=error code=] [=invalid argument=].
 
    1. Set |session|'s [=subscriptions=] to |new subscriptions|.
 


### PR DESCRIPTION
In https://github.com/w3c/webdriver-bidi/pull/828 I also overlooked that removal of subscriptions should only apply if all unsubscribe attributes match existing subscription data. To remain backward compatible, this PR adds steps to account for that and cover the cases like the following:

For events:

```
subscribe(events=[A, B])
unsubscribe(events=[A]) => works
unsubscribe(events=[A, B]) => expected to throw
```

For contexts:
```
subscribe(contexts=[A, B])
unsubscribe(contexts=[A]) => works
unsubscribe(contexts=[A, B]) => expected to throw
```

```
subscribe(events=[A])
unsubscribe(events=[A], contexts=[A]) => expected to throw
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/847.html" title="Last updated on Jan 10, 2025, 2:52 PM UTC (26665d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/847/87cd2c0...26665d2.html" title="Last updated on Jan 10, 2025, 2:52 PM UTC (26665d2)">Diff</a>