### PR TITLE
Allow fractional numbers for x and y positions of pointer actions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11492,8 +11492,8 @@ Note: for a detailed description of the behavior of this command, see the
 
       input.PointerMoveAction = {
         type: "pointerMove",
-        x: js-int,
-        y: js-int,
+        x: float,
+        y: float,
         ? duration: js-uint,
         ? origin: input.Origin,
         input.PointerCommonProperties


### PR DESCRIPTION
Fixes #873.

The relevant WebDriver classic PR is at https://github.com/w3c/webdriver/pull/1881.

Open question if we need this as well for `wheel` input sources, specifically for the `scroll` action. In Firefox we currently still only allow integers, but not sure how Chrome behaves here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/874.html" title="Last updated on Feb 7, 2025, 3:15 PM UTC (d54917e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/874/0713f9c...whimboo:d54917e.html" title="Last updated on Feb 7, 2025, 3:15 PM UTC (d54917e)">Diff</a>