### PR TITLE
Add support for "userContexts" argument to "browsingContext.setViewport" command.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4712,7 +4712,7 @@ before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
-   1. If the <code>viewport</code> field of |[=viewport overrides map=][|user context|] is present:
+   1. If the <code>viewport</code> field of [=viewport overrides map=][|user context|] is not null:
 
       1. [=Set viewport=] with |navigable| and [=viewport overrides map=][|user context|]["<code>viewport</code>"].
 

--- a/index.bs
+++ b/index.bs
@@ -4667,7 +4667,7 @@ To <dfn>set device pixel ratio override</dfn> given |navigable| and |device pixe
 
 1. If |device pixel ratio| is not null:
 
-   1. When the [=select an image source from a source set=] are run, act as if
+   1. When the [=select an image source from a source set=] steps are run, act as if
       the implementation's pixel density was set to |device pixel ratio| when selecting an image.
 
    1. For the purposes of the [=resolution media feature=], act as if
@@ -4785,6 +4785,8 @@ The [=remote end steps=] with |command parameters| are:
 
          1. [=list/Append=] |top-level traversable| to |navigables|.
 
+1. Otherwise, return [=error=] with [=error code=] [=invalid argument=].
+
 1. If |command parameters| [=map/contains=] the <code>viewport</code> field:
 
    1. Let |viewport| be the |command parameters|["<code>viewport</code>"].
@@ -4793,7 +4795,7 @@ The [=remote end steps=] with |command parameters| are:
 
       1. [=Set viewport=] with |navigable| and |viewport|.
 
-1. Run the [[cssom-view-1#resizing-viewports]] steps.
+      1. Run the [[cssom-view-1#resizing-viewports]] steps with |navigable|'s [=active document=].
 
 1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
 

--- a/index.bs
+++ b/index.bs
@@ -2966,6 +2966,13 @@ between [=navigables=] and device pixel ratio overrides. It is initially empty.
 Note: this map is not cleared when the final session ends i.e. device pixel
 ratio overrides outlive any WebDriver session.
 
+A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map
+between [=user contexts=] and [=structs=], with an [=struct/item=] named <code>viewport</code>
+and an [=struct/item=] named <code>devicePixelRatio</code>, which is a float or null.
+An [=struct/item=] <code>viewport</code> is a [=struct=] or null, with an [=struct/item=]
+named <code>height</code>, which is an integer, and an [=struct/item=] named <code>width</code>,
+which is an integer.
+
 ### Types ### {#module-browsingcontext-types}
 
 #### The browsingContext.BrowsingContext Type #### {#type-browsingContext-Browsingcontext}
@@ -4629,9 +4636,10 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command modifies 
       )
 
       browsingContext.SetViewportParameters = {
-        context: browsingContext.BrowsingContext,
+        ? context: browsingContext.BrowsingContext,
         ? viewport: browsingContext.Viewport / null,
         ? devicePixelRatio: (float .gt 0.0) / null,
+        ? userContexts: [+browser.UserContext],
       }
 
       browsingContext.Viewport = {
@@ -4648,34 +4656,141 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command modifies 
    </dd>
 </dl>
 
+<div algorithm>
+To <dfn>set device pixel ratio override</dfn> given |navigable| and |device pixel ratio|:
+
+1. Let |navigable| be the [=/navigable=] whose [=navigable/active document=] is
+   |navigable|'s [=navigable/active document=].
+
+1. If |device pixel ratio| is not null:
+
+   1. When the [=select an image source from a source set=] are run, act as if
+      the implementation's pixel density was set to |device pixel ratio| when selecting an image.
+
+   1. For the purposes of the [=resolution media feature=], act as if
+      the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
+
+   1. [=map/Set=] [=device pixel ratio overrides=][|navigable|] to |device pixel ratio|.
+
+      Note: This will take an effect because of the patch of [[#patchs-determine-the-device-pixel-ratio]].
+
+1. Otherwise:
+
+   1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
+      without any changes made by previous invocations of these steps.
+
+   1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
+      without any changes made by previous invocations of these steps.
+
+   1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
+
+1. Run [=evaluate media queries and report changes=] for [=/document=] currently loaded
+   in a specified |navigable|.
+
+</div>
+
+
+<div algorithm>
+To <dfn>set viewport</dfn> given |navigable| and |viewport|:
+
+1. If |viewport| is not null, set the width of |navigable|'s [=layout
+   viewport=] to be the <code>width</code> of |viewport| in CSS pixels and
+   set the height of the |navigable|'s [=layout viewport=] to be the
+   <code>height</code> of |viewport| in CSS pixels.
+
+1. Otherwise, set the |navigable|'s [=layout viewport=] to the
+   implementation-defined default.
+
+</div>
+
+<div algorithm="set viewport when a top-level traversable is created">
+
+When the [=set up a window environment settings object=]
+algorithm is invoked, immediately prior to returning the settings
+object:
+
+1. Let |environment settings| be the newly created [=environment settings
+   object=].
+
+1. Let |related navigables| be the result of [=get related navigables=] given |environment settings|.
+
+1. For each |navigable| of |related navigables|:
+
+   1. If |navigable| is not a [=/top-level traversable=], continue.
+
+   1. Let |user context| be |navigable|'s [=associated user context=].
+
+   1. If [=viewport overrides map=] [=map/contains=] |user context|:
+
+      1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>viewport</code> field:
+
+         1. [=Set viewport=] with |navigable| and |viewport overrides map|[|user context|]["<code>viewport</code>"].
+
+      1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>devicePixelRatio</code> field:
+
+         1. For the |navigable| and all [=descendant navigables=]:
+
+            1. [=Set device pixel ratio override=] with |navigable| and |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>""].
+
 <div algorithm="remote end steps for browsingContext.setViewport">
 
 The [=remote end steps=] with |command parameters| are:
 
-1. Let |navigable id| be the value of the <code>context</code> field of |command
-   parameters|.
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
 
-1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with
-   |navigable id|.
+1. Let |navigables| be a [=/set=].
 
-1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
-   [=error code=] [=invalid argument=].
+1. If the <code>context</code> field of |command parameters| is present:
 
-1. If the implementation is unable to adjust the |navigable|'s [=layout viewport=]
-   parameters with the given |command parameters| for any reason, return
-   [=error=] with [=error code=] [=unsupported operation=].
+   1. Let |navigable id| be the value of the <code>context</code> field of |command
+      parameters|.
+
+   1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with
+      |navigable id|.
+
+   1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
+      [=error code=] [=invalid argument=].
+
+   1. If the implementation is unable to adjust the |navigable|'s [=layout viewport=]
+      parameters with the given |command parameters| for any reason, return
+      [=error=] with [=error code=] [=unsupported operation=].
+
+   1. [=set/Append=] |navigable| to |navigables|.
+
+1. Otherwise, if the <code>userContexts</code> field of |command parameters| is present:
+
+   1. For each |user context id| of |command parameters|["<code>userContexts</code>"]:
+
+      1. Set |user context| to [=get user context=] with |user context id|.
+
+      1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
+
+      1. [=map/Set=] [=viewport overrides map=][|user context|] to a new [=/map=].
+
+      1. If |command parameters| [=map/contains=] the <code>viewport</code> field:
+
+         1. Set |viewport overrides map|[|user context|]["<code>viewport</code>"]
+            to |command parameters|["<code>viewport</code>"].
+
+      1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
+
+         1. Set |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>"]
+            to |command parameters|["<code>devicePixelRatio</code>"].
+
+      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+         whose [=associated user context=] is |user context|:
+
+         1. [=list/Append=] |top-level traversable| to |navigables|.
 
 1. If |command parameters| [=map/contains=] the <code>viewport</code> field:
 
    1. Let |viewport| be the |command parameters|["<code>viewport</code>"].
 
-   1. If |viewport| is not null, set the width of |navigable|'s [=layout
-      viewport=] to be the <code>width</code> of |viewport| in CSS pixels and
-      set the height of the |navigable|'s [=layout viewport=] to be the
-      <code>height</code> of |viewport| in CSS pixels.
+   1. For each |navigable| of |navigables|:
 
-   1. Otherwise, set the |navigable|'s [=layout viewport=] to the
-      implementation-defined default.
+      1. [=Set viewport=] with |navigable| and |viewport|.
 
 1. Run the [[cssom-view-1#resizing-viewports]] steps.
 
@@ -4684,35 +4799,11 @@ The [=remote end steps=] with |command parameters| are:
    1. Let |device pixel ratio| be the |command
       parameters|["<code>devicePixelRatio</code>"].
 
-   1. For the |navigable| and all [=descendant navigables=]:
+   1. For each |navigable| of |navigables|:
 
-      1. Let |navigable| be the [=/navigable=] whose [=navigable/active document=] is
-         |navigable|'s [=navigable/active document=].
+      1. For the |navigable| and all [=descendant navigables=]:
 
-      1. If |device pixel ratio| is not null:
-
-         1. When the [=select an image source from a source set=] are run, act as if
-            the implementation's pixel density was set to |device pixel ratio| when selecting an image.
-
-         1. For the purposes of the [=resolution media feature=], act as if
-            the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
-
-         1. [=map/Set=] [=device pixel ratio overrides=][|navigable|] to |device pixel ratio|.
-
-            Note: This will take an effect because of the patch of [[#patchs-determine-the-device-pixel-ratio]].
-
-      1. Otherwise:
-
-         1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
-            without any changes made by previous invocations of these steps.
-
-         1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
-            without any changes made by previous invocations of these steps.
-
-         1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
-
-      1. Run [=evaluate media queries and report changes=] for [=/document=] currently loaded
-         in a specified |navigable|.
+         1. [=Set device pixel ratio override=] with |navigable| and |device pixel ratio|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -4774,7 +4774,7 @@ The [=remote end steps=] with |command parameters| are:
 
       1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
 
-         1. Set [=viewport overrides map=]|[|user context|]["<code>devicePixelRatio</code>"]
+         1. Set [=viewport overrides map=][|user context|]["<code>devicePixelRatio</code>"]
             to |command parameters|["<code>devicePixelRatio</code>"].
 
       1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]

--- a/index.bs
+++ b/index.bs
@@ -4709,7 +4709,7 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 <div algorithm="set viewport when a navigable is created">
 
-After creating a document in a new [=/navigable=]|navigable| and
+After creating a document in a new [=/navigable=] |navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
 TODO: Move it as a hook in the html spec instead.

--- a/index.bs
+++ b/index.bs
@@ -4709,7 +4709,7 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 <div algorithm="set viewport when a top-level traversable is created">
 
-After creating a document in a new [=navigable=] |navigable| and
+After creating a document in a new [=/navigable=]|navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
 TODO: Move it as a hook in the html spec instead.

--- a/index.bs
+++ b/index.bs
@@ -4716,7 +4716,7 @@ before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
       1. [=Set viewport=] with |navigable| and [=viewport overrides map=][|user context|]["<code>viewport</code>"].
 
-   1. If the <code>devicePixelRatio</code> field of |[=viewport overrides map=][|user context|] is present:
+   1. If the <code>devicePixelRatio</code> field of [=viewport overrides map=][|user context|] is not null:
 
       1. For the |navigable| and all [=descendant navigables=]:
 

--- a/index.bs
+++ b/index.bs
@@ -4707,7 +4707,7 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 </div>
 
-<div algorithm="set viewport when a top-level traversable is created">
+<div algorithm="set viewport when a navigable is created">
 
 After creating a document in a new [=/navigable=]|navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:

--- a/index.bs
+++ b/index.bs
@@ -4662,9 +4662,6 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command modifies 
 <div algorithm>
 To <dfn>set device pixel ratio override</dfn> given |navigable| and |device pixel ratio|:
 
-1. Let |navigable| be the [=/navigable=] whose [=navigable/active document=] is
-   |navigable|'s [=navigable/active document=].
-
 1. If |device pixel ratio| is not null:
 
    1. When the [=select an image source from a source set=] steps are run, act as if
@@ -4715,15 +4712,15 @@ before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
-   1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>viewport</code> field:
+   1. If the <code>viewport</code> field of |[=viewport overrides map=][|user context|] is present:
 
-      1. [=Set viewport=] with |navigable| and |viewport overrides map|[|user context|]["<code>viewport</code>"].
+      1. [=Set viewport=] with |navigable| and [=viewport overrides map=][|user context|]["<code>viewport</code>"].
 
-   1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>devicePixelRatio</code> field:
+   1. If the <code>devicePixelRatio</code> field of |[=viewport overrides map=][|user context|] is present:
 
       1. For the |navigable| and all [=descendant navigables=]:
 
-         1. [=Set device pixel ratio override=] with |navigable| and |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>""].
+         1. [=Set device pixel ratio override=] with |navigable| and [=viewport overrides map=][|user context|]["<code>devicePixelRatio</code>""].
 
 </div>
 
@@ -4768,19 +4765,19 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |user context| of |user contexts|:
 
-      1. [=map/Set=] [=viewport overrides map=][|user context|] to a new [=/map=].
+      1. [=map/Set=] [=viewport overrides map=][|user context|] to a struct.
 
       1. If |command parameters| [=map/contains=] the <code>viewport</code> field:
 
-         1. Set |viewport overrides map|[|user context|]["<code>viewport</code>"]
+         1. Set [=viewport overrides map=][|user context|]["<code>viewport</code>"]
             to |command parameters|["<code>viewport</code>"].
 
       1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
 
-         1. Set |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>"]
+         1. Set [=viewport overrides map=]|[|user context|]["<code>devicePixelRatio</code>"]
             to |command parameters|["<code>devicePixelRatio</code>"].
 
-      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+      1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]
          whose [=associated user context=] is |user context|:
 
          1. [=list/Append=] |top-level traversable| to |navigables|.

--- a/index.bs
+++ b/index.bs
@@ -2966,12 +2966,15 @@ between [=navigables=] and device pixel ratio overrides. It is initially empty.
 Note: this map is not cleared when the final session ends i.e. device pixel
 ratio overrides outlive any WebDriver session.
 
-A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map
-between [=user contexts=] and [=structs=], with an [=struct/item=] named <code>viewport</code>
-and an [=struct/item=] named <code>devicePixelRatio</code>, which is a float or null.
-An [=struct/item=] <code>viewport</code> is a [=struct=] or null, with an [=struct/item=]
-named <code>height</code>, which is an integer, and an [=struct/item=] named <code>width</code>,
-which is an integer.
+A <dfn for="viewport-configuration">viewport dimensions</dfn> is a [=struct=] with an [=struct/item=] named
+<dfn attribute for="viewport-dimensions">height</dfn> which is an integer and
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">width</dfn> which is an integer.
+
+A <dfn>viewport configuration</dfn> is a [=struct=] with an [=struct/item=] named
+<dfn attribute for="viewport-configuration">viewport</dfn> which is a [=viewport-configuration/viewport dimensions=]
+or null and an [=struct/item=] named <dfn attribute for="viewport-configuration">devicePixelRatio</dfn> which is a float or null.
+
+A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map between [=user contexts=] and [=viewport configuration=].
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -4705,36 +4708,32 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 <div algorithm="set viewport when a top-level traversable is created">
 
-When the [=set up a window environment settings object=]
-algorithm is invoked, immediately prior to returning the settings
-object:
+After creating a document in a new [=navigable/top-level traversable=] |navigable| and
+before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 
-1. Let |environment settings| be the newly created [=environment settings
-   object=].
+1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. Let |related navigables| be the result of [=get related navigables=] given |environment settings|.
+1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
-1. For each |navigable| of |related navigables|:
+   1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>viewport</code> field:
 
-   1. If |navigable| is not a [=/top-level traversable=], continue.
+      1. [=Set viewport=] with |navigable| and |viewport overrides map|[|user context|]["<code>viewport</code>"].
 
-   1. Let |user context| be |navigable|'s [=associated user context=].
+   1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>devicePixelRatio</code> field:
 
-   1. If [=viewport overrides map=] [=map/contains=] |user context|:
+      1. For the |navigable| and all [=descendant navigables=]:
 
-      1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>viewport</code> field:
+         1. [=Set device pixel ratio override=] with |navigable| and |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>""].
 
-         1. [=Set viewport=] with |navigable| and |viewport overrides map|[|user context|]["<code>viewport</code>"].
-
-      1. If |viewport overrides map|[|user context|] [=map/contains=] the <code>devicePixelRatio</code> field:
-
-         1. For the |navigable| and all [=descendant navigables=]:
-
-            1. [=Set device pixel ratio override=] with |navigable| and |viewport overrides map|[|user context|]["<code>devicePixelRatio</code>""].
+</div>
 
 <div algorithm="remote end steps for browsingContext.setViewport">
 
 The [=remote end steps=] with |command parameters| are:
+
+1. If the implementation is unable to adjust the [=layout viewport=]
+   parameters with the given |command parameters| for any reason, return
+   [=error=] with [=error code=] [=unsupported operation=].
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
    and |command parameters| [=map/contains=] "<code>context</code>",
@@ -4753,19 +4752,21 @@ The [=remote end steps=] with |command parameters| are:
    1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
       [=error code=] [=invalid argument=].
 
-   1. If the implementation is unable to adjust the |navigable|'s [=layout viewport=]
-      parameters with the given |command parameters| for any reason, return
-      [=error=] with [=error code=] [=unsupported operation=].
-
    1. [=set/Append=] |navigable| to |navigables|.
 
 1. Otherwise, if the <code>userContexts</code> field of |command parameters| is present:
+
+   1. Let |user contexts| be a [=/set=].
 
    1. For each |user context id| of |command parameters|["<code>userContexts</code>"]:
 
       1. Set |user context| to [=get user context=] with |user context id|.
 
       1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
+
+      1. [=set/Append=] |user context| to |user contexts|.
+
+   1. For each |user context| of |user contexts|:
 
       1. [=map/Set=] [=viewport overrides map=][|user context|] to a new [=/map=].
 

--- a/index.bs
+++ b/index.bs
@@ -4664,11 +4664,13 @@ To <dfn>set device pixel ratio override</dfn> given |navigable| and |device pixe
 
 1. If |device pixel ratio| is not null:
 
-   1. When the [=select an image source from a source set=] steps are run, act as if
-      the implementation's pixel density was set to |device pixel ratio| when selecting an image.
+   1. For [=/document=] currently loaded in a specified |navigable|:
 
-   1. For the purposes of the [=resolution media feature=], act as if
-      the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
+      1. When the [=select an image source from a source set=] steps are run, act as if
+         the implementation's pixel density was set to |device pixel ratio| when selecting an image.
+
+      1. For the purposes of the [=resolution media feature=], act as if
+         the implementation's resolution is |device pixel ratio| dppx scaled by the page zoom.
 
    1. [=map/Set=] [=device pixel ratio overrides=][|navigable|] to |device pixel ratio|.
 
@@ -4676,11 +4678,13 @@ To <dfn>set device pixel ratio override</dfn> given |navigable| and |device pixe
 
 1. Otherwise:
 
-   1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
-      without any changes made by previous invocations of these steps.
+   1. For [=/document=] currently loaded in a specified |navigable|:
 
-   1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
-      without any changes made by previous invocations of these steps.
+      1. When the [=select an image source from a source set=] steps are run, use the implementation's default behavior,
+         without any changes made by previous invocations of these steps.
+
+      1. For the purposes of the [=resolution media feature=], use the implementation's default behavior,
+         without any changes made by previous invocations of these steps.
 
    1. [=map/Remove=] |navigable| from [=device pixel ratio overrides=].
 
@@ -4705,22 +4709,23 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 <div algorithm="set viewport when a top-level traversable is created">
 
-After creating a document in a new [=navigable/top-level traversable=] |navigable| and
+After creating a document in a new [=navigable=] |navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
+
+TODO: Move it as a hook in the html spec instead.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
-   1. If the <code>viewport</code> field of [=viewport overrides map=][|user context|] is not null:
+   1. If |navigable| is a [=/top-level traversable=] and the <code>viewport</code> field of
+      [=viewport overrides map=][|user context|] is not null:
 
       1. [=Set viewport=] with |navigable| and [=viewport overrides map=][|user context|]["<code>viewport</code>"].
 
    1. If the <code>devicePixelRatio</code> field of [=viewport overrides map=][|user context|] is not null:
 
-      1. For the |navigable| and all [=descendant navigables=]:
-
-         1. [=Set device pixel ratio override=] with |navigable| and [=viewport overrides map=][|user context|]["<code>devicePixelRatio</code>""].
+      1. [=Set device pixel ratio override=] with |navigable| and [=viewport overrides map=][|user context|]["<code>devicePixelRatio</code>""].
 
 </div>
 
@@ -4767,12 +4772,12 @@ The [=remote end steps=] with |command parameters| are:
 
       1. [=map/Set=] [=viewport overrides map=][|user context|] to a struct.
 
-      1. If |command parameters| [=map/contains=] the <code>viewport</code> field:
+      1. If |command parameters| [=map/contains=] "<code>viewport</code>":
 
          1. Set [=viewport overrides map=][|user context|]["<code>viewport</code>"]
             to |command parameters|["<code>viewport</code>"].
 
-      1. If |command parameters| [=map/contains=] the <code>devicePixelRatio</code> field:
+      1. If |command parameters| [=map/contains=] "<code>devicePixelRatio</code>":
 
          1. Set [=viewport overrides map=][|user context|]["<code>devicePixelRatio</code>"]
             to |command parameters|["<code>devicePixelRatio</code>"].


### PR DESCRIPTION
A proposal to add "userContexts" argument to "browsingContext.setViewport" command.

Closes #851


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/876.html" title="Last updated on Mar 4, 2025, 11:15 AM UTC (2fd7fdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/876/198ddae...lutien:2fd7fdd.html" title="Last updated on Mar 4, 2025, 11:15 AM UTC (2fd7fdd)">Diff</a>