### PR TITLE
Return "no such user context" and "no such frame" instead "invalid argument" in "session.subscribe" and "session.unsubscribe"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2000,7 +2000,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
        1. Let |user context| be [=get user context=] with |user context id|.
 
-       1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
+       1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
        1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
           whose [=associated user context=] is |user context|:

--- a/index.bs
+++ b/index.bs
@@ -1172,6 +1172,22 @@ To <dfn>get top-level traversables</dfn> given a [=/list=] of [=/navigables=] |n
 
 </div>
 
+<div algorithm>
+
+To <dfn>get valid navigables by ids</dfn> given a [=/list=] of context ids |navigable ids|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each |navigable id| in |navigable ids|:
+
+   1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |navigable id|.
+
+   1. [=set/Append=] |navigable| to |result|.
+
+1. Return [=success=] with data |result|.
+
+</div>
+
 <div algorithm> To <dfn export>emit an event</dfn> given |session|, and |body|:
 
 1. [=Assert=]: |body| has [=map/size=] 2 and [=map/contains=] "<code>method</code>"
@@ -1982,11 +1998,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |input context ids| is not empty:
 
-   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
-
-   1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
-
-      1. Return [=error=] with [=error code=] [=invalid argument=].
+   1. Let |navigables| be the result of [=trying=] to [=get valid navigables by ids=] with |input context ids|.
 
    1. Set |subscription navigables| be [=get top-level traversables=] with |navigables|.
 
@@ -2102,11 +2114,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. If |input context ids| is not empty:
 
-      1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
-
-      1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
-
-         1. Return [=error=] with [=error code=] [=invalid argument=].
+      1. Let |navigables| be the result of [=trying=] to [=get valid navigables by ids=] with |input context ids|.
 
       1. Set |top-level traversables| be [=get top-level traversables=] with |navigables|.
 


### PR DESCRIPTION
- Return "no such user context" error instead "invalid argument" in "session.subscribe" command.
- Return "no such frame" error instead "invalid argument" in "session.subscribe" and "session.unsubscribe" commands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/865.html" title="Last updated on Jan 21, 2025, 10:49 AM UTC (af4218a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/865/a4615b3...lutien:af4218a.html" title="Last updated on Jan 21, 2025, 10:49 AM UTC (af4218a)">Diff</a>