### PR TITLE
Fix extend

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4093,7 +4093,7 @@ To <dfn>locate nodes using inner text</dfn> with given |context nodes|,
 
       1. [=list/Append=] |child| to |child nodes|.
 
-    1. [=Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
+    1. [=list/Extend=] |returned nodes| with the result of [=trying=] to [=locate nodes using inner text=]
       with |child nodes|, |selector|, |max depth|, |match type|, |ignore case|, and |maximum returned node count|.
 
   1. If |context node| does not implement {{HTMLElement}} then [=continue=].


### PR DESCRIPTION
There is now set/extend and list/extend


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/872.html" title="Last updated on Jan 30, 2025, 1:46 PM UTC (5454201)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/872/10866d1...5454201.html" title="Last updated on Jan 30, 2025, 1:46 PM UTC (5454201)">Diff</a>