### PR TITLE
Always include stacktrace for console messages

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11029,17 +11029,14 @@ Define the following [=console steps=] with |method|, |args|, and
 
   1. Let |source| be the result of [=get the source=] given [=current Realm Record=].
 
-  1. If |method| is "<code>assert</code>", "<code>error</code>",
-     "<code>trace</code>", or "<code>warn</code>", let |stack| be the [=current
-     stack trace=]. Otherwise let |stack| be null.
+  1. Let |stack| be the [=current stack trace=].
 
   1. Let |entry| be a [=/map=] matching the <code>log.ConsoleLogEntry</code> production,
      with the the <code>level</code> field set to |level|, the <code>text</code>
      field set to |text|, the <code>timestamp</code> field set to |timestamp|, the
-     <code>stackTrace</code> field set to |stack| if |stack| is not null, or
-     omitted otherwise, the |method| field set to |method|, the <code>source</code>
-     field set to |source| and the <code>args</code> field set to |serialized
-     args|.
+     <code>stackTrace</code> field set to |stack|, the |method| field set to |method|,
+     the <code>source</code> field set to |source|,
+     and the <code>args</code> field set to |serialized args|.
 
   1. Let |body| be a [=/map=] matching the <code>log.EntryAdded</code> production, with
      the <code>params</code> field set to |entry|.


### PR DESCRIPTION
As an alternative to https://github.com/w3c/webdriver-bidi/pull/807 it makes sense to always include the stacktrace so that the client can figure out where the logs are coming from.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/854.html" title="Last updated on Jan 14, 2025, 5:05 PM UTC (e6001f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/854/e25f510...e6001f1.html" title="Last updated on Jan 14, 2025, 5:05 PM UTC (e6001f1)">Diff</a>