### PR TITLE
Fix typo in session.subscribe algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1971,7 +1971,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
    let |event names| be the [=set/union=] of |event names| and the result of
    [=trying=] to [=obtain a set of event names=] with |name|.
 
-1. Let |input user context ids| be [=set/create|create a set=] with |command parameters|[<code>contexts</code>].
+1. Let |input user context ids| be [=set/create|create a set=] with |command parameters|[<code>userContexts</code>].
 
 1. Let |input context ids| be [=set/create|create a set=] with |command parameters|[<code>contexts</code>].
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/860.html" title="Last updated on Jan 16, 2025, 10:04 AM UTC (5f3a6d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/860/1f2b39e...lutien:5f3a6d7.html" title="Last updated on Jan 16, 2025, 10:04 AM UTC (5f3a6d7)">Diff</a>