### PR TITLE
Fix webExtension.install base64 parameter name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11790,7 +11790,7 @@ To <dfn>expand a web extension data spec</dfn> given |extension data spec|:
 
     <dt>|type| is the string "<code>base64</code>"
     <dd>
-      1. Let |bytes| be [=forgiving-base64 decode=] |extension data spec|["<code>path</code>"].
+      1. Let |bytes| be [=forgiving-base64 decode=] |extension data spec|["<code>value</code>"].
       1. If |bytes| is failure, return null.
       1. Let |entry| be the result of [=trying=] to [=extract a zip archive=] given |bytes|.
 


### PR DESCRIPTION
`base64` is declared to use `value` instead of the `path`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ghostery/webdriver-bidi/pull/871.html" title="Last updated on Jan 29, 2025, 12:59 PM UTC (04c55ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/871/1d0fcc1...ghostery:04c55ab.html" title="Last updated on Jan 29, 2025, 12:59 PM UTC (04c55ab)">Diff</a>