### PR TITLE
Prevent navigable being overridden by parent navigable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3030,10 +3030,10 @@ To <dfn>get the navigable info</dfn> given |navigable|,
 
 1. Let |navigable id| be the [=navigable id=] for |navigable|.
 
-1. Let |navigable| be |navigable|'s [=navigable/parent=].
+1. Let |parent navigable| be |navigable|'s [=navigable/parent=].
 
-1. If |navigable| is not null let |parent id| be the
-   [=navigable id=] of |navigable|. Otherwise let
+1. If |parent navigable| is not null let |parent id| be the
+   [=navigable id=] of |parent navigable|. Otherwise let
    |parent id| be null.
 
 1. Let |document| be |navigable|'s [=active document=].


### PR DESCRIPTION
Within [`get the navigable info`](https://w3c.github.io/webdriver-bidi/#get-the-navigable-info) we are overriding the passed in `navigable` when trying to get the navigable id of the parent navigable. Further steps in this method will then base on the parent instead of the current navigable.