### PR TITLE
Add commands to collect and retrieve response bodies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5965,9 +5965,10 @@ A [=remote end=] has a <dfn>max total data size</dfn> which is an integer repres
 the size allocated to collect network data in [=collected network data=]. Its
 value is implementation-defined.
 
-Note: This allows implementations to set sensible technical limitations, without preventing
-to collect data that is fully decoded and handled by the
-handled by the browser, such as images and fonts used on a webpage.
+Note: This allows implementations to set resource usage limits.
+It is expected that the limits are sufficiently large that users can depend on
+collecting data that is fully decoded and handled by the browser,
+such as images and fonts used on a webpage.
 
 <div algorithm>
 To <dfn>get navigable for request</dfn> given request:

--- a/index.bs
+++ b/index.bs
@@ -6012,10 +6012,6 @@ To <dfn export>clone network response body</dfn> given |sessions|, |request| and
 
 Note: This hook is intended to be triggered by the fetch spec when the response is set.
 
-Note: Should check for collectors matching navigable + response here already?
-Otherwise we can do it only in [=maybe collect network response body=] so that
-clients can add the collector as late as possible?
-
 1. For each |session| in |sessions|:
 
    1. If |session|'s [=network collectors=] is not [=list/empty=]:
@@ -6065,13 +6061,13 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
 
 1. If |response|'s [=response/status=] is a [=redirect status=], return.
 
-   Note: For redirects, only the final response body has to be stored.
+   Note: For redirects, only the final response body is stored.
 
 1. Let |navigable| be [=get navigable for request=] with |request|.
 
 1. If |navigable| is null, return.
 
-   NOTE: This prevents from collecting data not related to a navigable.
+   ISSUE: This prevents collecting data not related to a navigable.
    We still need to retrieve the navigable to check against the collector
    configuration but we could still accept null here.
 
@@ -6109,7 +6105,7 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
       1. Set |size| to |response|'s [=response body info=]'s [=encoded size=].
 
          Note: There is a discrepancy between the fact that the bytes retrieved from the
-         fetch stream correspond to the dedoded data, but the encoded (network) size is
+         fetch stream correspond to the decoded data, but the encoded (network) size is
          used in order to calculate size limits. Implementations might decide to use a storage
          model such that it uses less size than storing the decoded data, as long as the data
          returned to clients in getData is identical to the decoded data. The potential
@@ -6147,7 +6143,7 @@ To <dfn>allocate size to record data</dfn> given |size|:
 
 1. Let |already collected data| be an empty list.
 
-1. For each |collected data| in [=collected network data=] in order:
+1. For each |collected data| in [=collected network data=]:
 
    1. If |collected data|'s <code>bytes</code> is not null:
 
@@ -6157,7 +6153,7 @@ To <dfn>allocate size to record data</dfn> given |size|:
 
 1. If |size| is greater than |available size|:
 
-   1. For each |collected data| in |already collected data| in order:
+   1. For each |collected data| in |already collected data|:
 
       1. Increase |available size| by |collected data|'s <code>size</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -5947,7 +5947,7 @@ an [=struct/item=] named <code>size</code>, which is a js-uint or null,
 an [=struct/item=] named <code>type</code>, which is a <code>network.DataType</code>.
 
 A <dfn for="network">collector</dfn> is a [=/struct=] consisting of
-an [=struct/item=] named <code>data max size</code>, which is a js-uint,
+an [=struct/item=] named <code>max data encoded size</code>, which is a js-uint,
 an [=struct/item=] named <code>contexts</code>, which is a list of <code>browsingContext.BrowsingContext</code>,
 an [=struct/item=] named <code>data types</code>, which is a list of <code>network.DataType</code>,
 an [=struct/item=] named <code>collector</code>, which is a <code>network.Collector</code>,
@@ -7571,8 +7571,8 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
       )
 
       network.AddDataCollectorParameters = {
-        dataMaxSize: js-uint,
         dataTypes: [+network.DataType],
+        maxDataEncodedSize: js-uint,
         ? collectorType: network.CollectorType .default "blob",
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
@@ -7597,11 +7597,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |input context ids| be [=set/create|create a set=] with
    |command parameters|[<code>contexts</code>].
 
-1. Let |data max size| be |command parameters|
-   ["<code>dataMaxSize</code>"].
-
 1. Let |data types| be [=set/create|create a set=] with
    |command parameters|["<code>dataTypes</code>"].
+
+1. Let |max data encoded size| be |command parameters|
+   ["<code>maxDataEncodedSize</code>"].
 
 1. Let |collector type| be |command parameters|
    ["<code>collectorType</code>"].
@@ -7612,7 +7612,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |data max size| is greater than [=max total data size=],
+1. If |max data encoded size| is greater than [=max total data size=],
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |input context ids| is not [=set/empty=]:
@@ -7634,7 +7634,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
        1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |collector| be a struct with
-   <code>data max size</code> field set to |data max size|,
+   <code>max data encoded size</code> field set to |max data encoded size|,
    <code>data types</code> field set to |data types|,
    <code>collector</code> field set to |collector id|,
    <code>collector type</code> field set to |collector type|,

--- a/index.bs
+++ b/index.bs
@@ -5947,7 +5947,7 @@ an [=struct/item=] named <code>size</code>, which is a js-uint or null,
 an [=struct/item=] named <code>type</code>, which is a <code>network.DataType</code>.
 
 A <dfn for="network">collector</dfn> is a [=/struct=] consisting of
-an [=struct/item=] named <code>max data encoded size</code>, which is a js-uint,
+an [=struct/item=] named <code>max encoded data size</code>, which is a js-uint,
 an [=struct/item=] named <code>contexts</code>, which is a list of <code>browsingContext.BrowsingContext</code>,
 an [=struct/item=] named <code>data types</code>, which is a list of <code>network.DataType</code>,
 an [=struct/item=] named <code>collector</code>, which is a <code>network.Collector</code>,
@@ -6123,7 +6123,7 @@ and [=clone network response body=] does not clone the corresponding body.
 
    1. For |collector| in |collectors|:
 
-      1. If |size| is less than or equal to |collector|'s <code>max data size</code>,
+      1. If |size| is less than or equal to |collector|'s <code>max encoded data size</code>,
          [=list/Append=] |collector|'s <code>collector</code> to |collected data|'s <code>collectors</code>.
 
    1. If |collected data|'s <code>collectors</code> is not [=list/empty=]:
@@ -7572,7 +7572,7 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
 
       network.AddDataCollectorParameters = {
         dataTypes: [+network.DataType],
-        maxDataEncodedSize: js-uint,
+        maxEncodedDataSize: js-uint,
         ? collectorType: network.CollectorType .default "blob",
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
@@ -7600,8 +7600,13 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |data types| be [=set/create|create a set=] with
    |command parameters|["<code>dataTypes</code>"].
 
-1. Let |max data encoded size| be |command parameters|
-   ["<code>maxDataEncodedSize</code>"].
+1. Let |max encoded data size| be |command parameters|
+   ["<code>maxEncodedDataSize</code>"].
+
+   Note: Different implementations might support different encodings, which means the
+   encoded size might be different between browsers. Therefore, for the same data collector
+   configuration, some network data might fit the maxEncodedDataSize only in some
+   implementations.
 
 1. Let |collector type| be |command parameters|
    ["<code>collectorType</code>"].
@@ -7612,7 +7617,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |max data encoded size| is greater than [=max total data size=],
+1. If |max encoded data size| is greater than [=max total data size=],
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |input context ids| is not [=set/empty=]:
@@ -7634,7 +7639,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
        1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |collector| be a struct with
-   <code>max data encoded size</code> field set to |max data encoded size|,
+   <code>max encoded data size</code> field set to |max encoded data size|,
    <code>data types</code> field set to |data types|,
    <code>collector</code> field set to |collector id|,
    <code>collector type</code> field set to |collector type|,

--- a/index.bs
+++ b/index.bs
@@ -7554,7 +7554,7 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
       network.AddDataCollectorParameters = {
         dataMaxSize: js-uint,
         dataTypes: [+network.DataType],
-        collectorType: network.collectorType,
+        ? collectorType: network.collectorType .default "blob",
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }

--- a/index.bs
+++ b/index.bs
@@ -221,6 +221,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: navigable; for:window; url: nav-history-apis.html#window-navigable
     text: navigables; url: document-sequences.html#navigables
     text: navigation id; url: browsing-the-web.html#navigation-id
+    text: ongoing-navigation; url: browsing-the-web.html#ongoing-navigation
     text: origin-clean; url: canvas.html#concept-canvas-origin-clean
     text: parent; for:navigable; url: document-sequences.html#nav-parent
     text: prompt to unload; url: browsing-the-web.html#prompt-to-unload-a-document
@@ -635,6 +636,9 @@ with the following additional codes:
   <dt><dfn for=errors export>no such history entry</dfn>
   <dd>Tried to havigate to an unknown [=session history entry=].
 
+  <dt><dfn for=errors export>no such collector</dfn>
+  <dd>Tried to remove an unknown [=network data collector=].
+
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
 
@@ -681,6 +685,7 @@ ErrorCode = "invalid argument" /
             "no such frame" /
             "no such handle" /
             "no such history entry" /
+            "no such collector" /
             "no such intercept" /
             "no such node" /
             "no such request" /
@@ -5096,6 +5101,11 @@ the <dfn export>WebDriver BiDi navigable created</dfn> steps given
    then perform implementation-defined steps to disable any implementation-specific
    resource caches for network requests originating from |navigable|.
 
+1. If |navigable| is a [=/top-level traversable=]:
+
+  1. For each |session| in [=active BiDi sessions=]
+     [=update navigable network collector sizes=] with |session| and |navigable|.
+
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
@@ -5877,6 +5887,7 @@ relating to network requests.
 <pre class="cddl" data-cddl-module="remote-cddl">
 
 NetworkCommand = (
+  network.AddDataCollector //
   network.AddIntercept //
   network.ContinueRequest //
   network.ContinueResponse //
@@ -5884,8 +5895,8 @@ NetworkCommand = (
   network.FailRequest //
   network.GetResponseBody //
   network.ProvideResponse //
+  network.RemoveDataCollector //
   network.RemoveIntercept //
-  network.SetBodyCollectorConfiguration //
   network.SetCacheBehavior
 )
 
@@ -5908,6 +5919,10 @@ NetworkEvent = (
 )
 
 </pre>
+
+A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
+empty map.  It's used to track the network events for which a
+<code>network.beforeRequestSent</code> event has already been sent.
 
 A [=remote end=] has a <dfn>default cache behavior</dfn> which is a string. It is
 initially "<code>default</code>".
@@ -6080,71 +6095,80 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 
 </div>
 
-### Network Responses ### {#network-responses}
+### Network Data ### {#network-data}
 
-A <dfn>network body collector configuration</dfn> is a struct which defines how
-a navigable should collect the content of network request and response bodies.
+A <dfn>network data collector</dfn> is a mechanism to allow remote ends to collect
+network data such as network response bodies.
 
-A [=BiDi session=] has <dfn>navigable network collector configurations</dfn> which is a weak map between [=navigables=] and [=network body collector configuration=]. It is initially empty.
+A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
+network data collector id and <code>network.CollectorInfo</code>. It is initially empty.
 
-A [=BiDi session=] has <dfn>user context network collector configurations</dfn>
-which is a weak map between [=user contexts=] and [=network body collector configuration=].
+A [=BiDi session=] has <dfn>navigable network collector sizes</dfn> which is a weak map
+between [=/top-level traversables=] and <code>network.CollectorSizes</code>. It describes
+the effective collector sizes for all [=/navigables=] under a [=/top-level traversable=].
 It is initially empty.
 
-A [=BiDi session=] has a <dfn>global network collector configuration</dfn> which is a [=network body collector configuration=]. It is initially null.
-
-A [=BiDi session=] has <dfn>collected responses</dfn> which is a list of
-[=struct=] with fields <code>navigable id</code>, <code>navigation</code>,
-<code>request id</code> and <code>response</code> that contains the collected
-network responses for the current session. It is initially empty.
+A [=BiDi session=] has <dfn>collected network data</dfn> which is a list of
+<code>network.CollectorData</code>. It is initially empty.
 
 <div algorithm>
-To <dfn>get network body collector configuration</dfn> given |session| and
-|navigable|:
+To <dfn>match collector info</dfn> given |collector info| and |navigable|:
 
-1. Let |top-level navigable| be [=/top-level traversable=] for |navigable|.
+1. If the <code>contexts</code> field of |collector info| is present:
 
-1. If |session|'s [=navigable network collector configurations=]
-   [=map/contains=] |top-level navigable|:
+  1. If |collector info|["contexts"] [=map/contains=] |navigable|'s [=navigable id=], return true.
 
-   1. Return |session|'s [=navigable network collector configurations=][|top-level navigable|].
+  1. Otherwise, return false.
 
-1. Let |user context| be |navigable|'s [=associated user context=].
+1. If the <code>userContexts</code> field of |collector info| is present:
 
-1. If |session|'s [=user context network collector configurations=]
-   [=map/contains=] |user context|:
+  1. Let |user context| be |navigable|'s [=associated user context=].
 
-   1. Return |session|'s [=user context network collector configurations=][|user context|].
+  1. If |collector info|["userContexts"] [=map/contains=] |user context|'s [=user context id=], return true.
 
-1. Return |session|'s [=global network collector configuration=].
+  1. Otherwise, return false.
+
+1. Return true.
 
 </div>
 
 <div algorithm>
-To <dfn>get available collector size</dfn> given |session|, |navigable| and |max total body size|:
+To <dfn>update navigable network collector sizes</dfn> given |session| and |top-level navigable|:
 
-1. Let |available size| be |max total body size|.
+1. Let |match| be false.
 
-1. Let |collected responses| be |session|'s [=collected responses=].
+1. Let |resource max size| be 0.
 
-1. For each |collected response| of |collected responses|:
+1. Let |total max size| be 0.
 
-  1. If the <code>response</code> field of |collected response| is null,
-     continue.
+1. For each |collector info| of |session|'s [=network collectors=]:
 
-  1. If the <code>navigable</code> field of |collected response| is not
-     |navigable|, continue.
+  1. If [=match collector info=] with |top-level navigable| and |collector info|:
 
-  1. Let |response| be the <code>response</code> field of |collected response|.
+    1. Set |match| to true.
 
-  1. Remove |response|'s [=response body info=]'s [=decoded size=] from |available size|.
+    1. If |collector info|["<code>resourceMaxSize</code>"] is greater than |resource max size|
+       set |resource max size| to |collector info|["<code>resourceMaxSize</code>"].
 
-1. Return |available size|.
+    1. If |collector info|["<code>totalMaxSize</code>"] is greater than |total max size|
+       set |total max size| to |collector info|["<code>totalMaxSize</code>"].
+
+1. If |match| is true:
+
+  1. Let |sizes| be a new [=/map=] matching the <code>network.CollectorSizes</code> production,
+     with the <code>resourceMaxSize</code> field set to |resource max size|
+     and the <code>totalMaxSize</code> field set to |total max size|.
+
+  1. [=map/Set=] |session|'s [=navigable network collector sizes=][|top-level navigable|] to |sizes|.
+
+1. Otherwise:
+
+  1. [=map/Remove=] |session|'s [=navigable network collector sizes=][|top-level navigable|]
 
 </div>
 
 <div algorithm>
-To <dfn>maybe collect the response body</dfn> given |session|, |request| and |response|:
+To <dfn>maybe collect network data</dfn> given |session|, |request| and |response|:
 
 1. Let |navigable| be null.
 
@@ -6158,73 +6182,95 @@ To <dfn>maybe collect the response body</dfn> given |session|, |request| and |re
 
 1. If |navigable| is null, return.
 
-1. Let |collected responses| be |session|'s [=collected responses=].
+1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
 
-1. Let |network body collector configuration| be the result of [=get network body collector configuration=] with |session| and |navigable|.
+1. If |session|'s [=navigable network collector sizes=] does not [=list/contains|contain=]
+   |top-level navigable| return.
 
-1. If |network body collector configuration| is not null:
+1. Let |response to collect| be null.
 
-  1. Let |max total body size| be |network body collector configuration|'s
-     <code>max total body size</code>.
+1. Let |response size| be |response|'s [=response/body=]'s [=body/length=].
 
-  1. Let |max resource body size| be |network body collector configuration|'s
-     <code>max resource body size</code>.
+1. Let |sizes| be |session|'s [=navigable network collector sizes=][|top-level navigable|].
 
-  1. Let |response size| be |response|'s [=response body info=]'s
-     [=decoded size=].
+1. If |response|’s [=response/body=] is not null and
+   if |sizes|' <code>maxResourceSize</code> is greater than |response size|:
 
-  1. Let |response to collect| be null.
+  1. [=Allocate size to record data=] with |session|, |navigable|, |response size| and
+     |sizes|' <code>maxTotalSize</code>.
 
-  1. Let |request id| be request's [=request id=].
+  1. Let |processBody| given |nullOrBytes| be this step:
 
-  1. If |response size| is less than or equal to |max resource body size|:
+    1. If |nullOrBytes| is not null, set |response to collect| to [=serialize protocol bytes=] with |nullOrBytes|.
 
-    1. Set |response to collect| to |response|.
+  1. Let |processBodyError| be this step: Do nothing.
 
-    1. If |response size| is greater than [=get available collector size=] with
-       |session|, |navigable| and |max total body size|:
+  1. [=Fully read=] |response|’s [=response/body=] given |processBody| and |processBodyError|.
 
-      1. For each |collected response| of |collected responses|:
+1. Let |collector data| be a new [=/map=] matching the
+         <code>network.CollectorData</code> production, with the
+         <code>data</code> field set to |response to collect|,
+         <code>navigable</code> field set to |navigable|'s [=navigable id=],
+         <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
+         <code>request</code> field set to |request|'s [=request id=] and
+         <code>size</code> field set to |response size|.
 
-        1. If the <code>response</code> field of |collected response| is null,
-           continue.
-
-        1. If the <code>navigable</code> field of |collected response| is not
-           |navigable|, continue.
-
-        1. Set the <code>response</code> field of |collected response| to null.
-
-        1. If [=get available collector size=] with |session|, |navigable| and
-           |max total body size| is greater than |response size|, break.
-
-  1. [=list/Add=] a struct with <code>navigation</code> |navigable|'s
-     [=ongoing navigation=], <code>navigable id</code> |navigable|'s
-     [=navigable id=], <code>request id</code> |request id|,
-     <code>response</code> |response to collect| to |collected responses|.
+1. [=list/Append=] |collector data| to |session|'s [=collected network data=].
 
 </div>
 
+<div algorithm>
+To <dfn>allocate size to record data</dfn> given |session|, |navigable|,
+|requested size| and |max total size|:
+
+1. Let |available size| be |max total size|.
+
+1. For each |collected data| in |session|'s [=collected network data=]:
+
+  1. Let |navigable id| be |collected data|'s <code>navigable</code>
+     field.
+
+  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
+
+  1. If |collected data|'s <code>data</code> is not null:
+
+    1. Decrease |available size| by |collected data|'s <code>size</code>.
+
+1. If |requested size| is greater than |available size|:
+
+  1. For each |collected data| in |session|'s [=collected network data=] in order:
+
+    1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
+
+    1. If |collected data|'s <code>data</code> is not null:
+
+      1. Increase |available size| by |collected data|'s <code>size</code>.
+
+      1. Set |collected data|'s <code>data</code> field to null.
+
+      1. If |available size| is greater than or equal to |requested size|, return.
+
+</div>
 
 <div algorithm>
 To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
-|navigation|:
+|current navigation|:
 
-1. For each |collected response| in |session|'s [=collected responses=]:
+1. For each |collected data| in |session|'s [=collected network data=]:
 
-  1. Let |response navigation| be collected response|'s <code>navigation</code>
+  1. Let |navigation| be |collected data|'s <code>navigation</code>
      field.
 
-  1. Let |response navigable id| be collected response|'s <code>navigable id</code>
+  1. Let |navigable id| be |collected data|'s <code>navigable</code>
      field.
 
-  1. If |response navigable id| is not |navigable|'s [=navigable id=], continue.
+  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
 
-  1. If |navigation| is not null, |response navigation| is |navigation|, continue.
+  1. If |current navigation| is not null and |current navigation| is |navigation|, continue.
 
-  1. Set |collected response|'s <code>response</code> field to null.
+  1. Set |collected data|'s <code>data</code> field to null.
 
 </div>
-
 
 ### Types ### {#module-network-types}
 
@@ -6411,6 +6457,60 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
    with |value| set to |text|.
 
 </div>
+
+#### The network.Collector Type #### {#type-network-Collector}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+network.Collector = text
+</pre>
+
+The <code>network.Collector</code> type represents the id of a [=network data collector=].
+
+#### The network.CollectorData Type #### {#type-network-CollectorData}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+network.CollectorData = {
+    data: network.BytesValue / null,
+    navigable: browsingContext.BrowsingContext,
+    navigation: browsingContext.Navigation,
+    request: network.Request,
+    size: js-uint,
+};
+</pre>
+
+The <code>network.CollectorData</code> type represents network data stored via a
+[=network data collector=].
+
+#### The network.CollectorInfo Type #### {#type-network-CollectorInfo}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+network.CollectorInfo = {
+    network.CollectorSizes,
+    ? contexts: [+browsingContext.BrowsingContext],
+    ? userContexts: [+browser.UserContext],
+};
+</pre>
+
+The <code>network.CollectorInfo</code> type represents a [=network data collector=].
+
+#### The network.CollectorSizes Type #### {#type-network-CollectorSizes}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+network.CollectorSizes = {
+    resourceMaxSize: js-uint,
+    totalMaxSize: js-uint,
+};
+</pre>
+
+The <code>network.CollectorSizes</code> type represents the sizes used by a [=network data collector=].
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
@@ -7401,6 +7501,106 @@ To <dfn>match URL pattern</dfn> given |url pattern| and |url string|:
 
 ### Commands ### {#module-network-commands}
 
+#### The network.addDataCollector Command ####  {#command-network-addDataCollector}
+
+The <dfn export for=commands>network.addDataCollector</dfn> command configures
+the data collector map.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.AddDataCollector = (
+        method: "network.addDataCollector",
+        params: network.AddDataCollectorParameters
+      )
+
+      network.AddDataCollectorParameters = {
+        ? contexts: [+browsingContext.BrowsingContext],
+        resourceMaxSize: js-uint,
+        totalMaxSize: js-uint,
+        ? userContexts: [+browser.UserContext],
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.addDataCollector">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |collector| be the string representation of a [[!RFC9562|UUID]].
+
+1. Let |input context ids| be [=set/create|create a set=] with
+   |command parameters|[<code>contexts</code>].
+
+1. Let |resource max size| be |command parameters|
+   ["<code>resourceMaxSize</code>"].
+
+1. Let |total max size| be |command parameters|
+   ["<code>totalMaxSize</code>"].
+
+1. Let |input user context ids| be [=set/create|create a set=] with
+   |command parameters|[<code>userContexts</code>].
+
+1. If |input user context ids| is not empty and |input context ids| is not
+   empty, return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |top-level traversable ids| be a [=/set=].
+
+1. Let |top-level traversables to update| be an empty [=/set=].
+
+1. If |input context ids| is not empty:
+
+   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
+
+   1. For each |navigable| in |navigables|:
+
+      1. If |navigable| is not a [=/top-level traversable=], return [=error=]
+         with [=error code=] [=invalid argument=].
+
+      1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable ids|.
+
+      1. [=set/Append=] |navigable| to |top-level traversables to update|.
+
+1. Otherwise, if |input user context ids| is not empty:
+
+    1. [=list/For each=] |user context id| of |input user context ids|:
+
+       1. Let |user context| be [=get user context=] with |user context id|.
+
+       1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
+
+       1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+          whose [=associated user context=] is |user context|:
+
+          1. [=set/Append=] |top-level traversable| to |top-level traversables to update|.
+
+1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
+
+1. Let |collector data| be a new [=/map=] matching the
+   <code>network.CollectorData</code> production with
+   the <code>resourceMaxSize</code> field set to |resource max size|,
+   the <code>totalMaxSize</code> field set to |total max size|,
+   the <code>userContexts</code> field set to |input user context ids| and
+   the <code>contexts</code> field set to |top-level traversable ids|.
+
+1. Set |session|'s [=network collectors=][|collector|] to |collector data|.
+
+1. For each |traversable| in |top-level traversables to update|, [=update navigable network collector sizes=]
+   with |session| and |traversable|.
+
+1. Return a new [=/map=] matching the
+   <code>network.AddDataCollectorResult</code> production with the
+   <code>collector</code> field set to |collector|.
+
+</div>
+
 #### The network.addIntercept Command ####  {#command-network-addIntercept}
 
 The <dfn export for=commands>network.addIntercept</dfn> command adds a
@@ -7821,7 +8021,7 @@ response body data if it is available.
    <dd>
     <pre class="cddl local-cddl">
       script.GetResponseBodyResult = {
-        body: network.BytesValue,
+        data: network.BytesValue,
       }
     </pre>
    </dd>
@@ -7832,14 +8032,14 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
-1. Let |collected responses| be |session|'s [=collected responses=].
+1. Let |collected network data| be |session|'s [=collected network data=].
 
 1. Let |match| be null.
 
-1. For each |collected response| of |collected responses|:
+1. For each |collected data| of |collected network data|:
 
-  1. If the <code>request id</code> field of |collected response| is |request id|,
-     set |match| to |collected response|, break.
+  1. If the <code>request</code> field of |collected data| is |request id|,
+     set |match| to |collected data|, break.
 
 1. If |match| is null:
 
@@ -7851,13 +8051,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
   1. Return [=error=] with [=error code=] [=no response body=].
 
-Issue: what do we do with bodies that are too large? The limit is often
-determined on the transport level and the implementation might not know
-it.
-
 1. Let |body| be a [=/map=] matching the <code>script.GetResponseBodyResult</code> production,
-   with the <code>body</code> field set to base-64 encoded value of |response|'s [=response/body=].
-   TODO: specify exact steps how to read the body.
+   with the <code>data</code> field set to the <code>data</code> field of |collected data|.
 
 1. Return [=success=] with data |body|.
 
@@ -7922,6 +8117,81 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+#### The network.removeDataCollector Command ####  {#command-network-removeDataCollector}
+
+The <dfn export for=commands>network.removeDataCollector</dfn> command removes a
+[=network data collector=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.RemoveDataCollector = (
+        method: "network.removeDataCollector",
+        params: network.RemoveDataCollectorParameters
+      )
+
+      network.RemoveDataCollectorParameters = {
+        collector: network.Collector
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.removeDataCollector">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |collector| be the value of the "<code>collector</code>" field in |command
+   parameters|.
+
+1. Let |collectors| be |session|'s [=network collectors=].
+
+1. If |collectors| does not [=map/contain=] |collector|, return
+   [=error=] with [=error code=] [=no such collector=].
+
+1. Let |collector data| be |collectors|[|collector|].
+
+1. Let |top-level traversables to update| be an empty [=/set=].
+
+1. If |collector data|'s <code>contexts</code> field is present:
+
+  1. For each |navigable id| of |collector data|'s <code>contexts</code> field:
+
+    1. Let |navigable| be the [=/navigable=] with id |navigable id|
+       if such [=/navigable=] exists, and null otherwise.
+
+    1. [=set/Append=] |navigable| to |top-level traversables to update| if |navigable| is not null.
+
+1. Otherwise if |collector data|'s <code>userContexts</code> field is present:
+
+  1. For each |user context id| of |collector data|'s <code>userContexts</code> field:
+
+    1. Let |user context| be [=get user context=] with |user context id|.
+
+    1. If |user context| is null, continue.
+
+    1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+       whose [=associated user context=] is |user context|:
+
+      1. [=set/Append=] |top-level traversable| to |top-level traversables to update|.
+
+1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
+
+1. [=map/Remove=] |collector| from |session|'s [=network collectors=].
+
+1. For each |traversable| in |top-level traversables to update|, [=update navigable network collector sizes=]
+   with |session| and |traversable|.
+
+1. Return [=success=] with data [=null=].
+
+</div>
+
 #### The network.removeIntercept Command ####  {#command-network-removeIntercept}
 
 The <dfn export for=commands>network.removeIntercept</dfn> command removes a
@@ -7967,112 +8237,6 @@ blocked by this intercept. Only future requests or future phases of existing
 requests will be affected.
 
 1. Return [=success=] with data [=null=].
-
-</div>
-
-#### The network.setBodyCollectorConfiguration Command ####  {#command-network-setBodyCollectorConfiguration}
-
-The <dfn export for=commands>network.setBodyCollectorConfiguration</dfn> command configures
-the network body collectors.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl remote-cddl">
-      network.SetBodyCollectorConfiguration = (
-        method: "network.setBodyCollectorConfiguration",
-        params: network.SetBodyCollectorConfigurationParameters
-      )
-
-      network.SetBodyCollectorConfigurationParameters = {
-        ? contexts: [+browsingContext.BrowsingContext],
-        maxTotalBodySize: js-uint,
-        ?maxResourceBodySize: js-uint,
-        ? userContexts: [+browser.UserContext],
-      }
-    </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <code>
-      EmptyResult
-    </code>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for network.setBodyCollectorConfiguration">
-The [=remote end steps=] given |session| and |command parameters| are:
-
-1. Let |input context ids| be [=set/create|create a set=] with
-   |command parameters|[<code>contexts</code>].
-
-1. Let |max total body size| be |command parameters|
-   ["<code>maxTotalBodySize</code>"].
-
-1. Let |max resource body size| be |command parameters|
-   ["<code>maxResourceBodySize</code>"].
-
-1. Let |input user context ids| be [=set/create|create a set=] with
-   |command parameters|[<code>userContexts</code>].
-
-1. If |input user context ids| is not empty and |input context ids| is not
-   empty, return [=error=] with [=error code=] [=invalid argument=].
-
-1. If |input user context ids| is not empty and |input context ids| is not
-   empty, return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |body collector configuration| be a struct with <code>max total body size</code>
-   |max total body size| and <code>max resource body size</code> |max resource body size|.
-
-1. If |input context ids| is not empty:
-
-   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
-
-   1. If [=list/size=] of |navigables| does not equal [=list/size=] of
-      |input context ids|:
-
-      1. Return [=error=] with [=error code=] [=invalid argument=].
-
-   1. Set |collector navigables| to [=get top-level traversables=] with
-      |navigables|.
-
-   1. For each |navigable| in |collector navigables|:
-
-     1. Let |navigable configurations| be |session|'s
-        [=navigable network collector configurations=].
-
-     1. [=map/Set=] |navigable configurations|[|navigable|] to |body collector configuration|.
-
-1. Otherwise, if |input user context ids| is not empty:
-
-    1. [=list/For each=] |user context id| of |input user context ids|:
-
-       1. Let |user context| be [=get user context=] with |user context id|.
-
-       1. If |user context| is null, return [=error=] with [=error code=]
-          [=invalid argument=].
-
-       1. For each |traversable| in remote end's [=/top-level traversables=]:
-
-          1. If |traversable|'s [=associated user context=] is |user context|,
-             [=map/Remove=] |session|'s [=navigable network collector configurations=][|traversable|].
-
-       1. Let |user context configurations| be |session|'s
-          [=user context network collector configurations=].
-
-       1. [=map/Set=] |user context configurations|[|user context|] to |body collector configuration|.
-
-1. Otherwise:
-
-   1. Set |session|'s [=user context network collector configurations=] to an
-      empty [=/map=].
-
-   1. Set |session|'s [=navigable network collector configurations=] to an empty
-      [=/map=].
-
-   1. Set |session|'s [=global network collector configuration=] to |body collector configuration|.
-
-1. Return [=success=] with data null.
 
 </div>
 
@@ -8527,8 +8691,6 @@ completed</dfn> steps given |request| and |response|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
-1. [=Maybe collect the response body=] |session|, |request| and |response|.
-
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>network.responseCompleted</code>" and |related navigables|:
 
@@ -8543,6 +8705,8 @@ completed</dfn> steps given |request| and |response|:
 
   1. Assert: |params| matches the <code>network.ResponseCompletedParameters</code>
      production.
+
+  1. [=Maybe collect network data=] with |session|, |request| and |response|.
 
   1. Let |body| be a map matching the <code>network.ResponseCompleted</code>
      production, with the <code>params</code> field set to |params|.

--- a/index.bs
+++ b/index.bs
@@ -635,6 +635,9 @@ with the following additional codes:
   <dt><dfn for=errors export>no such history entry</dfn>
   <dd>Tried to havigate to an unknown [=session history entry=].
 
+  <dt><dfn for=errors export>no such collector</dfn>
+  <dd>Tried to remove an unknown [=network body collector=].
+
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
 
@@ -681,6 +684,7 @@ ErrorCode = "invalid argument" /
             "no such frame" /
             "no such handle" /
             "no such history entry" /
+            "no such collector" /
             "no such intercept" /
             "no such node" /
             "no such request" /
@@ -5146,6 +5150,9 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
 1. Let |related navigables| be a [=/set=] containing |navigable|'s [=navigable/parent=],
    if that is not null, or an empty [=/set=] otherwise.
 
+1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
+   with |session| and |navigable|.
+
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related navigables|:
 
@@ -5568,6 +5575,9 @@ given |navigable| and |navigation status|:
 
 1. [=Resume=] with "<code>navigation committed</code>", |navigation id|, and |navigation status|.
 
+1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
+   with |session| and |navigable|.
+
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.navigationCommitted</code>" and |related navigables|:
 
@@ -5872,6 +5882,7 @@ relating to network requests.
 
 NetworkCommand = (
   network.AddIntercept //
+  network.AddBodyCollector //
   network.ContinueRequest //
   network.ContinueResponse //
   network.ContinueWithAuth //
@@ -5879,6 +5890,8 @@ NetworkCommand = (
   network.GetResponseBody //
   network.ProvideResponse //
   network.RemoveIntercept //
+  network.RemoveBodyCollector //
+  network.SetBodyCollectorConfiguration //
   network.SetCacheBehavior
 )
 
@@ -5902,27 +5915,6 @@ NetworkEvent = (
 
 </pre>
 
-A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
-empty map.  It's used to track the network events for which a
-<code>network.beforeRequestSent</code> event has already been sent.
-
-A [=remote end=] has a <dfn>response map</dfn> that maps a [=request id=]
-to [=/response=]. Responses must be removed on the following conditions:
-
-- when a browsing context group switch or destruction happens, responses
-  associated with the previous browsing context group are removed.
-
-- when a navigation commits a new document, resources associated with the
-  previous document are removed.
-
-- when a worker scope is removed the responses provided by the worker are
-  removed.
-
-- when a user-configured (command to be defined) per navigable size limit is
-  exceeded, the oldest response body is evicted until there is space for
-  the new body. Evicted resources should result in a distinct error
-  code.
-
 A [=remote end=] has a <dfn>default cache behavior</dfn> which is a string. It is
 initially "<code>default</code>".
 
@@ -5937,7 +5929,7 @@ and modify network requests and responses.
 
 A [=BiDi session=] has an <dfn>intercept map</dfn> which is a [=/map=] between
 intercept id and a [=struct=] with fields <code>url patterns</code>,
-<code>phases</code>, and <code>browsingContexts</code> that define the properties
+<code>phases</code>, and <code>contexts</code> that define the properties
 of active network intercepts. It is initially empty.
 
 A [=BiDi session=] has a <dfn>blocked request map</dfn>, used to track the
@@ -6093,6 +6085,133 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 1. Return |response|
 
 </div>
+
+### Network Responses ### {#network-responses}
+
+A <dfn>network body collector</dfn> is a mechanism to allow remote ends to collect
+the content of network request and response bodies.
+
+A [=BiDi session=] has a <dfn>network body collector map</dfn> which is a [=/map=] between
+network body collector id and a [=struct=] with fields <code>url patterns</code>,
+<code>contexts</code> and <code>user contexts</code> that define the properties
+of active network body collectors. It is initially empty.
+
+A [=BiDi session=] has a <dfn>response map</dfn> which is a [=/map=] between
+request id and a [=struct=] with fields <code>context</code> and <code>response</code>
+that define the collected network response bodies for the current session. It is initially empty.
+
+A [=BiDi session=] has a <dfn>network maximum body size</dfn> which is a number defining
+the maximum size (in bytes) that should be collected for a single network body. It is
+initially null.
+
+
+<div algorithm>
+To <dfn>match body collector</dfn> given |request|, |navigable| and |collector|:
+
+1. Let |url patterns| be |collector|'s url patterns.
+
+1. Let |contexts| be |collector|'s contexts.
+
+1. Let |user contexts| be |collector|'s user contexts.
+
+1. Let |url| be the result of running the [=URL serializer=] with |request|'s
+   [=request/URL=].
+
+1. If |url patterns| is not [=list/empty=]:
+
+  1. Let |match| be false.
+
+  1. For each |url pattern| in |url patterns|:
+
+    1. If [=match URL pattern=] with |url pattern| and |url|:
+
+      1. Set |match| to true.
+
+      1. Break.
+
+  1. If |match| is false, return false.
+
+1. If |contexts| is not [=list/empty=]:
+
+  1. Let |top-level navigable id| be [=/top-level traversable=]'s [=navigable id=] for |navigable|.
+
+  1. If |contexts| does not [=set/contains|contain=] |top-level navigable id|, return false.
+
+1. If |user contexts| is not [=list/empty=]:
+
+  1. Let |match| be false.
+
+  1. For each |user context id| in |user contexts|:
+
+    1. Set |user context| to [=get user context=] with |user context id|.
+
+    1. If |navigable|'s [=associated user context=] is |user context|:
+
+      1. Set |match| to true.
+
+      1. Break.
+
+  1. If |match| is false, return false.
+
+1. Return true.
+
+</div>
+
+
+<div algorithm>
+To <dfn>maybe collect the response body</dfn> given |session|, |request| and |response|:
+
+1. Let |navigable| be null.
+
+1. If |request|'s [=request/window=] is an [=environment settings object=]:
+
+  1. Let |environment settings| be |request|'s [=request/window=]
+
+  1. If there is a [=/navigable=] whose [=active window=] is |environment
+     settings|' [=environment settings object/global object=], set |navigable|
+     to be that navigable.
+
+1. If |navigable| is null, return.
+
+1. For each |collector| in |session|'s [=network body collector map=]:
+
+  1. If the result of [=match body collector=] with |request|, |navigable| and |collector| is true:
+
+    1. Let |response map| be |session|'s [=response map=].
+
+    1. Let |request id| be request's [=request id=].
+
+    1. Let |navigable id| be the [=navigable id=] for |navigable|.
+
+    1. Let |response size| be |response|'s [=response body info=]'s [=decoded size=]
+
+    1. Let |response to collect| be null.
+
+    1. Let |maximum  size| be |session|'s [=network maximum body size=].
+
+    1. If |maximum  size| is not null and |response size|
+       is smaller than or equal to |maximum  size|:
+
+      1. Set |response to collect| to |response|.
+
+    1. Set |response map|[|request id|] to a struct with <code>response</code>
+       |response to collect| and <code>context</code> |navigable id|.
+
+    1. Break.
+
+</div>
+
+
+<div algorithm>
+To <dfn>delete collected response bodies</dfn> given |session| and |navigable|:
+
+1. For each |collected response| in |session|'s [=response map=]:
+
+  1. If |collected response|'s [=navigable=] is |navigabke id|, set
+     |collected response|'s <code>response</code> field to null.
+
+</div>
+
 
 ### Types ### {#module-network-types}
 
@@ -6279,6 +6398,16 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
    with |value| set to |text|.
 
 </div>
+
+#### The network.Collector Type #### {#type-network-Collector}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl local-cddl remote-cddl">
+network.Collector = text
+</pre>
+
+The <code>network.Collector</code> type represents the id of a [=network body collector=].
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
@@ -7352,6 +7481,116 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+#### The network.addBodyCollector Command ####  {#command-network-addBodyCollector}
+
+The <dfn export for=commands>network.addBodyCollector</dfn> command adds a
+[=network body collector=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      network.AddBodyCollector = (
+        method: "network.addBodyCollector",
+        params: network.AddBodyCollectorParameters
+      )
+
+      network.AddBodyCollectorParameters = {
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? urlPatterns: [*network.UrlPattern],
+        ? userContexts: [+browser.UserContext],
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      network.AddBodyCollectorResult = {
+        collector: network.Collector
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.addBodyCollector">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |collector| be the string representation of a [[!RFC9562|UUID]].
+
+1. Let |url patterns| be the <code>urlPatterns</code> field of |command
+   parameters| if present, or an empty [=/list=] otherwise.
+
+1. Let |input user context ids| be [=set/create|create a set=] with |command parameters|[<code>userContexts</code>].
+
+1. Let |input context ids| be [=set/create|create a set=] with |command parameters|[<code>contexts</code>].
+
+1. If |input user context ids| is not empty and |input context ids| is not empty,
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |top-level traversable context ids| be a [=/set=].
+
+1. If |input context ids| is not empty:
+
+   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
+
+   1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
+
+      1. Return [=error=] with [=error code=] [=invalid argument=].
+
+   1. Set |subscription navigables| be [=get top-level traversables=] with |navigables|.
+
+   1. For each |navigable| in |subscription navigables|:
+
+      1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable context ids|.
+
+1. Otherwise, if |input user context ids| is not empty:
+
+    1. [=list/For each=] |user context id| of |input user context ids|:
+
+       1. Let |user context| be [=get user context=] with |user context id|.
+
+       1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
+
+
+1. If the <code>contexts</code> field of |command parameters| is present:
+
+   1. Set |navigables| to an empty [=/set=].
+
+   1. For each |navigable id| of |command parameters|["<code>contexts</code>"]
+
+      1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
+         with |navigable id|.
+
+      1. If |navigable| is not a [=/top-level traversable=], return [=error=]
+         with [=error code=] [=invalid argument=].
+
+      1. Append |navigable| to |navigables|.
+
+   1. If |navigables| is an empty [=/set=], return [=error=] with [=error code=]
+      [=invalid argument=].
+
+1. Let |collector map| be |session|'s [=network body collector map=].
+
+1. Let |parsed patterns| be an empty [=/list=].
+
+1. For each |url pattern| in |url patterns|:
+
+  1. Let |parsed| be the result of [=trying=] to [=parse url pattern=] with |url
+     pattern|.
+
+  1. [=list/Append=] |parsed| to |parsed patterns|.
+
+1. Set |collector map|[|collector|] to a struct with <code>url patterns</code>
+   |parsed patterns|, <code>userContexts</code>
+   |input user context ids| and <code>contexts</code>
+   |top-level traversable context ids|.
+
+1. Return a new [=/map=] matching the
+   <code>network.AddBodyCollectorResult</code> production with the
+   <code>collector</code> field set to |collector|.
+
+</div>
+
 #### The network.continueRequest Command ####  {#command-network-continueRequest}
 
 The <dfn export for=commands>network.continueRequest</dfn> command continues a request
@@ -7781,7 +8020,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-
 #### The network.removeIntercept Command ####  {#command-network-removeIntercept}
 
 The <dfn export for=commands>network.removeIntercept</dfn> command removes a
@@ -7827,6 +8065,88 @@ blocked by this intercept. Only future requests or future phases of existing
 requests will be affected.
 
 1. Return [=success=] with data [=null=].
+
+</div>
+
+#### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
+
+The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
+[=network body collector=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.RemoveBodyCollector = (
+        method: "network.removeBodyCollector",
+        params: network.RemoveBodyCollectorParameters
+      )
+
+      network.RemoveBodyCollectorParameters = {
+        collector: network.Collector
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.removeBodyCollector">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |collector| be the value of the "<code>collector</code>" field in |command
+   parameters|.
+
+1. Let |collector map| be |session|'s [=network body collector map=].
+
+1. If |collector map| does not [=map/contain=] |collector|, return
+   [=error=] with [=error code=] [=no such collector=].
+
+1. [=map/Remove=] |collector| from |collector map|.
+
+1. Return [=success=] with data [=null=].
+
+</div>
+
+#### The network.setBodyCollectorConfiguration Command ####  {#command-network-setBodyCollectorConfiguration}
+
+The <dfn export for=commands>network.setBodyCollectorConfiguration</dfn> command configures
+the network body collectors.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.SetBodyCollectorConfiguration = (
+        method: "network.setBodyCollectorConfiguration",
+        params: network.SetBodyCollectorConfigurationParameters
+      )
+
+      network.SetBodyCollectorConfigurationParameters = {
+        maximumBodySize: js-uint,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.setBodyCollectorConfiguration">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |size| be |command parameters|["<code>maximumBodySize</code>"].
+
+1. Set |session|'s [=network maximum body size=] to |size|.
+
+1. Return [=success=] with data null.
 
 </div>
 
@@ -8281,8 +8601,7 @@ completed</dfn> steps given |request| and |response|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
-1. If the implementation is configured to save response data for |request|,
-   set [=response map=][|request|'s [=request id=]] to |response|.
+1. [=Maybe collect the response body=] |session|, |request| and |response|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>network.responseCompleted</code>" and |related navigables|:

--- a/index.bs
+++ b/index.bs
@@ -5144,7 +5144,7 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 1, given
 </dl>
 The [=remote end event trigger=] is:
 
-<div algorithm="remote end event trigger for browsingContext.contexDestroyed">
+<div algorithm="remote end event trigger for browsingContext.contextDestroyed">
 
 The [=remote end event trigger=] is
 the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|:
@@ -5158,9 +5158,6 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
 
 1. Let |related navigables| be a [=/set=] containing |navigable|'s [=navigable/parent=],
    if that is not null, or an empty [=/set=] otherwise.
-
-1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
-   with |session|, |navigable| and null.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related navigables|:
@@ -5584,9 +5581,6 @@ given |navigable| and |navigation status|:
 
 1. [=Resume=] with "<code>navigation committed</code>", |navigation id|, and |navigation status|.
 
-1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
-   with |session|, |navigable| and |navigation id|.
-
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.navigationCommitted</code>" and |related navigables|:
 
@@ -5934,14 +5928,12 @@ A [=remote end=] has a <dfn>navigable cache behavior map</dfn> which is a weak
 map between [=/top-level traversables=] and strings representing cache
 behavior. It is initially empty.
 
-### Network Body Collection### {#network-body-collection}
+### Network Body Collection ### {#network-body-collection}
 
 A <dfn for="network">body</dfn> is a [=/struct=] consisting of
 an [=struct/item=] named <code>bytes</code>, which is a <code>network.BytesValue</code> or null,
 an [=struct/item=] named <code>cloned body</code>, which is a [=response/body=] or null,
 an [=struct/item=] named <code>collectors</code>, which is a list of <code>network.Collector</code>,
-an [=struct/item=] named <code>navigable</code>, which is a <code>browsingContext.BrowsingContext</code>,
-an [=struct/item=] named <code>navigation</code>, which is a <code>browsingContext.Navigation</code>,
 an [=struct/item=] named <code>request</code>, which is a <code>network.Request</code>,
 an [=struct/item=] named <code>size</code>, which is a js-uint or null,
 an [=struct/item=] named <code>type</code>, which is a <code>network.BodyType</code>.
@@ -5952,14 +5944,17 @@ an [=struct/item=] named <code>contexts</code>, which is a list of <code>browsin
 an [=struct/item=] named <code>body types</code>, which is a list of <code>network.BodyType</code>,
 an [=struct/item=] named <code>collector</code>, which is a <code>network.Collector</code>,
 an [=struct/item=] named <code>collector type</code>, which is a <code>network.CollectorType</code>,
-an [=struct/item=] named <code>total max size</code>, which is a js-uint,
 an [=struct/item=] named <code>user contexts</code>, which is a list of <code>browser.UserContext</code>.
 
 A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
 <code>network.Collector</code> and a [=network/collector=]. It is initially empty.
 
-A [=BiDi session=] has <dfn>collected network bodies</dfn> which is a list of
+A [=remote end=] has <dfn>collected network bodies</dfn> which is a list of
 [=network/body|bodies=]. It is initially empty.
+
+A [=remote end=] has a <dfn>max total body size</dfn> which is an integer representing
+the size allocated to collect network bodies in [=collected network bodies=]. Its
+value is implementation-defined.
 
 <div algorithm>
 To <dfn>get navigable for request</dfn> given request:
@@ -6004,32 +5999,32 @@ To <dfn export>clone network response body</dfn> given |request| and |response b
 
 Note: This hook is intended to be triggered by the fetch spec when the response is set.
 
-1. Let |navigable| be [=get navigable for request=] with |request|.
-
 1. For each |session| in [=active BiDi sessions=]:
 
    Note: Should check for collectors matching navigable + response here already?
    Otherwise we can do it only in [=maybe collect network response body=] so that
    clients can add the collector as late as possible?
 
-   1. Let |collected body| be a struct with
+   1. If |session|'s [=network collectors=] is not [=list/empty=]:
+
+      1. Let |collected body| be a struct with
             <code>bytes</code> field set to null,
             <code>cloned body</code> field set to [=body/clone=] with |response body|,
             <code>collectors</code> field set to an empty list,
-            <code>navigable</code> field set to |navigable|'s [=navigable id=],
-            <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
             <code>request</code> field set to |request|'s [=request id=],
             <code>size</code> field set to null,
             <code>type</code> field set to "response".
 
-   1. [=list/Append=] |collected body| to |session|'s [=collected network bodies=].
+      1. [=list/Append=] |collected body| to [=collected network bodies=].
+
+      1. Return.
 
 </div>
 
 <div algorithm>
-To <dfn>get collected body</dfn> given |session|, |request id| and |body type|.
+To <dfn>get collected body</dfn> given |request id| and |body type|.
 
-1. For |collected body| of |session|'s [=collected network bodies=]:
+1. For |collected body| of [=collected network bodies=]:
 
    1. If |collected body|'s <code>request</code> is |request id| and
       |collected body|'s <code>type</code> is |body type|, return |collected body|.
@@ -6045,6 +6040,10 @@ To <dfn>maybe collect network response body</dfn> given |session| and |request|:
 
 1. If |navigable| is null, return.
 
+NOTE: This prevents from collecting bodies not related to a navigable.
+We still need to retrieve the navigable to check against the collector
+configuration but we could still accept null here.
+
 1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
 
 1. Let |collectors| be an empty list.
@@ -6057,9 +6056,12 @@ To <dfn>maybe collect network response body</dfn> given |session| and |request|:
 
 1. If |collectors| is [=list/empty=], return.
 
-1. Let |collected body| be [=get collected body=] with |session|, |request|'s [=request id=] and "response".
+1. Let |collected body| be [=get collected body=] with |request|'s [=request id=] and "response".
 
-1. Assert |collected body| is not null.
+1. If |collected body| is null, return.
+
+Note: This might happen if there are no collectors setup when the response is created,
+and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |bytes| be null.
 
@@ -6083,15 +6085,12 @@ To <dfn>maybe collect network response body</dfn> given |session| and |request|:
 
 1. For |collector| in |collectors|:
 
-   1. If |size| is greater than |collector|'s <code>max body size</code>, remove |collector| from |collectors|.
+   1. If |size| is less than or equal to |collector|'s <code>max body size</code>,
+      [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>.
 
-1. If |collectors| is [=list/empty=], return.
+1. If |collected body|'s <code>collectors</code> is [=list/empty=], return.
 
-1. For |collector| in |collectors|:
-
-   1. [=Allocate size to record body=] given |session|, |navigable|, |collector| and |size|.
-
-   1. [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>
+1. [=Allocate size to record body=] given |size|.
 
 1. Set |collected body|'s <code>bytes</code> to |bytes|.
 
@@ -6100,20 +6099,13 @@ To <dfn>maybe collect network response body</dfn> given |session| and |request|:
 </div>
 
 <div algorithm>
-To <dfn>allocate size to record body</dfn> given |session|, |navigable|,
-|collector| and |size|:
+To <dfn>allocate size to record body</dfn> given |size|:
 
-1. Let |available size| be |collector|'s <code>max total size</code>.
+1. Let |available size| be [=max total body size=].
 
 1. Let |already collected bodies| be an empty list.
 
-1. For each |collected body| in |session|'s [=collected network bodies=]:
-
-   1. If |collected body|'s <code>navigable</code> is not |navigable|'s
-      [=navigable id=], continue.
-
-   1. If |collected body|'s <code>collectors</code> does not [=list/contain=]
-      |collector|'s <code>collector</code>, continue.
+1. For each |collected body| in [=collected network bodies=] in order:
 
    1. If |collected body|'s <code>bytes</code> is not null:
 
@@ -6123,40 +6115,15 @@ To <dfn>allocate size to record body</dfn> given |session|, |navigable|,
 
 1. If |size| is greater than |available size|:
 
-   1. For each |collected body| in |already collected bodies|'s in order:
+   1. For each |collected body| in |already collected bodies| in order:
 
       1. Increase |available size| by |collected body|'s <code>size</code>.
 
-      1. [=list/Remove=] |collector|'s <code>collector</code> from |collected body|'s
-         <code>collectors</code>.
+      1. Set |collected body|'s <code>bytes</code> field to null.
 
-      1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
-
-         1. Set |collected body|'s <code>bytes</code> field to null.
-
-         1. Set |collected body|'s <code>size</code> field to null.
+      1. Set |collected body|'s <code>size</code> field to null.
 
       1. If |available size| is greater than or equal to |size|, return.
-
-</div>
-
-<div algorithm>
-To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
-|current navigation|:
-
-1. For each |collected body| in |session|'s [=collected network bodies=]:
-
-  1. Let |navigation| be |collected body|'s <code>navigation</code>
-     field.
-
-  1. Let |navigable id| be |collected body|'s <code>navigable</code>
-     field.
-
-  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
-
-  1. If |current navigation| is not null and |current navigation| is |navigation|, continue.
-
-  1. Set |collected body|'s <code>bytes</code> field to null.
 
 </div>
 
@@ -7549,11 +7516,10 @@ The <dfn export for=commands>network.addBodyCollector</dfn> adds a
       )
 
       network.AddBodyCollectorParameters = {
-        ? contexts: [+browsingContext.BrowsingContext],
         bodyMaxSize: js-uint,
         bodyTypes: [+network.BodyType],
         collectorType: network.collectorType,
-        totalMaxSize: js-uint,
+        ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }
     </pre>
@@ -7583,14 +7549,14 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |collector type| be |command parameters|
    ["<code>collectorType</code>"].
 
-1. Let |total max size| be |command parameters|
-   ["<code>totalMaxSize</code>"].
-
 1. Let |input user context ids| be [=set/create|create a set=] with
    |command parameters|[<code>userContexts</code>].
 
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
+
+1. If |body max size| is greater than [=max total body size=],
+   return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |input context ids| is not [=set/empty=]:
 
@@ -7616,8 +7582,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
    <code>collector</code> field set to |collector id|,
    <code>collector type</code> field set to |collector type|,
    <code>contexts</code> field set to |input context ids|,
-   <code>user contexts</code> field set to |input user context ids|,
-   <code>total max size</code> field set to |total max size|.
+   <code>user contexts</code> field set to |input user context ids|.
 
 1. Set |session|'s [=network collectors=][|collector id|] to |collector|.
 
@@ -7970,6 +7935,70 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+#### The network.disownBody Command ####  {#command-network-disownBody}
+
+The <dfn export for=commands>network.disownBody</dfn> command releases a
+collected network body for a given [=network/collector=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.DisownBody = (
+        method: "network.disownBody",
+        params: network.disownBodyParameters
+      )
+
+      network.disownBodyParameters = {
+        bodyType: network.BodyType,
+        collector: network.Collector,
+        request: network.Request,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.disownBody">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |body type| be the value of the "<code>bodyType</code>" field in |command
+   parameters|.
+
+1. Let |collector id| be the value of the "<code>collector</code>" field in |command
+   parameters|.
+
+1. Let |request id| be the value of the "<code>request</code>" field in |command
+   parameters|.
+
+1. Let |collectors| be |session|'s [=network collectors=].
+
+1. If |collectors| does not [=map/contain=] |collector id|, return
+   [=error=] with [=error code=] [=no such collector=].
+
+1. Let |collected body| be [=get collected body=] with |request id| and |body type|.
+
+1. If |collected body| is null, return [=error=] with [=error code=] [=no such network body=].
+
+1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
+
+   1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
+
+   1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
+
+      1. Set |collected body|'s <code>bytes</code> field to null.
+
+      1. Set |collected body|'s <code>size</code> field to null.
+
+1. Return [=success=] with data [=null=].
+
+</div>
+
 #### The network.failRequest Command ####  {#command-network-failRequest}
 
 The <dfn export for=commands>network.failRequest</dfn> command fails a
@@ -8040,7 +8069,7 @@ network body data if it is available.
 
       network.GetNetworkBodyParameters = {
         bodyType: network.BodyType,
-        collector: network.Collector,
+        ?collector: network.Collector,
         request: network.Request,
       }
       </pre>
@@ -8060,28 +8089,27 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |body type| be |command parameters|["<code>bodyType</code>"].
 
-1. Let |collector id| be |command parameters|["<code>collector</code>"].
-
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
-1. Let |collectors| be |session|'s [=network collectors=].
+1. Let |collector id| be null.
 
-1. If |collectors| does not [=map/contain=] |collector id|, return
-   [=error=] with [=error code=] [=no such collector=].
+1. If |command parameters| [=map/contains=] "<code>collector</code>":
 
-1. Let |collector| be |session|'s [=network collectors=]["<code>collector id</code>"].
+   1. Let |collectors| be |session|'s [=network collectors=].
 
-1. If |collector|'s <code>collector type</code> is not "blob",
-   return error with [=error code=] [=unsupported operation=].
+   1. If |collectors| does not [=map/contain=] |collector id|, return
+      [=error=] with [=error code=] [=no such collector=].
 
-1. Let |collected body| be [=get collected body=] given |session|, |request id| and |body type|.
+   1. Set |collector id| to |command parameters|["<code>collector</code>"].
+
+1. Let |collected body| be [=get collected body=] given |request id| and |body type|.
 
 1. If |collected body| is null:
 
    1. Return [=error=] with [=error code=] [=no such network body=].
 
-1. If |collected body|'s <code>collectors</code> does not [=list/contain=]
-   |collector|:
+1. If |collector id| is not null and if |collected body|'s <code>collectors</code>
+   does not [=list/contain=] |collector id|:
 
    1. Return [=error=] with [=error code=] [=no such network body=].
 
@@ -8157,70 +8185,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.releaseBody Command ####  {#command-network-releaseBody}
-
-The <dfn export for=commands>network.releaseBody</dfn> command releases a
-collected network body for a given [=network/collector=].
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl remote-cddl">
-      network.ReleaseBody = (
-        method: "network.releaseBody",
-        params: network.releaseBodyParameters
-      )
-
-      network.releaseBodyParameters = {
-        bodyType: network.BodyType,
-        collector: network.Collector,
-        request: network.Request,
-      }
-    </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <code>
-      EmptyResult
-    </code>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for network.releaseBody">
-The [=remote end steps=] given |session| and |command parameters| are:
-
-1. Let |body type| be the value of the "<code>bodyType</code>" field in |command
-   parameters|.
-
-1. Let |collector id| be the value of the "<code>collector</code>" field in |command
-   parameters|.
-
-1. Let |request id| be the value of the "<code>request</code>" field in |command
-   parameters|.
-
-1. Let |collectors| be |session|'s [=network collectors=].
-
-1. If |collectors| does not [=map/contain=] |collector id|, return
-   [=error=] with [=error code=] [=no such collector=].
-
-1. Let |collected body| be [=get collected body=] with |session|, |request id| and |body type|.
-
-1. If |collected body| is null, return [=error=] with [=error code=] [=no such network body=].
-
-1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
-
-   1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
-
-   1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
-
-      1. Set |collected body|'s <code>bytes</code> field to null.
-
-      1. Set |collected body|'s <code>size</code> field to null.
-
-1. Return [=success=] with data [=null=].
-
-</div>
-
 #### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
 
 The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
@@ -8261,7 +8225,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. [=map/Remove=] |collector id| from |session|'s [=network collectors=].
 
-1. For |collected body| in |session|'s [=collected network bodies=]:
+1. For |collected body| in [=collected network bodies=]:
 
    1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
 
@@ -8776,6 +8740,8 @@ completed</dfn> steps given |request| and |response|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
+1. [=Maybe collect network response body=] with and |request|.
+
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>network.responseCompleted</code>" and |related navigables|:
 
@@ -8790,8 +8756,6 @@ completed</dfn> steps given |request| and |response|:
 
   1. Assert: |params| matches the <code>network.ResponseCompletedParameters</code>
      production.
-
-  1. [=Maybe collect network response body=] with |session| and |request|.
 
   1. Let |body| be a map matching the <code>network.ResponseCompleted</code>
      production, with the <code>params</code> field set to |params|.

--- a/index.bs
+++ b/index.bs
@@ -5907,7 +5907,21 @@ empty map.  It's used to track the network events for which a
 <code>network.beforeRequestSent</code> event has already been sent.
 
 A [=remote end=] has a <dfn>response map</dfn> that maps a [=request id=]
-to [=/response=]. Implementations may remove data from [=response map=] map at any time.
+to [=/response=]. Responses must be removed on the following conditions:
+
+- when a browsing context group switch or destruction happens, responses
+  associated with the previous browsing context group are removed.
+
+- when a navigation commits a new document, resources associated with the
+  previous document are removed.
+
+- when a worker scope is removed the responses provided by the worker are
+  removed.
+
+- when a user-configured (command to be defined) per navigable size limit is
+  exceeded, the oldest response body is evicted until there is space for
+  the new body. Evicted resources should result in a distinct error
+  code.
 
 A [=remote end=] has a <dfn>default cache behavior</dfn> which is a string. It is
 initially "<code>default</code>".

--- a/index.bs
+++ b/index.bs
@@ -637,7 +637,7 @@ with the following additional codes:
   <dt><dfn for=errors export>no such history entry</dfn>
   <dd>Tried to havigate to an unknown [=session history entry=].
 
-  <dt><dfn for=errors export>no such collector</dfn>
+  <dt><dfn for=errors export>no such network collector</dfn>
   <dd>Tried to remove an unknown [=network/collector=].
 
   <dt><dfn for=errors export>no such intercept</dfn>
@@ -688,7 +688,7 @@ ErrorCode = "invalid argument" /
             "invalid web extension" /
             "move target out of bounds" /
             "no such alert" /
-            "no such collector" /
+            "no such network collector" /
             "no such element" /
             "no such frame" /
             "no such handle" /
@@ -5960,7 +5960,7 @@ A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
 A [=remote end=] has <dfn>collected network data</dfn> which is a list of
 [=network/data=]. It is initially empty.
 
-A [=remote end=] has a <dfn>max total data size</dfn> which is an integer representing
+A [=remote end=] has a <dfn>max total data size</dfn> which is a js-uint representing
 the size allocated to collect network data in [=collected network data=]. Its
 value is implementation-defined.
 
@@ -6071,9 +6071,9 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
 
 1. If |navigable| is null, return.
 
-NOTE: This prevents from collecting data not related to a navigable.
-We still need to retrieve the navigable to check against the collector
-configuration but we could still accept null here.
+   NOTE: This prevents from collecting data not related to a navigable.
+   We still need to retrieve the navigable to check against the collector
+   configuration but we could still accept null here.
 
 1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
 
@@ -6093,8 +6093,8 @@ configuration but we could still accept null here.
 
 1. If |collected data| is null, return.
 
-Note: This might happen if there are no collectors setup when the response is created,
-and [=clone network response body=] does not clone the corresponding body.
+   NOTE: This might happen if there are no collectors setup when the response is created,
+   and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |bytes| be null.
 
@@ -6124,7 +6124,7 @@ and [=clone network response body=] does not clone the corresponding body.
    1. For |collector| in |collectors|:
 
       1. If |size| is less than or equal to |collector|'s <code>max encoded data size</code>,
-         [=list/Append=] |collector|'s <code>collector</code> to |collected data|'s <code>collectors</code>.
+         [=list/append=] |collector|'s <code>collector</code> to |collected data|'s <code>collectors</code>.
 
    1. If |collected data|'s <code>collectors</code> is not [=list/empty=]:
 
@@ -7594,7 +7594,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector id| be the string representation of a [[!RFC9562|UUID]].
 
-1. Let |input context ids| be [=set/create|create a set=] with
+1. Let |input context ids| be an empty [=/set=].
+
+1. If the <code>contexts</code> field of |command parameters| is present,
+   set |input context ids| to [=set/create|create a set=] with
    |command parameters|[<code>contexts</code>].
 
 1. Let |data types| be [=set/create|create a set=] with
@@ -7611,7 +7614,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |collector type| be |command parameters|
    ["<code>collectorType</code>"].
 
-1. Let |input user context ids| be [=set/create|create a set=] with
+1. Let |input user context ids| be an empty [=/set=].
+
+1. If the <code>userContexts</code> field of |command parameters| is present,
+   set |input user context ids| to [=set/create|create a set=] with
    |command parameters|[<code>userContexts</code>].
 
 1. If |input user context ids| is not empty and |input context ids| is not
@@ -8041,7 +8047,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |collectors| be |session|'s [=network collectors=].
 
 1. If |collectors| does not [=map/contain=] |collector id|, return
-   [=error=] with [=error code=] [=no such collector=].
+   [=error=] with [=error code=] [=no such network collector=].
 
 1. Let |collected data| be [=get collected data=] with |request id| and |data type|.
 
@@ -8124,7 +8130,7 @@ network data if it is available.
       network.GetDataParameters = {
         dataType: network.DataType,
         ? collector: network.Collector,
-        ? disown: bool,
+        ? disown: bool .default false,
         request: network.Request,
       }
       </pre>
@@ -8153,16 +8159,13 @@ The [=remote end steps=] given |session| and |command parameters| are:
    1. Let |collectors| be |session|'s [=network collectors=].
 
    1. If |collectors| does not [=map/contain=] |collector id|, return
-      [=error=] with [=error code=] [=no such collector=].
+      [=error=] with [=error code=] [=no such network collector=].
 
    1. Set |collector id| to |command parameters|["<code>collector</code>"].
 
-1. Let |disown| be false.
+1. Let |disown| be |command parameters|["<code>disown</code>"].
 
-1. If |command parameters| [=map/contains=] "<code>disown</code>",
-   set |disown| to |command parameters|["<code>disown</code>"].
-
-1. If |disown| is true and |collector id| is null, , return [=error=]
+1. If |disown| is true and |collector id| is null, return [=error=]
    with [=error code=] [=invalid argument=].
 
 1. Let |collected data| be [=get collected data=] given |request id| and |data type|.
@@ -8290,7 +8293,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |collectors| be |session|'s [=network collectors=].
 
 1. If |collectors| does not [=map/contain=] |collector id|, return
-   [=error=] with [=error code=] [=no such collector=].
+   [=error=] with [=error code=] [=no such network collector=].
 
 1. [=map/Remove=] |collector id| from |session|'s [=network collectors=].
 

--- a/index.bs
+++ b/index.bs
@@ -643,8 +643,8 @@ with the following additional codes:
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
 
-  <dt><dfn for=errors export>no such network body</dfn>
-  <dd>Tried to reference an unknown [=network/body=].
+  <dt><dfn for=errors export>no such network data</dfn>
+  <dd>Tried to reference an unknown [=network/data=].
 
   <dt><dfn for=errors export>no such node</dfn>
   <dd>Tried to deserialize an unknown <code>SharedReference</code>.
@@ -676,8 +676,8 @@ with the following additional codes:
   <dt><dfn for=errors export>unable to set file input</dfn>
   <dd>Tried to set a file input, but failed to do so.
 
-  <dt><dfn for=errors export>unavailable network body</dfn>
-  <dd>Tried to get network body which was not collected or already evicted.
+  <dt><dfn for=errors export>unavailable network data</dfn>
+  <dd>Tried to get network data which was not collected or already evicted.
 
 </dl>
 
@@ -694,7 +694,7 @@ ErrorCode = "invalid argument" /
             "no such handle" /
             "no such history entry" /
             "no such intercept" /
-            "no such network body" /
+            "no such network data" /
             "no such node" /
             "no such request" /
             "no such script" /
@@ -706,7 +706,7 @@ ErrorCode = "invalid argument" /
             "unable to close browser" /
             "unable to set cookie" /
             "unable to set file input" /
-            "unavailable network body" /
+            "unavailable network data" /
             "underspecified storage partition" /
             "unknown command" /
             "unknown error" /
@@ -5884,15 +5884,15 @@ relating to network requests.
 <pre class="cddl" data-cddl-module="remote-cddl">
 
 NetworkCommand = (
-  network.AddBodyCollector //
+  network.AddDataCollector //
   network.AddIntercept //
   network.ContinueRequest //
   network.ContinueResponse //
   network.ContinueWithAuth //
   network.FailRequest //
-  network.GetNetworkBody //
+  network.GetNetworkData //
   network.ProvideResponse //
-  network.RemoveBodyCollector //
+  network.RemoveDataCollector //
   network.RemoveIntercept //
   network.SetCacheBehavior
 )
@@ -5928,22 +5928,22 @@ A [=remote end=] has a <dfn>navigable cache behavior map</dfn> which is a weak
 map between [=/top-level traversables=] and strings representing cache
 behavior. It is initially empty.
 
-### Network Body Collection ### {#network-body-collection}
+### Network Data Collection ### {#network-data-collection}
 
-A <dfn for="network">body</dfn> is a [=/struct=] consisting of
+A <dfn for="network">data</dfn> is a [=/struct=] consisting of
 an [=struct/item=] named <code>bytes</code>, which is a <code>network.BytesValue</code> or null,
-an [=struct/item=] named <code>cloned body</code>, which is a [=response/body=] or null,
+an [=struct/item=] named <code>cloned body</code>, which is a [=/body=] or null,
 an [=struct/item=] named <code>collectors</code>, which is a list of <code>network.Collector</code>,
-an [=struct/item=] named <code>decode body steps</code>, which is an algorithm,
+an [=struct/item=] named <code>decode data steps</code>, which is an algorithm,
 an [=struct/item=] named <code>pending</code>, which is a boolean,
 an [=struct/item=] named <code>request</code>, which is a <code>network.Request</code>,
 an [=struct/item=] named <code>size</code>, which is a js-uint or null,
-an [=struct/item=] named <code>type</code>, which is a <code>network.BodyType</code>.
+an [=struct/item=] named <code>type</code>, which is a <code>network.DataType</code>.
 
 A <dfn for="network">collector</dfn> is a [=/struct=] consisting of
-an [=struct/item=] named <code>body max size</code>, which is a js-uint,
+an [=struct/item=] named <code>data max size</code>, which is a js-uint,
 an [=struct/item=] named <code>contexts</code>, which is a list of <code>browsingContext.BrowsingContext</code>,
-an [=struct/item=] named <code>body types</code>, which is a list of <code>network.BodyType</code>,
+an [=struct/item=] named <code>data types</code>, which is a list of <code>network.DataType</code>,
 an [=struct/item=] named <code>collector</code>, which is a <code>network.Collector</code>,
 an [=struct/item=] named <code>collector type</code>, which is a <code>network.CollectorType</code>,
 an [=struct/item=] named <code>user contexts</code>, which is a list of <code>browser.UserContext</code>.
@@ -5951,11 +5951,11 @@ an [=struct/item=] named <code>user contexts</code>, which is a list of <code>br
 A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
 <code>network.Collector</code> and a [=network/collector=]. It is initially empty.
 
-A [=remote end=] has <dfn>collected network bodies</dfn> which is a list of
-[=network/body|bodies=]. It is initially empty.
+A [=remote end=] has <dfn>collected network data</dfn> which is a list of
+[=network/data=]. It is initially empty.
 
-A [=remote end=] has a <dfn>max total body size</dfn> which is an integer representing
-the size allocated to collect network bodies in [=collected network bodies=]. Its
+A [=remote end=] has a <dfn>max total data size</dfn> which is an integer representing
+the size allocated to collect network data in [=collected network data=]. Its
 value is implementation-defined.
 
 <div algorithm>
@@ -6009,29 +6009,29 @@ clients can add the collector as late as possible?
 
    1. If |session|'s [=network collectors=] is not [=list/empty=]:
 
-      1. Let |collected body| be a struct with
+      1. Let |collected data| be a struct with
          <code>bytes</code> field set to null,
          <code>cloned body</code> field set to [=body/clone=] with |response body|,
          <code>collectors</code> field set to an empty list,
-         <code>decode body steps</code> field set null,
+         <code>decode data steps</code> field set null,
          <code>pending</code> field set to true,
          <code>request</code> field set to |request|'s [=request id=],
          <code>size</code> field set to null,
          <code>type</code> field set to "response".
 
-      1. [=list/Append=] |collected body| to [=collected network bodies=].
+      1. [=list/Append=] |collected data| to [=collected network data=].
 
       1. Return.
 
 </div>
 
 <div algorithm>
-To <dfn>get collected body</dfn> given |request id| and |body type|.
+To <dfn>get collected data</dfn> given |request id| and |data type|.
 
-1. For |collected body| of [=collected network bodies=]:
+1. For |collected data| of [=collected network data=]:
 
-   1. If |collected body|'s <code>request</code> is |request id| and
-      |collected body|'s <code>type</code> is |body type|, return |collected body|.
+   1. If |collected data|'s <code>request</code> is |request id| and
+      |collected data|'s <code>type</code> is |data type|, return |collected data|.
 
 1. Return null.
 
@@ -6040,13 +6040,13 @@ To <dfn>get collected body</dfn> given |request id| and |body type|.
 <div algorithm>
 To <dfn>maybe abort network response body collection</dfn> given |request|:
 
-1. Let |collected body| be [=get collected body=] with |request|'s [=request id=] and "response".
+1. Let |collected data| be [=get collected data=] with |request|'s [=request id=] and "response".
 
-1. If |collected body| is null, return.
+1. If |collected data| is null, return.
 
-1. Set |collected body|'s <code>pending</code> to false.
+1. Set |collected data|'s <code>pending</code> to false.
 
-1. [=Resume=] with "<code>network body collected</code>" and (|request|'s [=request id=], "response").
+1. [=Resume=] with "<code>network data collected</code>" and (|request|'s [=request id=], "response").
 
 </div>
 
@@ -6061,7 +6061,7 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
 
 1. If |navigable| is null, return.
 
-NOTE: This prevents from collecting bodies not related to a navigable.
+NOTE: This prevents from collecting data not related to a navigable.
 We still need to retrieve the navigable to check against the collector
 configuration but we could still accept null here.
 
@@ -6073,22 +6073,22 @@ configuration but we could still accept null here.
 
    1. For each |collector| in |session|'s [=network collectors=]:
 
-      1. If |collector|'s <code>body types</code> [=list/contains=] "response" and if [=match collector for navigable=] with |collector| and |top-level navigable|:
+      1. If |collector|'s <code>data types</code> [=list/contains=] "response" and if [=match collector for navigable=] with |collector| and |top-level navigable|:
 
          1. [=list/Append=] |collector| to |collectors|.
 
 1. If |collectors| is [=list/empty=], return.
 
-1. Let |collected body| be [=get collected body=] with |request|'s [=request id=] and "response".
+1. Let |collected data| be [=get collected data=] with |request|'s [=request id=] and "response".
 
-1. If |collected body| is null, return.
+1. If |collected data| is null, return.
 
 Note: This might happen if there are no collectors setup when the response is created,
 and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |bytes| be null.
 
-1. Let |decodeBodySteps| be null.
+1. Let |decodeDataSteps| be null.
 
 1. Let |size| be null.
 
@@ -6097,9 +6097,9 @@ and [=clone network response body=] does not clone the corresponding body.
    1. If |nullOrBytes| is not null:
 
       1. Optionally, set |nullOrBytes| to the result of running implementation-defined encoding steps
-         with |nullOrBytes| and let |decodeBodySteps| be the steps to reverse those encoding steps.
+         with |nullOrBytes| and let |decodeDataSteps| be the steps to reverse those encoding steps.
 
-         Note: Implementations are allowed to store encoded network bodies as long as they
+         Note: Implementations are allowed to store encoded network data as long as they
          are able to decode the content later on and provide the exact same |nullOrBytes| as the ones
          exposed by fetch.
 
@@ -6109,55 +6109,55 @@ and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |processBodyError| be this step: Do nothing.
 
-1. [=Fully read=] |collected body|’s <code>cloned body</code> given |processBody| and |processBodyError|.
+1. [=Fully read=] |collected data|’s <code>cloned body</code> given |processBody| and |processBodyError|.
 
 1. If |bytes| is not null:
 
    1. For |collector| in |collectors|:
 
-      1. If |size| is less than or equal to |collector|'s <code>max body size</code>,
-         [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>.
+      1. If |size| is less than or equal to |collector|'s <code>max data size</code>,
+         [=list/Append=] |collector|'s <code>collector</code> to |collected data|'s <code>collectors</code>.
 
-   1. If |collected body|'s <code>collectors</code> is not [=list/empty=]:
+   1. If |collected data|'s <code>collectors</code> is not [=list/empty=]:
 
-      1. [=Allocate size to record body=] given |size|.
+      1. [=Allocate size to record data=] given |size|.
 
-1. Set |collected body|'s <code>bytes</code> to |bytes|.
+1. Set |collected data|'s <code>bytes</code> to |bytes|.
 
-1. Set |collected body|'s <code>decode body steps</code> to |decodeBodySteps|.
+1. Set |collected data|'s <code>decode data steps</code> to |decodeDataSteps|.
 
-1. Set |collected body|'s <code>pending</code> to false.
+1. Set |collected data|'s <code>pending</code> to false.
 
-1. Set |collected body|'s <code>size</code> to |size|.
+1. Set |collected data|'s <code>size</code> to |size|.
 
-1. [=Resume=] with "<code>network body collected</code>" and (|request|'s [=request id=], "response").
+1. [=Resume=] with "<code>network data collected</code>" and (|request|'s [=request id=], "response").
 
 </div>
 
 <div algorithm>
-To <dfn>allocate size to record body</dfn> given |size|:
+To <dfn>allocate size to record data</dfn> given |size|:
 
-1. Let |available size| be [=max total body size=].
+1. Let |available size| be [=max total data size=].
 
-1. Let |already collected bodies| be an empty list.
+1. Let |already collected data| be an empty list.
 
-1. For each |collected body| in [=collected network bodies=] in order:
+1. For each |collected data| in [=collected network data=] in order:
 
-   1. If |collected body|'s <code>bytes</code> is not null:
+   1. If |collected data|'s <code>bytes</code> is not null:
 
-      1. Decrease |available size| by |collected body|'s <code>size</code>.
+      1. Decrease |available size| by |collected data|'s <code>size</code>.
 
-      1. [=list/Append=] |collected body| to |already collected bodies|
+      1. [=list/Append=] |collected data| to |already collected data|
 
 1. If |size| is greater than |available size|:
 
-   1. For each |collected body| in |already collected bodies| in order:
+   1. For each |collected data| in |already collected data| in order:
 
-      1. Increase |available size| by |collected body|'s <code>size</code>.
+      1. Increase |available size| by |collected data|'s <code>size</code>.
 
-      1. Set |collected body|'s <code>bytes</code> field to null.
+      1. Set |collected data|'s <code>bytes</code> field to null.
 
-      1. Set |collected body|'s <code>size</code> field to null.
+      1. Set |collected data|'s <code>size</code> field to null.
 
       1. If |available size| is greater than or equal to |size|, return.
 
@@ -6459,15 +6459,15 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 </div>
 
-#### The network.BodyType Type #### {#type-network-BodyType}
+#### The network.DataType Type #### {#type-network-dataType}
 
 [=Remote end definition=] and [=local end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
-network.BodyType = "response"
+network.DataType = "response"
 </pre>
 
-The <code>network.BodyType</code> type represents the different types of network bodies
+The <code>network.DataType</code> type represents the different types of network data
 that can be collected.
 
 #### The network.BytesValue Type #### {#type-network-BytesValue}
@@ -6543,9 +6543,9 @@ network.CollectorType = "blob"
 </pre>
 
 Note: In the future we might also support the "stream" collector type for clients
-which want to read the bodies gathered by a given collector via a stream.
+which want to read the data gathered by a given collector via a stream.
 
-The <code>network.CollectorType</code> type represents the different types of body collectors
+The <code>network.CollectorType</code> type represents the different types of data collectors
 that can be added.
 
 #### The network.Cookie Type #### {#type-network-Cookie}
@@ -7537,23 +7537,23 @@ To <dfn>match URL pattern</dfn> given |url pattern| and |url string|:
 
 ### Commands ### {#module-network-commands}
 
-#### The network.addBodyCollector Command ####  {#command-network-addBodyCollector}
+#### The network.addDataCollector Command ####  {#command-network-addDataCollector}
 
-The <dfn export for=commands>network.addBodyCollector</dfn> adds a
+The <dfn export for=commands>network.addDataCollector</dfn> adds a
 [=network/collector=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.AddBodyCollector = (
-        method: "network.addBodyCollector",
-        params: network.AddBodyCollectorParameters
+      network.AddDataCollector = (
+        method: "network.addDataCollector",
+        params: network.AddDataCollectorParameters
       )
 
-      network.AddBodyCollectorParameters = {
-        bodyMaxSize: js-uint,
-        bodyTypes: [+network.BodyType],
+      network.AddDataCollectorParameters = {
+        dataMaxSize: js-uint,
+        dataTypes: [+network.DataType],
         collectorType: network.collectorType,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
@@ -7568,7 +7568,7 @@ The <dfn export for=commands>network.addBodyCollector</dfn> adds a
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.addBodyCollector">
+<div algorithm="remote end steps for network.addDataCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector id| be the string representation of a [[!RFC9562|UUID]].
@@ -7576,11 +7576,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |input context ids| be [=set/create|create a set=] with
    |command parameters|[<code>contexts</code>].
 
-1. Let |body max size| be |command parameters|
-   ["<code>bodyMaxSize</code>"].
+1. Let |data max size| be |command parameters|
+   ["<code>dataMaxSize</code>"].
 
-1. Let |body types| be [=set/create|create a set=] with
-   |command parameters|["<code>bodyTypes</code>"].
+1. Let |data types| be [=set/create|create a set=] with
+   |command parameters|["<code>dataTypes</code>"].
 
 1. Let |collector type| be |command parameters|
    ["<code>collectorType</code>"].
@@ -7591,7 +7591,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |body max size| is greater than [=max total body size=],
+1. If |data max size| is greater than [=max total data size=],
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |input context ids| is not [=set/empty=]:
@@ -7613,8 +7613,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
        1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |collector| be a struct with
-   <code>body max size</code> field set to |body max size|,
-   <code>body types</code> field set to |body types|,
+   <code>data max size</code> field set to |data max size|,
+   <code>data types</code> field set to |data types|,
    <code>collector</code> field set to |collector id|,
    <code>collector type</code> field set to |collector type|,
    <code>contexts</code> field set to |input context ids|,
@@ -7623,7 +7623,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Set |session|'s [=network collectors=][|collector id|] to |collector|.
 
 1. Return a new [=/map=] matching the
-   <code>network.AddBodyCollectorResult</code> production with the
+   <code>network.AddDataCollectorResult</code> production with the
    <code>collector</code> field set to |collector id|.
 
 </div>
@@ -7971,22 +7971,22 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.disownBody Command ####  {#command-network-disownBody}
+#### The network.disownData Command ####  {#command-network-disownData}
 
-The <dfn export for=commands>network.disownBody</dfn> command releases a
-collected network body for a given [=network/collector=].
+The <dfn export for=commands>network.disownData</dfn> command releases a
+collected network data for a given [=network/collector=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.DisownBody = (
-        method: "network.disownBody",
-        params: network.disownBodyParameters
+      network.DisownData = (
+        method: "network.disownData",
+        params: network.disownDataParameters
       )
 
-      network.disownBodyParameters = {
-        bodyType: network.BodyType,
+      network.disownDataParameters = {
+        dataType: network.DataType,
         collector: network.Collector,
         request: network.Request,
       }
@@ -8000,10 +8000,10 @@ collected network body for a given [=network/collector=].
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.disownBody">
+<div algorithm="remote end steps for network.disownData">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |body type| be the value of the "<code>bodyType</code>" field in |command
+1. Let |data type| be the value of the "<code>dataType</code>" field in |command
    parameters|.
 
 1. Let |collector id| be the value of the "<code>collector</code>" field in |command
@@ -8017,19 +8017,19 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |collectors| does not [=map/contain=] |collector id|, return
    [=error=] with [=error code=] [=no such collector=].
 
-1. Let |collected body| be [=get collected body=] with |request id| and |body type|.
+1. Let |collected data| be [=get collected data=] with |request id| and |data type|.
 
-1. If |collected body| is null, return [=error=] with [=error code=] [=no such network body=].
+1. If |collected data| is null, return [=error=] with [=error code=] [=no such network data=].
 
-1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
+1. If |collected data|'s <code>collectors</code> [=list/contains=] |collector id|:
 
-   1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
+   1. [=list/Remove=] |collector id| from |collected data|'s <code>collectors</code>.
 
-   1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
+   1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
 
-      1. Set |collected body|'s <code>bytes</code> field to null.
+      1. Set |collected data|'s <code>bytes</code> field to null.
 
-      1. Set |collected body|'s <code>size</code> field to null.
+      1. Set |collected data|'s <code>size</code> field to null.
 
 1. Return [=success=] with data [=null=].
 
@@ -8089,22 +8089,22 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.getNetworkBody Command ####  {#command-network-getNetworkBody}
+#### The network.getNetworkData Command ####  {#command-network-getNetworkData}
 
-The <dfn export for=commands>network.getNetworkBody</dfn> command retrieves a
-network body data if it is available.
+The <dfn export for=commands>network.getNetworkData</dfn> command retrieves a
+network data if it is available.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.GetNetworkBody = (
-        method: "network.getNetworkBody",
-        params: network.GetNetworkBodyParameters
+      network.GetNetworkData = (
+        method: "network.getNetworkData",
+        params: network.GetNetworkDataParameters
       )
 
-      network.GetNetworkBodyParameters = {
-        bodyType: network.BodyType,
+      network.GetNetworkDataParameters = {
+        dataType: network.DataType,
         ?collector: network.Collector,
         request: network.Request,
       }
@@ -8113,17 +8113,17 @@ network body data if it is available.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      script.GetNetworkBodyResult = {
+      script.GetNetworkDataResult = {
         bytes: network.BytesValue,
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.getNetworkBody">
+<div algorithm="remote end steps for network.getNetworkData">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |body type| be |command parameters|["<code>bodyType</code>"].
+1. Let |data type| be |command parameters|["<code>dataType</code>"].
 
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
@@ -8138,31 +8138,31 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Set |collector id| to |command parameters|["<code>collector</code>"].
 
-1. Let |collected body| be [=get collected body=] given |request id| and |body type|.
+1. Let |collected data| be [=get collected data=] given |request id| and |data type|.
 
-1. If |collected body| is null:
+1. If |collected data| is null:
 
-   1. Return [=error=] with [=error code=] [=no such network body=].
+   1. Return [=error=] with [=error code=] [=no such network data=].
 
-1. If |collected body|'s <code>pending</code> is true:
+1. If |collected data|'s <code>pending</code> is true:
 
-   1. [=Await=] with "network body collected" and (|request id|, |body type|).
+   1. [=Await=] with "network data collected" and (|request id|, |data type|).
 
-1. If |collector id| is not null and if |collected body|'s <code>collectors</code>
+1. If |collector id| is not null and if |collected data|'s <code>collectors</code>
    does not [=list/contain=] |collector id|:
 
-   1. Return [=error=] with [=error code=] [=no such network body=].
+   1. Return [=error=] with [=error code=] [=no such network data=].
 
-1. Let |bytes| be |collected body|'s <code>bytes</code>.
+1. Let |bytes| be |collected data|'s <code>bytes</code>.
 
 1. If |bytes| is null,
 
-   1. Return [=error=] with [=error code=] [=unavailable network body=].
+   1. Return [=error=] with [=error code=] [=unavailable network data=].
 
-1. If |collected body|'s <code>decode body steps</code> is not null, set |bytes| to
-   the the result of running |collected body|'s <code>decode body steps</code>.
+1. If |collected data|'s <code>decode data steps</code> is not null, set |bytes| to
+   the the result of running |collected data|'s <code>decode data steps</code>.
 
-1. Let |body| be a [=/map=] matching the <code>script.GetNetworkBodyResult</code> production,
+1. Let |body| be a [=/map=] matching the <code>script.GetNetworkDataResult</code> production,
    with the <code>bytes</code> field set to |bytes|.
 
 1. Return [=success=] with data |body|.
@@ -8228,21 +8228,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
+#### The network.removeDataCollector Command ####  {#command-network-removeDataCollector}
 
-The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
+The <dfn export for=commands>network.removeDataCollector</dfn> command removes a
 [=network/collector=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.RemoveBodyCollector = (
-        method: "network.removeBodyCollector",
-        params: network.RemoveBodyCollectorParameters
+      network.RemoveDataCollector = (
+        method: "network.removeDataCollector",
+        params: network.RemoveDataCollectorParameters
       )
 
-      network.RemoveBodyCollectorParameters = {
+      network.RemoveDataCollectorParameters = {
         collector: network.Collector
       }
     </pre>
@@ -8255,7 +8255,7 @@ The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.removeBodyCollector">
+<div algorithm="remote end steps for network.removeDataCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector id| be the value of the "<code>collector</code>" field in |command
@@ -8268,17 +8268,17 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. [=map/Remove=] |collector id| from |session|'s [=network collectors=].
 
-1. For |collected body| in [=collected network bodies=]:
+1. For |collected data| in [=collected network data=]:
 
-   1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
+   1. If |collected data|'s <code>collectors</code> [=list/contains=] |collector id|:
 
-      1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
+      1. [=list/Remove=] |collector id| from |collected data|'s <code>collectors</code>.
 
-      1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
+      1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
 
-         1. Set |collected body|'s <code>bytes</code> field to null.
+         1. Set |collected data|'s <code>bytes</code> field to null.
 
-         1. Set |collected body|'s <code>size</code> field to null.
+         1. Set |collected data|'s <code>size</code> field to null.
 
 1. Return [=success=] with data [=null=].
 

--- a/index.bs
+++ b/index.bs
@@ -7592,16 +7592,17 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |input context ids| is not empty:
+1. If |input context ids| is not [=set/empty=]:
 
-   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
+   1. Let |navigables| be the result of [=trying=] to [=get valid navigables by ids=]
+      with |input context ids|.
 
    1. For each |navigable| in |navigables|:
 
       1. If |navigable| is not a [=/top-level traversable=], return [=error=]
          with [=error code=] [=invalid argument=].
 
-1. Otherwise, if |input user context ids| is not empty:
+1. Otherwise, if |input user context ids| is not [=set/empty=]:
 
     1. [=list/For each=] |user context id| of |input user context ids|:
 

--- a/index.bs
+++ b/index.bs
@@ -6163,6 +6163,21 @@ To <dfn>allocate size to record data</dfn> given |size|:
 
 </div>
 
+<div algorithm>
+To <dfn>remove collector from data</dfn> given |collected data| and |collector id|:
+
+1. If |collected data|'s <code>collectors</code> [=list/contains=] |collector id|:
+
+   1. [=list/Remove=] |collector id| from |collected data|'s <code>collectors</code>.
+
+   1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
+
+      1. Set |collected data|'s <code>bytes</code> field to null.
+
+      1. Set |collected data|'s <code>size</code> field to null.
+
+</div>
+
 ### Network Intercepts ### {#network-intercepts}
 
 A <dfn>network intercept</dfn> is a mechanism to allow remote ends to intercept
@@ -8021,15 +8036,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. If |collected data| is null, return [=error=] with [=error code=] [=no such network data=].
 
-1. If |collected data|'s <code>collectors</code> [=list/contains=] |collector id|:
-
-   1. [=list/Remove=] |collector id| from |collected data|'s <code>collectors</code>.
-
-   1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
-
-      1. Set |collected data|'s <code>bytes</code> field to null.
-
-      1. Set |collected data|'s <code>size</code> field to null.
+1. [=Remove collector from data=] with |collected data| and |collector id|.
 
 1. Return [=success=] with data [=null=].
 
@@ -8268,17 +8275,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. [=map/Remove=] |collector id| from |session|'s [=network collectors=].
 
-1. For |collected data| in [=collected network data=]:
-
-   1. If |collected data|'s <code>collectors</code> [=list/contains=] |collector id|:
-
-      1. [=list/Remove=] |collector id| from |collected data|'s <code>collectors</code>.
-
-      1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
-
-         1. Set |collected data|'s <code>bytes</code> field to null.
-
-         1. Set |collected data|'s <code>size</code> field to null.
+1. For |collected data| in [=collected network data=], [=remove collector from data=]
+   with |collected data| and |collector id|.
 
 1. Return [=success=] with data [=null=].
 

--- a/index.bs
+++ b/index.bs
@@ -5934,6 +5934,8 @@ A <dfn for="network">body</dfn> is a [=/struct=] consisting of
 an [=struct/item=] named <code>bytes</code>, which is a <code>network.BytesValue</code> or null,
 an [=struct/item=] named <code>cloned body</code>, which is a [=response/body=] or null,
 an [=struct/item=] named <code>collectors</code>, which is a list of <code>network.Collector</code>,
+an [=struct/item=] named <code>decode body steps</code>, which is an algorithm,
+an [=struct/item=] named <code>pending</code>, which is a boolean,
 an [=struct/item=] named <code>request</code>, which is a <code>network.Request</code>,
 an [=struct/item=] named <code>size</code>, which is a js-uint or null,
 an [=struct/item=] named <code>type</code>, which is a <code>network.BodyType</code>.
@@ -5961,9 +5963,9 @@ To <dfn>get navigable for request</dfn> given request:
 
 1. Let |navigable| be null.
 
-1. If |request|'s [=request/window=] is an [=environment settings object=]:
+1. If |request|'s [=request/client=] is an [=environment settings object=]:
 
-   1. Let |environment settings| be |request|'s [=request/window=]
+   1. Let |environment settings| be |request|'s [=request/client=]
 
    1. If there is a [=/navigable=] whose [=active window=] is |environment
       settings|' [=environment settings object/global object=], set |navigable|
@@ -5995,25 +5997,27 @@ To <dfn>match collector for navigable</dfn> given |collector| and |navigable|:
 </div>
 
 <div algorithm>
-To <dfn export>clone network response body</dfn> given |request| and |response body|:
+To <dfn export>clone network response body</dfn> given |sessions|, |request| and |response body|:
 
 Note: This hook is intended to be triggered by the fetch spec when the response is set.
 
-1. For each |session| in [=active BiDi sessions=]:
+Note: Should check for collectors matching navigable + response here already?
+Otherwise we can do it only in [=maybe collect network response body=] so that
+clients can add the collector as late as possible?
 
-   Note: Should check for collectors matching navigable + response here already?
-   Otherwise we can do it only in [=maybe collect network response body=] so that
-   clients can add the collector as late as possible?
+1. For each |session| in |sessions|:
 
    1. If |session|'s [=network collectors=] is not [=list/empty=]:
 
       1. Let |collected body| be a struct with
-            <code>bytes</code> field set to null,
-            <code>cloned body</code> field set to [=body/clone=] with |response body|,
-            <code>collectors</code> field set to an empty list,
-            <code>request</code> field set to |request|'s [=request id=],
-            <code>size</code> field set to null,
-            <code>type</code> field set to "response".
+         <code>bytes</code> field set to null,
+         <code>cloned body</code> field set to [=body/clone=] with |response body|,
+         <code>collectors</code> field set to an empty list,
+         <code>decode body steps</code> field set null,
+         <code>pending</code> field set to true,
+         <code>request</code> field set to |request|'s [=request id=],
+         <code>size</code> field set to null,
+         <code>type</code> field set to "response".
 
       1. [=list/Append=] |collected body| to [=collected network bodies=].
 
@@ -6034,7 +6038,24 @@ To <dfn>get collected body</dfn> given |request id| and |body type|.
 </div>
 
 <div algorithm>
-To <dfn>maybe collect network response body</dfn> given |session| and |request|:
+To <dfn>maybe abort network response body collection</dfn> given |request|:
+
+1. Let |collected body| be [=get collected body=] with |request|'s [=request id=] and "response".
+
+1. If |collected body| is null, return.
+
+1. Set |collected body|'s <code>pending</code> to false.
+
+1. [=Resume=] with "<code>network body collected</code>" and (|request|'s [=request id=], "response").
+
+</div>
+
+<div algorithm>
+To <dfn>maybe collect network response body</dfn> given |sessions|, |request| and |response|:
+
+1. If |response|'s [=response/status=] is a [=redirect status=], return.
+
+   Note: For redirects, only the final response body has to be stored.
 
 1. Let |navigable| be [=get navigable for request=] with |request|.
 
@@ -6048,11 +6069,13 @@ configuration but we could still accept null here.
 
 1. Let |collectors| be an empty list.
 
-1. For each |collector| in |session|'s [=network collectors=]:
+1. For each |session| in |sessions|:
 
-   1. If |collector|'s <code>body types</code> [=list/contains=] "response" and if [=match collector for navigable=] with |collector| and |top-level navigable|:
+   1. For each |collector| in |session|'s [=network collectors=]:
 
-      1. [=list/Append=] |collector| to |collectors|.
+      1. If |collector|'s <code>body types</code> [=list/contains=] "response" and if [=match collector for navigable=] with |collector| and |top-level navigable|:
+
+         1. [=list/Append=] |collector| to |collectors|.
 
 1. If |collectors| is [=list/empty=], return.
 
@@ -6065,11 +6088,20 @@ and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |bytes| be null.
 
+1. Let |decodeBodySteps| be null.
+
 1. Let |size| be null.
 
 1. Let |processBody| given |nullOrBytes| be this step:
 
    1. If |nullOrBytes| is not null:
+
+      1. Optionally, set |nullOrBytes| to the result of running implementation-defined encoding steps
+         with |nullOrBytes| and let |decodeBodySteps| be the steps to reverse those encoding steps.
+
+         Note: Implementations are allowed to store encoded network bodies as long as they
+         are able to decode the content later on and provide the exact same |nullOrBytes| as the ones
+         exposed by fetch.
 
       1. Set |bytes| to [=serialize protocol bytes=] with |nullOrBytes|.
 
@@ -6079,22 +6111,26 @@ and [=clone network response body=] does not clone the corresponding body.
 
 1. [=Fully read=] |collected body|’s <code>cloned body</code> given |processBody| and |processBodyError|.
 
-1. If |bytes| is null, return.
+1. If |bytes| is not null:
 
-   Note: Should this be reflected on the collected body struct, eg with a status?
+   1. For |collector| in |collectors|:
 
-1. For |collector| in |collectors|:
+      1. If |size| is less than or equal to |collector|'s <code>max body size</code>,
+         [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>.
 
-   1. If |size| is less than or equal to |collector|'s <code>max body size</code>,
-      [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>.
+   1. If |collected body|'s <code>collectors</code> is not [=list/empty=]:
 
-1. If |collected body|'s <code>collectors</code> is [=list/empty=], return.
-
-1. [=Allocate size to record body=] given |size|.
+      1. [=Allocate size to record body=] given |size|.
 
 1. Set |collected body|'s <code>bytes</code> to |bytes|.
 
+1. Set |collected body|'s <code>decode body steps</code> to |decodeBodySteps|.
+
+1. Set |collected body|'s <code>pending</code> to false.
+
 1. Set |collected body|'s <code>size</code> to |size|.
+
+1. [=Resume=] with "<code>network body collected</code>" and (|request|'s [=request id=], "response").
 
 </div>
 
@@ -6428,7 +6464,7 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 [=Remote end definition=] and [=local end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
-network.BodyType = "request" / "response"
+network.BodyType = "response"
 </pre>
 
 The <code>network.BodyType</code> type represents the different types of network bodies
@@ -8108,6 +8144,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Return [=error=] with [=error code=] [=no such network body=].
 
+1. If |collected body|'s <code>pending</code> is true:
+
+   1. [=Await=] with "network body collected" and (|request id|, |body type|).
+
 1. If |collector id| is not null and if |collected body|'s <code>collectors</code>
    does not [=list/contain=] |collector id|:
 
@@ -8119,8 +8159,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Return [=error=] with [=error code=] [=unavailable network body=].
 
+1. If |collected body|'s <code>decode body steps</code> is not null, set |bytes| to
+   the the result of running |collected body|'s <code>decode body steps</code>.
+
 1. Let |body| be a [=/map=] matching the <code>script.GetNetworkBodyResult</code> production,
-   with the <code>bytes</code> field set to |collected body|'s <code>bytes</code>.
+   with the <code>bytes</code> field set to |bytes|.
 
 1. Return [=success=] with data |body|.
 
@@ -8684,12 +8727,13 @@ error</dfn> steps given |request|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
+1. [=Maybe abort network response body collection=] with |request|.
+
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>network.fetchError</code>" and |related navigables|:
 
   1. Let |params| be the result of [=process a network event=] with |session|
      "<code>network.fetchError</code>", and |request|.
-
 
   1. TODO: Set the <code>errorText</code> field of |params|.
 
@@ -8740,10 +8784,12 @@ completed</dfn> steps given |request| and |response|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
-1. [=Maybe collect network response body=] with and |request|.
+1. Let |sessions| be the [=set of sessions for which an event is enabled=]
+   given "<code>network.responseCompleted</code>" and |related navigables|.
 
-1. For each |session| in the [=set of sessions for which an event is enabled=]
-   given "<code>network.responseCompleted</code>" and |related navigables|:
+1. [=Maybe collect network response body=] with |sessions|, |request| and |response|.
+
+1. For each |session| in |sessions|:
 
   1. Let |params| be the result of [=process a network event=] with |session|
      "<code>network.responseCompleted</code>", and |request|.
@@ -8804,8 +8850,12 @@ started</dfn> steps given |request| and |response|:
 
 1. Let |response status| be "<code>incomplete</code>".
 
-1. For each |session| in the [=set of sessions for which an event is enabled=]
-   given "<code>network.responseStarted</code>" and |related navigables|:
+1. Let |sessions| be the [=set of sessions for which an event is enabled=]
+   given "<code>network.responseStarted</code>" and |related navigables|.
+
+1. [=Clone network response body=] with |sessions|, |request| and |response|.
+
+1. For each |session| in |sessions|:
 
   1. Let |params| be the result of [=process a network event=] with |session|
      "<code>network.responseStarted</code>", and |request|.

--- a/index.bs
+++ b/index.bs
@@ -97,8 +97,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: no such alert; url: dfn-no-such-alert
     text: no such element; url: dfn-no-such-element
     text: no such frame; url: dfn-no-such-frame
-    text: no such response; url: dfn-no-such-response
-    text: no response body; url: dfn-no-response-body
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
     text: process capabilities; url: dfn-capabilities-processing
@@ -679,17 +677,16 @@ ErrorCode = "invalid argument" /
             "invalid session id" /
             "invalid web extension" /
             "move target out of bounds" /
-            "no response body" /
             "no such alert" /
+            "no such collector"
             "no such element" /
             "no such frame" /
             "no such handle" /
             "no such history entry" /
-            "no such collector" /
             "no such intercept" /
+            "no such network body" /
             "no such node" /
             "no such request" /
-            "no such response" /
             "no such script" /
             "no such storage partition" /
             "no such user context" /
@@ -699,6 +696,7 @@ ErrorCode = "invalid argument" /
             "unable to close browser" /
             "unable to set cookie" /
             "unable to set file input" /
+            "unavailable network body" /
             "underspecified storage partition" /
             "unknown command" /
             "unknown error" /
@@ -5893,7 +5891,7 @@ NetworkCommand = (
   network.ContinueResponse //
   network.ContinueWithAuth //
   network.FailRequest //
-  network.GetResponseBody //
+  network.GetNetworkBody //
   network.ProvideResponse //
   network.RemoveDataCollector //
   network.RemoveIntercept //
@@ -6168,7 +6166,7 @@ To <dfn>update navigable network collector sizes</dfn> given |session| and |top-
 </div>
 
 <div algorithm>
-To <dfn>maybe collect network data</dfn> given |session|, |request| and |response|:
+To <dfn>maybe collect network response body</dfn> given |session|, |request| and |response|:
 
 1. Let |navigable| be null.
 
@@ -6209,6 +6207,7 @@ To <dfn>maybe collect network data</dfn> given |session|, |request| and |respons
 
 1. Let |collector data| be a new [=/map=] matching the
          <code>network.CollectorData</code> production, with the
+         <code>bodyType</code> field set to "response",
          <code>data</code> field set to |response to collect|,
          <code>navigable</code> field set to |navigable|'s [=navigable id=],
          <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
@@ -6404,6 +6403,17 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 </div>
 
+#### The network.BodyType Type #### {#type-network-BodyType}
+
+[=Remote end definition=] and [=local end definition=]
+
+<pre class="cddl remote-cddl local-cddl">
+network.BodyType = "request" / "response"
+</pre>
+
+The <code>network.BodyType</code> type represents the different types of network bodies
+that can be collected.
+
 #### The network.BytesValue Type #### {#type-network-BytesValue}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
@@ -6474,6 +6484,7 @@ The <code>network.Collector</code> type represents the id of a [=network data co
 
 <pre class="cddl local-cddl remote-cddl">
 network.CollectorData = {
+    bodyType: network.BodyType,
     data: network.BytesValue / null,
     navigable: browsingContext.BrowsingContext,
     navigation: browsingContext.Navigation,
@@ -7584,7 +7595,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
 
 1. Let |collector data| be a new [=/map=] matching the
-   <code>network.CollectorData</code> production with
+   <code>network.CollectorInfo</code> production with
    the <code>resourceMaxSize</code> field set to |resource max size|,
    the <code>totalMaxSize</code> field set to |total max size|,
    the <code>userContexts</code> field set to |input user context ids| and
@@ -7998,21 +8009,22 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.getResponseBody Command ####  {#command-network-getResponseBody}
+#### The network.getNetworkBody Command ####  {#command-network-getNetworkBody}
 
-The <dfn export for=commands>network.getResponseBody</dfn> command retrieved the
-response body data if it is available.
+The <dfn export for=commands>network.getNetworkBody</dfn> command retrieves a
+network body data if it is available.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.GetResponseBody = (
-        method: "network.getResponseBody",
-        params: network.GetResponseBodyParameters
+      network.GetNetworkBody = (
+        method: "network.getNetworkBody",
+        params: network.GetNetworkBodyParameters
       )
 
-      network.GetResponseBodyParameters = {
+      network.GetNetworkBodyParameters = {
+        bodyType: network.BodyType,
         request: network.Request,
       }
       </pre>
@@ -8020,15 +8032,17 @@ response body data if it is available.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      script.GetResponseBodyResult = {
+      script.GetNetworkBodyResult = {
         data: network.BytesValue,
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.getResponseBody">
+<div algorithm="remote end steps for network.getNetworkBody">
 The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |body type| be |command parameters|["<code>bodyType</code>"].
 
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
@@ -8038,20 +8052,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. For each |collected data| of |collected network data|:
 
-  1. If the <code>request</code> field of |collected data| is |request id|,
+  1. If the <code>request</code> field of |collected data| is |request id|
+     and the <code>bodyType</code> field of |collected data| is |body type|,
      set |match| to |collected data|, break.
 
 1. If |match| is null:
 
-  1. Return [=error=] with [=error code=] [=no such response=].
+  1. Return [=error=] with [=error code=] [=no such network body=].
 
 1. Let |response| the <code>response</code> field of |match|.
 
 1. If |response| is null,
 
-  1. Return [=error=] with [=error code=] [=no response body=].
+  1. Return [=error=] with [=error code=] [=unavailable network body=].
 
-1. Let |body| be a [=/map=] matching the <code>script.GetResponseBodyResult</code> production,
+1. Let |body| be a [=/map=] matching the <code>script.GetNetworkBodyResult</code> production,
    with the <code>data</code> field set to the <code>data</code> field of |collected data|.
 
 1. Return [=success=] with data |body|.
@@ -8706,7 +8721,7 @@ completed</dfn> steps given |request| and |response|:
   1. Assert: |params| matches the <code>network.ResponseCompletedParameters</code>
      production.
 
-  1. [=Maybe collect network data=] with |session|, |request| and |response|.
+  1. [=Maybe collect network response body=] with |session|, |request| and |response|.
 
   1. Let |body| be a map matching the <code>network.ResponseCompleted</code>
      production, with the <code>params</code> field set to |params|.

--- a/index.bs
+++ b/index.bs
@@ -7578,7 +7578,7 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
       network.AddDataCollectorParameters = {
         dataMaxSize: js-uint,
         dataTypes: [+network.DataType],
-        ? collectorType: network.collectorType .default "blob",
+        ? collectorType: network.CollectorType .default "blob",
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }

--- a/index.bs
+++ b/index.bs
@@ -97,6 +97,8 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: no such alert; url: dfn-no-such-alert
     text: no such element; url: dfn-no-such-element
     text: no such frame; url: dfn-no-such-frame
+    text: no such response; url: dfn-no-such-response
+    text: no response body; url: dfn-no-response-body
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
     text: process capabilities; url: dfn-capabilities-processing
@@ -673,6 +675,7 @@ ErrorCode = "invalid argument" /
             "invalid session id" /
             "invalid web extension" /
             "move target out of bounds" /
+            "no response body" /
             "no such alert" /
             "no such element" /
             "no such frame" /
@@ -681,6 +684,7 @@ ErrorCode = "invalid argument" /
             "no such intercept" /
             "no such node" /
             "no such request" /
+            "no such response" /
             "no such script" /
             "no such storage partition" /
             "no such user context" /
@@ -5872,6 +5876,7 @@ NetworkCommand = (
   network.ContinueResponse //
   network.ContinueWithAuth //
   network.FailRequest //
+  network.GetResponseBody //
   network.ProvideResponse //
   network.RemoveIntercept //
   network.SetCacheBehavior
@@ -5900,6 +5905,9 @@ NetworkEvent = (
 A [=remote end=] has a <dfn>before request sent map</dfn> which is initially an
 empty map.  It's used to track the network events for which a
 <code>network.beforeRequestSent</code> event has already been sent.
+
+A [=remote end=] has a <dfn>response map</dfn> that maps a [=request id=]
+to [=/response=]. Implementations may remove data from [=response map=] map at any time.
 
 A [=remote end=] has a <dfn>default cache behavior</dfn> which is a string. It is
 initially "<code>default</code>".
@@ -7644,6 +7652,63 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+#### The network.getResponseBody Command ####  {#command-network-getResponseBody}
+
+The <dfn export for=commands>network.getResponseBody</dfn> command retrieved the
+response body data if it is available.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl remote-cddl">
+      network.GetResponseBody = (
+        method: "network.getResponseBody",
+        params: network.GetResponseBodyParameters
+      )
+
+      network.GetResponseBodyParameters = {
+        request: network.Request,
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl local-cddl">
+      script.GetResponseBodyResult = {
+        body: network.BytesValue,
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.getResponseBody">
+The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
+
+1. Let |request id| be |command parameters|["<code>request</code>"].
+
+1. If [=response map=] does not [=map/contain=] |request id|:
+
+  1. Return [=error=] with [=error code=] [=no such response=].
+
+1. Let |response| be [=response map=][|request id|].
+
+1. If |response|'s [=response/body=] is null,
+
+  1. Return [=error=] with [=error code=] [=no response body=].
+
+Issue: what do we do with bodies that are too large? The limit is often
+determined on the transport level and the implementation might not know
+it.
+
+1. Let |body| be a [=/map=] matching the <code>script.GetResponseBodyResult</code> production,
+   with the <code>body</code> field set to base-64 encoded value of |response|'s [=response/body=].
+   TODO: specify exact steps how to read the body.
+
+1. Return [=success=] with data |body|.
+
+</div>
+
+
 #### The network.provideResponse Command ####  {#command-network-provideResponse}
 
 The <dfn export for=commands>network.provideResponse</dfn> command continues a
@@ -8201,6 +8266,9 @@ completed</dfn> steps given |request| and |response|:
    be the result of [=get related navigables=] with |request|'s
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
+
+1. If the implementation is configured to save response data for |request|,
+   set [=response map=][|request|'s [=request id=]] to |response|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>network.responseCompleted</code>" and |related navigables|:

--- a/index.bs
+++ b/index.bs
@@ -688,7 +688,7 @@ ErrorCode = "invalid argument" /
             "invalid web extension" /
             "move target out of bounds" /
             "no such alert" /
-            "no such collector"
+            "no such collector" /
             "no such element" /
             "no such frame" /
             "no such handle" /

--- a/index.bs
+++ b/index.bs
@@ -1646,6 +1646,13 @@ To <dfn>cleanup the session</dfn> given |session|:
    1. [=map/Remove=] |session|'s
       [=user context to proxy configuration map=][|user context|].
 
+1. For each |collector| in |session's| [=network collectors=]:
+
+   1. Let |collector id| be |collector|'s <code>collector</code>.
+
+   1. For each |collected data| in [=collected network data=], [=remove collector from data=]
+      with |collected data| and |collector id|.
+
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
 1. Perform any implementation-specific cleanup steps.
@@ -6176,9 +6183,7 @@ To <dfn>remove collector from data</dfn> given |collected data| and |collector i
 
    1. If |collected data|'s <code>collectors</code> is [=list/empty=]:
 
-      1. Set |collected data|'s <code>bytes</code> field to null.
-
-      1. Set |collected data|'s <code>size</code> field to null.
+      1. [=list/Remove=] |collected data| from [=collected network data=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5897,7 +5897,7 @@ NetworkCommand = (
   network.ContinueResponse //
   network.ContinueWithAuth //
   network.FailRequest //
-  network.GetNetworkData //
+  network.GetData //
   network.ProvideResponse //
   network.RemoveDataCollector //
   network.RemoveIntercept //
@@ -6112,7 +6112,7 @@ and [=clone network response body=] does not clone the corresponding body.
          fetch stream correspond to the dedoded data, but the encoded (network) size is
          used in order to calculate size limits. Implementations might decide to use a storage
          model such that it uses less size than storing the decoded data, as long as the data
-         returned to clients in getNetworkData is identical to the decoded data. The potential
+         returned to clients in getData is identical to the decoded data. The potential
          tradeoff between storage and performance is up to the implementation.
 
 1. Let |processBodyError| be this step: Do nothing.
@@ -8102,21 +8102,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.getNetworkData Command ####  {#command-network-getNetworkData}
+#### The network.getData Command ####  {#command-network-getData}
 
-The <dfn export for=commands>network.getNetworkData</dfn> command retrieves a
+The <dfn export for=commands>network.getData</dfn> command retrieves a
 network data if it is available.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
       <pre class="cddl remote-cddl">
-      network.GetNetworkData = (
-        method: "network.getNetworkData",
-        params: network.GetNetworkDataParameters
+      network.GetData = (
+        method: "network.getData",
+        params: network.GetDataParameters
       )
 
-      network.GetNetworkDataParameters = {
+      network.GetDataParameters = {
         dataType: network.DataType,
         ? collector: network.Collector,
         ? disown: bool,
@@ -8127,14 +8127,14 @@ network data if it is available.
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl local-cddl">
-      script.GetNetworkDataResult = {
+      script.GetDataResult = {
         bytes: network.BytesValue,
       }
     </pre>
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.getNetworkData">
+<div algorithm="remote end steps for network.getData">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |data type| be |command parameters|["<code>dataType</code>"].
@@ -8181,7 +8181,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Return [=error=] with [=error code=] [=unavailable network data=].
 
-1. Let |body| be a [=/map=] matching the <code>script.GetNetworkDataResult</code> production,
+1. Let |body| be a [=/map=] matching the <code>script.GetDataResult</code> production,
    with the <code>bytes</code> field set to |bytes|.
 
 1. If |disown| is true, [=remove collector from data=] with |collected data| and |collector id|.

--- a/index.bs
+++ b/index.bs
@@ -635,7 +635,7 @@ with the following additional codes:
   <dd>Tried to havigate to an unknown [=session history entry=].
 
   <dt><dfn for=errors export>no such collector</dfn>
-  <dd>Tried to remove an unknown [=network data collector=].
+  <dd>Tried to remove an unknown [=network body collector=].
 
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
@@ -5885,7 +5885,7 @@ relating to network requests.
 <pre class="cddl" data-cddl-module="remote-cddl">
 
 NetworkCommand = (
-  network.AddDataCollector //
+  network.AddBodyCollector //
   network.AddIntercept //
   network.ContinueRequest //
   network.ContinueResponse //
@@ -5893,7 +5893,7 @@ NetworkCommand = (
   network.FailRequest //
   network.GetNetworkBody //
   network.ProvideResponse //
-  network.RemoveDataCollector //
+  network.RemoveBodyCollector //
   network.RemoveIntercept //
   network.SetCacheBehavior
 )
@@ -6095,19 +6095,19 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 
 ### Network Data ### {#network-data}
 
-A <dfn>network data collector</dfn> is a mechanism to allow remote ends to collect
+A <dfn>network body collector</dfn> is a mechanism to allow remote ends to collect
 network data such as network response bodies.
 
 A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
-network data collector id and <code>network.CollectorInfo</code>. It is initially empty.
+network body collector id and <code>network.CollectorInfo</code>. It is initially empty.
 
 A [=BiDi session=] has <dfn>navigable network collector sizes</dfn> which is a weak map
 between [=/top-level traversables=] and <code>network.CollectorSizes</code>. It describes
 the effective collector sizes for all [=/navigables=] under a [=/top-level traversable=].
 It is initially empty.
 
-A [=BiDi session=] has <dfn>collected network data</dfn> which is a list of
-<code>network.CollectorData</code>. It is initially empty.
+A [=BiDi session=] has <dfn>collected network bodies</dfn> which is a list of
+<code>network.CollectorBody</code>. It is initially empty.
 
 <div algorithm>
 To <dfn>match collector info</dfn> given |collector info| and |navigable|:
@@ -6205,16 +6205,16 @@ To <dfn>maybe collect network response body</dfn> given |session|, |request| and
 
   1. [=Fully read=] |response|’s [=response/body=] given |processBody| and |processBodyError|.
 
-1. Let |collector data| be a new [=/map=] matching the
-         <code>network.CollectorData</code> production, with the
+1. Let |collector body| be a new [=/map=] matching the
+         <code>network.CollectorBody</code> production, with the
+         <code>body</code> field set to |response to collect|,
          <code>bodyType</code> field set to "response",
-         <code>data</code> field set to |response to collect|,
          <code>navigable</code> field set to |navigable|'s [=navigable id=],
          <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
          <code>request</code> field set to |request|'s [=request id=] and
          <code>size</code> field set to |response size|.
 
-1. [=list/Append=] |collector data| to |session|'s [=collected network data=].
+1. [=list/Append=] |collector body| to |session|'s [=collected network bodies=].
 
 </div>
 
@@ -6224,28 +6224,28 @@ To <dfn>allocate size to record data</dfn> given |session|, |navigable|,
 
 1. Let |available size| be |max total size|.
 
-1. For each |collected data| in |session|'s [=collected network data=]:
+1. For each |collected body| in |session|'s [=collected network bodies=]:
 
-  1. Let |navigable id| be |collected data|'s <code>navigable</code>
+  1. Let |navigable id| be |collected body|'s <code>navigable</code>
      field.
 
   1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
 
-  1. If |collected data|'s <code>data</code> is not null:
+  1. If |collected body|'s <code>data</code> is not null:
 
-    1. Decrease |available size| by |collected data|'s <code>size</code>.
+    1. Decrease |available size| by |collected body|'s <code>size</code>.
 
 1. If |requested size| is greater than |available size|:
 
-  1. For each |collected data| in |session|'s [=collected network data=] in order:
+  1. For each |collected body| in |session|'s [=collected network bodies=] in order:
 
     1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
 
-    1. If |collected data|'s <code>data</code> is not null:
+    1. If |collected body|'s <code>data</code> is not null:
 
-      1. Increase |available size| by |collected data|'s <code>size</code>.
+      1. Increase |available size| by |collected body|'s <code>size</code>.
 
-      1. Set |collected data|'s <code>data</code> field to null.
+      1. Set |collected body|'s <code>data</code> field to null.
 
       1. If |available size| is greater than or equal to |requested size|, return.
 
@@ -6255,19 +6255,19 @@ To <dfn>allocate size to record data</dfn> given |session|, |navigable|,
 To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
 |current navigation|:
 
-1. For each |collected data| in |session|'s [=collected network data=]:
+1. For each |collected body| in |session|'s [=collected network bodies=]:
 
-  1. Let |navigation| be |collected data|'s <code>navigation</code>
+  1. Let |navigation| be |collected body|'s <code>navigation</code>
      field.
 
-  1. Let |navigable id| be |collected data|'s <code>navigable</code>
+  1. Let |navigable id| be |collected body|'s <code>navigable</code>
      field.
 
   1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
 
   1. If |current navigation| is not null and |current navigation| is |navigation|, continue.
 
-  1. Set |collected data|'s <code>data</code> field to null.
+  1. Set |collected body|'s <code>data</code> field to null.
 
 </div>
 
@@ -6476,16 +6476,16 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 network.Collector = text
 </pre>
 
-The <code>network.Collector</code> type represents the id of a [=network data collector=].
+The <code>network.Collector</code> type represents the id of a [=network body collector=].
 
-#### The network.CollectorData Type #### {#type-network-CollectorData}
+#### The network.CollectorBody Type #### {#type-network-CollectorBody}
 
 [=Remote end definition=] and [=local end definition=]
 
 <pre class="cddl local-cddl remote-cddl">
-network.CollectorData = {
+network.CollectorBody = {
+    body: network.BytesValue / null,
     bodyType: network.BodyType,
-    data: network.BytesValue / null,
     navigable: browsingContext.BrowsingContext,
     navigation: browsingContext.Navigation,
     request: network.Request,
@@ -6493,8 +6493,8 @@ network.CollectorData = {
 };
 </pre>
 
-The <code>network.CollectorData</code> type represents network data stored via a
-[=network data collector=].
+The <code>network.CollectorBody</code> type represents a network body stored via a
+[=network body collector=].
 
 #### The network.CollectorInfo Type #### {#type-network-CollectorInfo}
 
@@ -6508,7 +6508,7 @@ network.CollectorInfo = {
 };
 </pre>
 
-The <code>network.CollectorInfo</code> type represents a [=network data collector=].
+The <code>network.CollectorInfo</code> type represents a [=network body collector=].
 
 #### The network.CollectorSizes Type #### {#type-network-CollectorSizes}
 
@@ -6521,7 +6521,7 @@ network.CollectorSizes = {
 };
 </pre>
 
-The <code>network.CollectorSizes</code> type represents the sizes used by a [=network data collector=].
+The <code>network.CollectorSizes</code> type represents the sizes used by a [=network body collector=].
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
@@ -7512,21 +7512,21 @@ To <dfn>match URL pattern</dfn> given |url pattern| and |url string|:
 
 ### Commands ### {#module-network-commands}
 
-#### The network.addDataCollector Command ####  {#command-network-addDataCollector}
+#### The network.addBodyCollector Command ####  {#command-network-addBodyCollector}
 
-The <dfn export for=commands>network.addDataCollector</dfn> command configures
-the data collector map.
+The <dfn export for=commands>network.addBodyCollector</dfn> command configures
+the body collector map.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.AddDataCollector = (
-        method: "network.addDataCollector",
-        params: network.AddDataCollectorParameters
+      network.AddBodyCollector = (
+        method: "network.addBodyCollector",
+        params: network.AddBodyCollectorParameters
       )
 
-      network.AddDataCollectorParameters = {
+      network.AddBodyCollectorParameters = {
         ? contexts: [+browsingContext.BrowsingContext],
         bodyMaxSize: js-uint,
         totalMaxSize: js-uint,
@@ -7542,7 +7542,7 @@ the data collector map.
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.addDataCollector">
+<div algorithm="remote end steps for network.addBodyCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector| be the string representation of a [[!RFC9562|UUID]].
@@ -7594,20 +7594,20 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
 
-1. Let |collector data| be a new [=/map=] matching the
+1. Let |collector info| be a new [=/map=] matching the
    <code>network.CollectorInfo</code> production with
    the <code>bodyMaxSize</code> field set to |body max size|,
    the <code>totalMaxSize</code> field set to |total max size|,
    the <code>userContexts</code> field set to |input user context ids| and
    the <code>contexts</code> field set to |top-level traversable ids|.
 
-1. Set |session|'s [=network collectors=][|collector|] to |collector data|.
+1. Set |session|'s [=network collectors=][|collector|] to |collector info|.
 
 1. For each |traversable| in |top-level traversables to update|, [=update navigable network collector sizes=]
    with |session| and |traversable|.
 
 1. Return a new [=/map=] matching the
-   <code>network.AddDataCollectorResult</code> production with the
+   <code>network.AddBodyCollectorResult</code> production with the
    <code>collector</code> field set to |collector|.
 
 </div>
@@ -8046,15 +8046,15 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
-1. Let |collected network data| be |session|'s [=collected network data=].
+1. Let |collected network bodies| be |session|'s [=collected network bodies=].
 
 1. Let |match| be null.
 
-1. For each |collected data| of |collected network data|:
+1. For each |collected body| of |collected network bodies|:
 
-  1. If the <code>request</code> field of |collected data| is |request id|
-     and the <code>bodyType</code> field of |collected data| is |body type|,
-     set |match| to |collected data|, break.
+  1. If the <code>request</code> field of |collected body| is |request id|
+     and the <code>bodyType</code> field of |collected body| is |body type|,
+     set |match| to |collected body|, break.
 
 1. If |match| is null:
 
@@ -8067,7 +8067,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
   1. Return [=error=] with [=error code=] [=unavailable network body=].
 
 1. Let |body| be a [=/map=] matching the <code>script.GetNetworkBodyResult</code> production,
-   with the <code>data</code> field set to the <code>data</code> field of |collected data|.
+   with the <code>data</code> field set to the <code>data</code> field of |collected body|.
 
 1. Return [=success=] with data |body|.
 
@@ -8132,21 +8132,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.removeDataCollector Command ####  {#command-network-removeDataCollector}
+#### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
 
-The <dfn export for=commands>network.removeDataCollector</dfn> command removes a
-[=network data collector=].
+The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
+[=network body collector=].
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl remote-cddl">
-      network.RemoveDataCollector = (
-        method: "network.removeDataCollector",
-        params: network.RemoveDataCollectorParameters
+      network.RemoveBodyCollector = (
+        method: "network.removeBodyCollector",
+        params: network.RemoveBodyCollectorParameters
       )
 
-      network.RemoveDataCollectorParameters = {
+      network.RemoveBodyCollectorParameters = {
         collector: network.Collector
       }
     </pre>
@@ -8159,7 +8159,7 @@ The <dfn export for=commands>network.removeDataCollector</dfn> command removes a
    </dd>
 </dl>
 
-<div algorithm="remote end steps for network.removeDataCollector">
+<div algorithm="remote end steps for network.removeBodyCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector| be the value of the "<code>collector</code>" field in |command
@@ -8170,22 +8170,22 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |collectors| does not [=map/contain=] |collector|, return
    [=error=] with [=error code=] [=no such collector=].
 
-1. Let |collector data| be |collectors|[|collector|].
+1. Let |collector info| be |collectors|[|collector|].
 
 1. Let |top-level traversables to update| be an empty [=/set=].
 
-1. If |collector data|'s <code>contexts</code> field is present:
+1. If |collector info|'s <code>contexts</code> field is present:
 
-  1. For each |navigable id| of |collector data|'s <code>contexts</code> field:
+  1. For each |navigable id| of |collector info|'s <code>contexts</code> field:
 
     1. Let |navigable| be the [=/navigable=] with id |navigable id|
        if such [=/navigable=] exists, and null otherwise.
 
     1. [=set/Append=] |navigable| to |top-level traversables to update| if |navigable| is not null.
 
-1. Otherwise if |collector data|'s <code>userContexts</code> field is present:
+1. Otherwise if |collector info|'s <code>userContexts</code> field is present:
 
-  1. For each |user context id| of |collector data|'s <code>userContexts</code> field:
+  1. For each |user context id| of |collector info|'s <code>userContexts</code> field:
 
     1. Let |user context| be [=get user context=] with |user context id|.
 

--- a/index.bs
+++ b/index.bs
@@ -6482,7 +6482,7 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.DataType = "response"
 </pre>
 
@@ -6547,7 +6547,7 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Collector = text
 </pre>
 
@@ -6557,7 +6557,7 @@ The <code>network.Collector</code> type represents the id of a [=network/collect
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.CollectorType = "blob"
 </pre>
 
@@ -7564,7 +7564,7 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       network.AddDataCollector = (
         method: "network.addDataCollector",
         params: network.AddDataCollectorParameters
@@ -7581,7 +7581,7 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       network.AddDataCollectorResult = {
         collector: network.Collector
       }
@@ -8005,7 +8005,7 @@ collected network data for a given [=network/collector=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       network.DisownData = (
         method: "network.disownData",
         params: network.disownDataParameters
@@ -8115,7 +8115,7 @@ network data if it is available.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.GetData = (
         method: "network.getData",
         params: network.GetDataParameters
@@ -8131,7 +8131,7 @@ network data if it is available.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       script.GetDataResult = {
         bytes: network.BytesValue,
       }
@@ -8262,7 +8262,7 @@ The <dfn export for=commands>network.removeDataCollector</dfn> command removes a
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       network.RemoveDataCollector = (
         method: "network.removeDataCollector",
         params: network.RemoveDataCollectorParameters

--- a/index.bs
+++ b/index.bs
@@ -5941,7 +5941,6 @@ A <dfn for="network">data</dfn> is a [=/struct=] consisting of
 an [=struct/item=] named <code>bytes</code>, which is a <code>network.BytesValue</code> or null,
 an [=struct/item=] named <code>cloned body</code>, which is a [=/body=] or null,
 an [=struct/item=] named <code>collectors</code>, which is a list of <code>network.Collector</code>,
-an [=struct/item=] named <code>decode data steps</code>, which is an algorithm,
 an [=struct/item=] named <code>pending</code>, which is a boolean,
 an [=struct/item=] named <code>request</code>, which is a <code>network.Request</code>,
 an [=struct/item=] named <code>size</code>, which is a js-uint or null,
@@ -6025,7 +6024,6 @@ clients can add the collector as late as possible?
          <code>bytes</code> field set to null,
          <code>cloned body</code> field set to [=body/clone=] with |response body|,
          <code>collectors</code> field set to an empty list,
-         <code>decode data steps</code> field set null,
          <code>pending</code> field set to true,
          <code>request</code> field set to |request|'s [=request id=],
          <code>size</code> field set to null,
@@ -6100,24 +6098,22 @@ and [=clone network response body=] does not clone the corresponding body.
 
 1. Let |bytes| be null.
 
-1. Let |decodeDataSteps| be null.
-
 1. Let |size| be null.
 
 1. Let |processBody| given |nullOrBytes| be this step:
 
    1. If |nullOrBytes| is not null:
 
-      1. Optionally, set |nullOrBytes| to the result of running implementation-defined encoding steps
-         with |nullOrBytes| and let |decodeDataSteps| be the steps to reverse those encoding steps.
-
-         Note: Implementations are allowed to store encoded network data as long as they
-         are able to decode the content later on and provide the exact same |nullOrBytes| as the ones
-         exposed by fetch.
-
       1. Set |bytes| to [=serialize protocol bytes=] with |nullOrBytes|.
 
       1. Set |size| to |response|'s [=response body info=]'s [=encoded size=].
+
+         Note: There is a discrepancy between the fact that the bytes retrieved from the
+         fetch stream correspond to the dedoded data, but the encoded (network) size is
+         used in order to calculate size limits. Implementations might decide to use a storage
+         model such that it uses less size than storing the decoded data, as long as the data
+         returned to clients in getNetworkData is identical to the decoded data. The potential
+         tradeoff between storage and performance is up to the implementation.
 
 1. Let |processBodyError| be this step: Do nothing.
 
@@ -6135,8 +6131,6 @@ and [=clone network response body=] does not clone the corresponding body.
       1. [=Allocate size to record data=] given |size|.
 
 1. Set |collected data|'s <code>bytes</code> to |bytes|.
-
-1. Set |collected data|'s <code>decode data steps</code> to |decodeDataSteps|.
 
 1. Set |collected data|'s <code>pending</code> to false.
 
@@ -8184,9 +8178,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |bytes| is null,
 
    1. Return [=error=] with [=error code=] [=unavailable network data=].
-
-1. If |collected data|'s <code>decode data steps</code> is not null, set |bytes| to
-   the the result of running |collected data|'s <code>decode data steps</code>.
 
 1. Let |body| be a [=/map=] matching the <code>script.GetNetworkDataResult</code> production,
    with the <code>bytes</code> field set to |bytes|.

--- a/index.bs
+++ b/index.bs
@@ -7581,9 +7581,11 @@ The <dfn export for=commands>network.addDataCollector</dfn> adds a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <code>
-      EmptyResult
-    </code>
+    <pre class="cddl local-cddl">
+      network.AddDataCollectorResult = {
+        collector: network.Collector
+      }
+    </pre>
    </dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -6135,7 +6135,7 @@ To <dfn>update navigable network collector sizes</dfn> given |session| and |top-
 
 1. Let |match| be false.
 
-1. Let |resource max size| be 0.
+1. Let |body max size| be 0.
 
 1. Let |total max size| be 0.
 
@@ -6145,8 +6145,8 @@ To <dfn>update navigable network collector sizes</dfn> given |session| and |top-
 
     1. Set |match| to true.
 
-    1. If |collector info|["<code>resourceMaxSize</code>"] is greater than |resource max size|
-       set |resource max size| to |collector info|["<code>resourceMaxSize</code>"].
+    1. If |collector info|["<code>bodyMaxSize</code>"] is greater than |body max size|
+       set |body max size| to |collector info|["<code>bodyMaxSize</code>"].
 
     1. If |collector info|["<code>totalMaxSize</code>"] is greater than |total max size|
        set |total max size| to |collector info|["<code>totalMaxSize</code>"].
@@ -6154,7 +6154,7 @@ To <dfn>update navigable network collector sizes</dfn> given |session| and |top-
 1. If |match| is true:
 
   1. Let |sizes| be a new [=/map=] matching the <code>network.CollectorSizes</code> production,
-     with the <code>resourceMaxSize</code> field set to |resource max size|
+     with the <code>bodyMaxSize</code> field set to |body max size|
      and the <code>totalMaxSize</code> field set to |total max size|.
 
   1. [=map/Set=] |session|'s [=navigable network collector sizes=][|top-level navigable|] to |sizes|.
@@ -6516,7 +6516,7 @@ The <code>network.CollectorInfo</code> type represents a [=network data collecto
 
 <pre class="cddl local-cddl remote-cddl">
 network.CollectorSizes = {
-    resourceMaxSize: js-uint,
+    bodyMaxSize: js-uint,
     totalMaxSize: js-uint,
 };
 </pre>
@@ -7528,7 +7528,7 @@ the data collector map.
 
       network.AddDataCollectorParameters = {
         ? contexts: [+browsingContext.BrowsingContext],
-        resourceMaxSize: js-uint,
+        bodyMaxSize: js-uint,
         totalMaxSize: js-uint,
         ? userContexts: [+browser.UserContext],
       }
@@ -7550,8 +7550,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |input context ids| be [=set/create|create a set=] with
    |command parameters|[<code>contexts</code>].
 
-1. Let |resource max size| be |command parameters|
-   ["<code>resourceMaxSize</code>"].
+1. Let |body max size| be |command parameters|
+   ["<code>bodyMaxSize</code>"].
 
 1. Let |total max size| be |command parameters|
    ["<code>totalMaxSize</code>"].
@@ -7596,7 +7596,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |collector data| be a new [=/map=] matching the
    <code>network.CollectorInfo</code> production with
-   the <code>resourceMaxSize</code> field set to |resource max size|,
+   the <code>bodyMaxSize</code> field set to |body max size|,
    the <code>totalMaxSize</code> field set to |total max size|,
    the <code>userContexts</code> field set to |input user context ids| and
    the <code>contexts</code> field set to |top-level traversable ids|.

--- a/index.bs
+++ b/index.bs
@@ -308,6 +308,9 @@ spec: RFC9110; urlPrefix: https://httpwg.org/specs/rfc9110.html
   type: dfn
     text: field-name token; url: #fields.names
     text: method token; url: #method.overview
+spec: STREAMS; urlPrefix: https://streams.spec.whatwg.org/
+  type: dfn
+    text: ReadableStream; url: #readablestream
 </pre>
 
 <pre class="biblio">
@@ -635,10 +638,13 @@ with the following additional codes:
   <dd>Tried to havigate to an unknown [=session history entry=].
 
   <dt><dfn for=errors export>no such collector</dfn>
-  <dd>Tried to remove an unknown [=network body collector=].
+  <dd>Tried to remove an unknown [=network/collector=].
 
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
+
+  <dt><dfn for=errors export>no such network body</dfn>
+  <dd>Tried to reference an unknown [=network/body=].
 
   <dt><dfn for=errors export>no such node</dfn>
   <dd>Tried to deserialize an unknown <code>SharedReference</code>.
@@ -669,6 +675,10 @@ with the following additional codes:
 
   <dt><dfn for=errors export>unable to set file input</dfn>
   <dd>Tried to set a file input, but failed to do so.
+
+  <dt><dfn for=errors export>unavailable network body</dfn>
+  <dd>Tried to get network body which was not collected or already evicted.
+
 </dl>
 
 <pre class="cddl" data-cddl-module="local-cddl">
@@ -5099,11 +5109,6 @@ the <dfn export>WebDriver BiDi navigable created</dfn> steps given
    then perform implementation-defined steps to disable any implementation-specific
    resource caches for network requests originating from |navigable|.
 
-1. If |navigable| is a [=/top-level traversable=]:
-
-  1. For each |session| in [=active BiDi sessions=]
-     [=update navigable network collector sizes=] with |session| and |navigable|.
-
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
@@ -5929,6 +5934,232 @@ A [=remote end=] has a <dfn>navigable cache behavior map</dfn> which is a weak
 map between [=/top-level traversables=] and strings representing cache
 behavior. It is initially empty.
 
+### Network Body Collection### {#network-body-collection}
+
+A <dfn for="network">body</dfn> is a [=/struct=] consisting of
+an [=struct/item=] named <code>bytes</code>, which is a <code>network.BytesValue</code> or null,
+an [=struct/item=] named <code>cloned body</code>, which is a [=response/body=] or null,
+an [=struct/item=] named <code>collectors</code>, which is a list of <code>network.Collector</code>,
+an [=struct/item=] named <code>navigable</code>, which is a <code>browsingContext.BrowsingContext</code>,
+an [=struct/item=] named <code>navigation</code>, which is a <code>browsingContext.Navigation</code>,
+an [=struct/item=] named <code>request</code>, which is a <code>network.Request</code>,
+an [=struct/item=] named <code>size</code>, which is a js-uint or null,
+an [=struct/item=] named <code>type</code>, which is a <code>network.BodyType</code>.
+
+A <dfn for="network">collector</dfn> is a [=/struct=] consisting of
+an [=struct/item=] named <code>body max size</code>, which is a js-uint,
+an [=struct/item=] named <code>contexts</code>, which is a list of <code>browsingContext.BrowsingContext</code>,
+an [=struct/item=] named <code>body types</code>, which is a list of <code>network.BodyType</code>,
+an [=struct/item=] named <code>collector</code>, which is a <code>network.Collector</code>,
+an [=struct/item=] named <code>collector type</code>, which is a <code>network.CollectorType</code>,
+an [=struct/item=] named <code>total max size</code>, which is a js-uint,
+an [=struct/item=] named <code>user contexts</code>, which is a list of <code>browser.UserContext</code>.
+
+A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
+<code>network.Collector</code> and a [=network/collector=]. It is initially empty.
+
+A [=BiDi session=] has <dfn>collected network bodies</dfn> which is a list of
+[=network/body|bodies=]. It is initially empty.
+
+<div algorithm>
+To <dfn>get navigable for request</dfn> given request:
+
+1. Let |navigable| be null.
+
+1. If |request|'s [=request/window=] is an [=environment settings object=]:
+
+   1. Let |environment settings| be |request|'s [=request/window=]
+
+   1. If there is a [=/navigable=] whose [=active window=] is |environment
+      settings|' [=environment settings object/global object=], set |navigable|
+      to be that navigable.
+
+1. Return |navigable|.
+
+</div>
+
+<div algorithm>
+To <dfn>match collector for navigable</dfn> given |collector| and |navigable|:
+
+1. If |collector|'s <code>contexts</code> is not [=list/empty=]:
+
+  1. If |collector|'s <code>contexts</code> [=list/contains=] |navigable|'s [=navigable id=], return true.
+
+  1. Otherwise, return false.
+
+1. If |collector|'s <code>user contexts</code> is not [=list/empty=]:
+
+  1. Let |user context| be |navigable|'s [=associated user context=].
+
+  1. If |collector|'s <code>user contexts</code> [=list/contains=] |user context|'s [=user context id=], return true.
+
+  1. Otherwise, return false.
+
+1. Return true.
+
+</div>
+
+<div algorithm>
+To <dfn export>clone network response body</dfn> given |request| and |response body|:
+
+Note: This hook is intended to be triggered by the fetch spec when the response is set.
+
+1. Let |navigable| be [=get navigable for request=] with |request|.
+
+1. For each |session| in [=active BiDi sessions=]:
+
+   Note: Should check for collectors matching navigable + response here already?
+   Otherwise we can do it only in [=maybe collect network response body=] so that
+   clients can add the collector as late as possible?
+
+   1. Let |collected body| be a struct with
+            <code>bytes</code> field set to null,
+            <code>cloned body</code> field set to [=body/clone=] with |response body|,
+            <code>collectors</code> field set to an empty list,
+            <code>navigable</code> field set to |navigable|'s [=navigable id=],
+            <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
+            <code>request</code> field set to |request|'s [=request id=],
+            <code>size</code> field set to null,
+            <code>type</code> field set to "response".
+
+   1. [=list/Append=] |collected body| to |session|'s [=collected network bodies=].
+
+</div>
+
+<div algorithm>
+To <dfn>get collected body</dfn> given |session|, |request id| and |body type|.
+
+1. For |collected body| of |session|'s [=collected network bodies=]:
+
+   1. If |collected body|'s <code>request</code> is |request id| and
+      |collected body|'s <code>type</code> is |body type|, return |collected body|.
+
+1. Return null.
+
+</div>
+
+<div algorithm>
+To <dfn>maybe collect network response body</dfn> given |session| and |request|:
+
+1. Let |navigable| be [=get navigable for request=] with |request|.
+
+1. If |navigable| is null, return.
+
+1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
+
+1. Let |collectors| be an empty list.
+
+1. For each |collector| in |session|'s [=network collectors=]:
+
+   1. If |collector|'s <code>body types</code> [=list/contains=] "response" and if [=match collector for navigable=] with |collector| and |top-level navigable|:
+
+      1. [=list/Append=] |collector| to |collectors|.
+
+1. If |collectors| is [=list/empty=], return.
+
+1. Let |collected body| be [=get collected body=] with |session|, |request|'s [=request id=] and "response".
+
+1. Assert |collected body| is not null.
+
+1. Let |bytes| be null.
+
+1. Let |size| be null.
+
+1. Let |processBody| given |nullOrBytes| be this step:
+
+   1. If |nullOrBytes| is not null:
+
+      1. Set |bytes| to [=serialize protocol bytes=] with |nullOrBytes|.
+
+      1. Set |size| to |nullOrBytes|'s length.
+
+1. Let |processBodyError| be this step: Do nothing.
+
+1. [=Fully read=] |collected body|’s <code>cloned body</code> given |processBody| and |processBodyError|.
+
+1. If |bytes| is null, return.
+
+   Note: Should this be reflected on the collected body struct, eg with a status?
+
+1. For |collector| in |collectors|:
+
+   1. If |size| is greater than |collector|'s <code>max body size</code>, remove |collector| from |collectors|.
+
+1. If |collectors| is [=list/empty=], return.
+
+1. For |collector| in |collectors|:
+
+   1. [=Allocate size to record body=] given |session|, |navigable|, |collector| and |size|.
+
+   1. [=list/Append=] |collector|'s <code>collector</code> to |collected body|'s <code>collectors</code>
+
+1. Set |collected body|'s <code>bytes</code> to |bytes|.
+
+1. Set |collected body|'s <code>size</code> to |size|.
+
+</div>
+
+<div algorithm>
+To <dfn>allocate size to record body</dfn> given |session|, |navigable|,
+|collector| and |size|:
+
+1. Let |available size| be |collector|'s <code>max total size</code>.
+
+1. Let |already collected bodies| be an empty list.
+
+1. For each |collected body| in |session|'s [=collected network bodies=]:
+
+   1. If |collected body|'s <code>navigable</code> is not |navigable|'s
+      [=navigable id=], continue.
+
+   1. If |collected body|'s <code>collectors</code> does not [=list/contain=]
+      |collector|'s <code>collector</code>, continue.
+
+   1. If |collected body|'s <code>bytes</code> is not null:
+
+      1. Decrease |available size| by |collected body|'s <code>size</code>.
+
+      1. [=list/Append=] |collected body| to |already collected bodies|
+
+1. If |size| is greater than |available size|:
+
+   1. For each |collected body| in |already collected bodies|'s in order:
+
+      1. Increase |available size| by |collected body|'s <code>size</code>.
+
+      1. [=list/Remove=] |collector|'s <code>collector</code> from |collected body|'s
+         <code>collectors</code>.
+
+      1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
+
+         1. Set |collected body|'s <code>bytes</code> field to null.
+
+         1. Set |collected body|'s <code>size</code> field to null.
+
+      1. If |available size| is greater than or equal to |size|, return.
+
+</div>
+
+<div algorithm>
+To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
+|current navigation|:
+
+1. For each |collected body| in |session|'s [=collected network bodies=]:
+
+  1. Let |navigation| be |collected body|'s <code>navigation</code>
+     field.
+
+  1. Let |navigable id| be |collected body|'s <code>navigable</code>
+     field.
+
+  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
+
+  1. If |current navigation| is not null and |current navigation| is |navigation|, continue.
+
+  1. Set |collected body|'s <code>bytes</code> field to null.
+
+</div>
+
 ### Network Intercepts ### {#network-intercepts}
 
 A <dfn>network intercept</dfn> is a mechanism to allow remote ends to intercept
@@ -6090,184 +6321,6 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
       (|credentials|["<code>username</code>"], |credentials|["<code>password</code>"])
 
 1. Return |response|
-
-</div>
-
-### Network Data ### {#network-data}
-
-A <dfn>network body collector</dfn> is a mechanism to allow remote ends to collect
-network data such as network response bodies.
-
-A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
-network body collector id and <code>network.CollectorInfo</code>. It is initially empty.
-
-A [=BiDi session=] has <dfn>navigable network collector sizes</dfn> which is a weak map
-between [=/top-level traversables=] and <code>network.CollectorSizes</code>. It describes
-the effective collector sizes for all [=/navigables=] under a [=/top-level traversable=].
-It is initially empty.
-
-A [=BiDi session=] has <dfn>collected network bodies</dfn> which is a list of
-<code>network.CollectorBody</code>. It is initially empty.
-
-<div algorithm>
-To <dfn>match collector info</dfn> given |collector info| and |navigable|:
-
-1. If the <code>contexts</code> field of |collector info| is present:
-
-  1. If |collector info|["contexts"] [=map/contains=] |navigable|'s [=navigable id=], return true.
-
-  1. Otherwise, return false.
-
-1. If the <code>userContexts</code> field of |collector info| is present:
-
-  1. Let |user context| be |navigable|'s [=associated user context=].
-
-  1. If |collector info|["userContexts"] [=map/contains=] |user context|'s [=user context id=], return true.
-
-  1. Otherwise, return false.
-
-1. Return true.
-
-</div>
-
-<div algorithm>
-To <dfn>update navigable network collector sizes</dfn> given |session| and |top-level navigable|:
-
-1. Let |match| be false.
-
-1. Let |body max size| be 0.
-
-1. Let |total max size| be 0.
-
-1. For each |collector info| of |session|'s [=network collectors=]:
-
-  1. If [=match collector info=] with |top-level navigable| and |collector info|:
-
-    1. Set |match| to true.
-
-    1. If |collector info|["<code>bodyMaxSize</code>"] is greater than |body max size|
-       set |body max size| to |collector info|["<code>bodyMaxSize</code>"].
-
-    1. If |collector info|["<code>totalMaxSize</code>"] is greater than |total max size|
-       set |total max size| to |collector info|["<code>totalMaxSize</code>"].
-
-1. If |match| is true:
-
-  1. Let |sizes| be a new [=/map=] matching the <code>network.CollectorSizes</code> production,
-     with the <code>bodyMaxSize</code> field set to |body max size|
-     and the <code>totalMaxSize</code> field set to |total max size|.
-
-  1. [=map/Set=] |session|'s [=navigable network collector sizes=][|top-level navigable|] to |sizes|.
-
-1. Otherwise:
-
-  1. [=map/Remove=] |session|'s [=navigable network collector sizes=][|top-level navigable|]
-
-</div>
-
-<div algorithm>
-To <dfn>maybe collect network response body</dfn> given |session|, |request| and |response|:
-
-1. Let |navigable| be null.
-
-1. If |request|'s [=request/window=] is an [=environment settings object=]:
-
-  1. Let |environment settings| be |request|'s [=request/window=]
-
-  1. If there is a [=/navigable=] whose [=active window=] is |environment
-     settings|' [=environment settings object/global object=], set |navigable|
-     to be that navigable.
-
-1. If |navigable| is null, return.
-
-1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
-
-1. If |session|'s [=navigable network collector sizes=] does not [=list/contains|contain=]
-   |top-level navigable| return.
-
-1. Let |response to collect| be null.
-
-1. Let |response size| be |response|'s [=response/body=]'s [=body/length=].
-
-1. Let |sizes| be |session|'s [=navigable network collector sizes=][|top-level navigable|].
-
-1. If |response|’s [=response/body=] is not null and
-   if |sizes|' <code>maxResourceSize</code> is greater than |response size|:
-
-  1. [=Allocate size to record data=] with |session|, |navigable|, |response size| and
-     |sizes|' <code>maxTotalSize</code>.
-
-  1. Let |processBody| given |nullOrBytes| be this step:
-
-    1. If |nullOrBytes| is not null, set |response to collect| to [=serialize protocol bytes=] with |nullOrBytes|.
-
-  1. Let |processBodyError| be this step: Do nothing.
-
-  1. [=Fully read=] |response|’s [=response/body=] given |processBody| and |processBodyError|.
-
-1. Let |collector body| be a new [=/map=] matching the
-         <code>network.CollectorBody</code> production, with the
-         <code>body</code> field set to |response to collect|,
-         <code>bodyType</code> field set to "response",
-         <code>navigable</code> field set to |navigable|'s [=navigable id=],
-         <code>navigation</code> field set to |navigable|'s [=ongoing-navigation=],
-         <code>request</code> field set to |request|'s [=request id=] and
-         <code>size</code> field set to |response size|.
-
-1. [=list/Append=] |collector body| to |session|'s [=collected network bodies=].
-
-</div>
-
-<div algorithm>
-To <dfn>allocate size to record data</dfn> given |session|, |navigable|,
-|requested size| and |max total size|:
-
-1. Let |available size| be |max total size|.
-
-1. For each |collected body| in |session|'s [=collected network bodies=]:
-
-  1. Let |navigable id| be |collected body|'s <code>navigable</code>
-     field.
-
-  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
-
-  1. If |collected body|'s <code>data</code> is not null:
-
-    1. Decrease |available size| by |collected body|'s <code>size</code>.
-
-1. If |requested size| is greater than |available size|:
-
-  1. For each |collected body| in |session|'s [=collected network bodies=] in order:
-
-    1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
-
-    1. If |collected body|'s <code>data</code> is not null:
-
-      1. Increase |available size| by |collected body|'s <code>size</code>.
-
-      1. Set |collected body|'s <code>data</code> field to null.
-
-      1. If |available size| is greater than or equal to |requested size|, return.
-
-</div>
-
-<div algorithm>
-To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
-|current navigation|:
-
-1. For each |collected body| in |session|'s [=collected network bodies=]:
-
-  1. Let |navigation| be |collected body|'s <code>navigation</code>
-     field.
-
-  1. Let |navigable id| be |collected body|'s <code>navigable</code>
-     field.
-
-  1. If |navigable id| is not |navigable|'s [=navigable id=], continue.
-
-  1. If |current navigation| is not null and |current navigation| is |navigation|, continue.
-
-  1. Set |collected body|'s <code>data</code> field to null.
 
 </div>
 
@@ -6476,52 +6529,21 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 network.Collector = text
 </pre>
 
-The <code>network.Collector</code> type represents the id of a [=network body collector=].
+The <code>network.Collector</code> type represents the id of a [=network/collector=].
 
-#### The network.CollectorBody Type #### {#type-network-CollectorBody}
-
-[=Remote end definition=] and [=local end definition=]
-
-<pre class="cddl local-cddl remote-cddl">
-network.CollectorBody = {
-    body: network.BytesValue / null,
-    bodyType: network.BodyType,
-    navigable: browsingContext.BrowsingContext,
-    navigation: browsingContext.Navigation,
-    request: network.Request,
-    size: js-uint,
-};
-</pre>
-
-The <code>network.CollectorBody</code> type represents a network body stored via a
-[=network body collector=].
-
-#### The network.CollectorInfo Type #### {#type-network-CollectorInfo}
+#### The network.CollectorType Type #### {#type-network-CollectorType}
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
-network.CollectorInfo = {
-    network.CollectorSizes,
-    ? contexts: [+browsingContext.BrowsingContext],
-    ? userContexts: [+browser.UserContext],
-};
+<pre class="cddl remote-cddl local-cddl">
+network.CollectorType = "blob"
 </pre>
 
-The <code>network.CollectorInfo</code> type represents a [=network body collector=].
+Note: In the future we might also support the "stream" collector type for clients
+which want to read the bodies gathered by a given collector via a stream.
 
-#### The network.CollectorSizes Type #### {#type-network-CollectorSizes}
-
-[=Remote end definition=] and [=local end definition=]
-
-<pre class="cddl local-cddl remote-cddl">
-network.CollectorSizes = {
-    bodyMaxSize: js-uint,
-    totalMaxSize: js-uint,
-};
-</pre>
-
-The <code>network.CollectorSizes</code> type represents the sizes used by a [=network body collector=].
+The <code>network.CollectorType</code> type represents the different types of body collectors
+that can be added.
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
@@ -7514,8 +7536,8 @@ To <dfn>match URL pattern</dfn> given |url pattern| and |url string|:
 
 #### The network.addBodyCollector Command ####  {#command-network-addBodyCollector}
 
-The <dfn export for=commands>network.addBodyCollector</dfn> command configures
-the body collector map.
+The <dfn export for=commands>network.addBodyCollector</dfn> adds a
+[=network/collector=].
 
 <dl>
    <dt>Command Type</dt>
@@ -7529,6 +7551,8 @@ the body collector map.
       network.AddBodyCollectorParameters = {
         ? contexts: [+browsingContext.BrowsingContext],
         bodyMaxSize: js-uint,
+        bodyTypes: [+network.BodyType],
+        collectorType: network.collectorType,
         totalMaxSize: js-uint,
         ? userContexts: [+browser.UserContext],
       }
@@ -7545,13 +7569,19 @@ the body collector map.
 <div algorithm="remote end steps for network.addBodyCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |collector| be the string representation of a [[!RFC9562|UUID]].
+1. Let |collector id| be the string representation of a [[!RFC9562|UUID]].
 
 1. Let |input context ids| be [=set/create|create a set=] with
    |command parameters|[<code>contexts</code>].
 
 1. Let |body max size| be |command parameters|
    ["<code>bodyMaxSize</code>"].
+
+1. Let |body types| be [=set/create|create a set=] with
+   |command parameters|["<code>bodyTypes</code>"].
+
+1. Let |collector type| be |command parameters|
+   ["<code>collectorType</code>"].
 
 1. Let |total max size| be |command parameters|
    ["<code>totalMaxSize</code>"].
@@ -7562,10 +7592,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. Let |top-level traversable ids| be a [=/set=].
-
-1. Let |top-level traversables to update| be an empty [=/set=].
-
 1. If |input context ids| is not empty:
 
    1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
@@ -7575,10 +7601,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. If |navigable| is not a [=/top-level traversable=], return [=error=]
          with [=error code=] [=invalid argument=].
 
-      1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable ids|.
-
-      1. [=set/Append=] |navigable| to |top-level traversables to update|.
-
 1. Otherwise, if |input user context ids| is not empty:
 
     1. [=list/For each=] |user context id| of |input user context ids|:
@@ -7587,28 +7609,20 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
        1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
 
-       1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
-          whose [=associated user context=] is |user context|:
+1. Let |collector| be a struct with
+   <code>body max size</code> field set to |body max size|,
+   <code>body types</code> field set to |body types|,
+   <code>collector</code> field set to |collector id|,
+   <code>collector type</code> field set to |collector type|,
+   <code>contexts</code> field set to |input context ids|,
+   <code>user contexts</code> field set to |input user context ids|,
+   <code>total max size</code> field set to |total max size|.
 
-          1. [=set/Append=] |top-level traversable| to |top-level traversables to update|.
-
-1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
-
-1. Let |collector info| be a new [=/map=] matching the
-   <code>network.CollectorInfo</code> production with
-   the <code>bodyMaxSize</code> field set to |body max size|,
-   the <code>totalMaxSize</code> field set to |total max size|,
-   the <code>userContexts</code> field set to |input user context ids| and
-   the <code>contexts</code> field set to |top-level traversable ids|.
-
-1. Set |session|'s [=network collectors=][|collector|] to |collector info|.
-
-1. For each |traversable| in |top-level traversables to update|, [=update navigable network collector sizes=]
-   with |session| and |traversable|.
+1. Set |session|'s [=network collectors=][|collector id|] to |collector|.
 
 1. Return a new [=/map=] matching the
    <code>network.AddBodyCollectorResult</code> production with the
-   <code>collector</code> field set to |collector|.
+   <code>collector</code> field set to |collector id|.
 
 </div>
 
@@ -8025,6 +8039,7 @@ network body data if it is available.
 
       network.GetNetworkBodyParameters = {
         bodyType: network.BodyType,
+        collector: network.Collector,
         request: network.Request,
       }
       </pre>
@@ -8033,7 +8048,7 @@ network body data if it is available.
    <dd>
     <pre class="cddl local-cddl">
       script.GetNetworkBodyResult = {
-        data: network.BytesValue,
+        bytes: network.BytesValue,
       }
     </pre>
    </dd>
@@ -8044,30 +8059,39 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |body type| be |command parameters|["<code>bodyType</code>"].
 
+1. Let |collector id| be |command parameters|["<code>collector</code>"].
+
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
-1. Let |collected network bodies| be |session|'s [=collected network bodies=].
+1. Let |collectors| be |session|'s [=network collectors=].
 
-1. Let |match| be null.
+1. If |collectors| does not [=map/contain=] |collector id|, return
+   [=error=] with [=error code=] [=no such collector=].
 
-1. For each |collected body| of |collected network bodies|:
+1. Let |collector| be |session|'s [=network collectors=]["<code>collector id</code>"].
 
-  1. If the <code>request</code> field of |collected body| is |request id|
-     and the <code>bodyType</code> field of |collected body| is |body type|,
-     set |match| to |collected body|, break.
+1. If |collector|'s <code>collector type</code> is not "blob",
+   return error with [=error code=] [=unsupported operation=].
 
-1. If |match| is null:
+1. Let |collected body| be [=get collected body=] given |session|, |request id| and |body type|.
 
-  1. Return [=error=] with [=error code=] [=no such network body=].
+1. If |collected body| is null:
 
-1. Let |response| the <code>response</code> field of |match|.
+   1. Return [=error=] with [=error code=] [=no such network body=].
 
-1. If |response| is null,
+1. If |collected body|'s <code>collectors</code> does not [=list/contain=]
+   |collector|:
 
-  1. Return [=error=] with [=error code=] [=unavailable network body=].
+   1. Return [=error=] with [=error code=] [=no such network body=].
+
+1. Let |bytes| be |collected body|'s <code>bytes</code>.
+
+1. If |bytes| is null,
+
+   1. Return [=error=] with [=error code=] [=unavailable network body=].
 
 1. Let |body| be a [=/map=] matching the <code>script.GetNetworkBodyResult</code> production,
-   with the <code>data</code> field set to the <code>data</code> field of |collected body|.
+   with the <code>bytes</code> field set to |collected body|'s <code>bytes</code>.
 
 1. Return [=success=] with data |body|.
 
@@ -8132,10 +8156,74 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+#### The network.releaseBody Command ####  {#command-network-releaseBody}
+
+The <dfn export for=commands>network.releaseBody</dfn> command releases a
+collected network body for a given [=network/collector=].
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.ReleaseBody = (
+        method: "network.releaseBody",
+        params: network.releaseBodyParameters
+      )
+
+      network.releaseBodyParameters = {
+        bodyType: network.BodyType,
+        collector: network.Collector,
+        request: network.Request,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.releaseBody">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |body type| be the value of the "<code>bodyType</code>" field in |command
+   parameters|.
+
+1. Let |collector id| be the value of the "<code>collector</code>" field in |command
+   parameters|.
+
+1. Let |request id| be the value of the "<code>request</code>" field in |command
+   parameters|.
+
+1. Let |collectors| be |session|'s [=network collectors=].
+
+1. If |collectors| does not [=map/contain=] |collector id|, return
+   [=error=] with [=error code=] [=no such collector=].
+
+1. Let |collected body| be [=get collected body=] with |session|, |request id| and |body type|.
+
+1. If |collected body| is null, return [=error=] with [=error code=] [=no such network body=].
+
+1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
+
+   1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
+
+   1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
+
+      1. Set |collected body|'s <code>bytes</code> field to null.
+
+      1. Set |collected body|'s <code>size</code> field to null.
+
+1. Return [=success=] with data [=null=].
+
+</div>
+
 #### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
 
 The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
-[=network body collector=].
+[=network/collector=].
 
 <dl>
    <dt>Command Type</dt>
@@ -8162,46 +8250,27 @@ The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
 <div algorithm="remote end steps for network.removeBodyCollector">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |collector| be the value of the "<code>collector</code>" field in |command
+1. Let |collector id| be the value of the "<code>collector</code>" field in |command
    parameters|.
 
 1. Let |collectors| be |session|'s [=network collectors=].
 
-1. If |collectors| does not [=map/contain=] |collector|, return
+1. If |collectors| does not [=map/contain=] |collector id|, return
    [=error=] with [=error code=] [=no such collector=].
 
-1. Let |collector info| be |collectors|[|collector|].
+1. [=map/Remove=] |collector id| from |session|'s [=network collectors=].
 
-1. Let |top-level traversables to update| be an empty [=/set=].
+1. For |collected body| in |session|'s [=collected network bodies=]:
 
-1. If |collector info|'s <code>contexts</code> field is present:
+   1. If |collected body|'s <code>collectors</code> [=list/contains=] |collector id|:
 
-  1. For each |navigable id| of |collector info|'s <code>contexts</code> field:
+      1. [=list/Remove=] |collector id| from |collected body|'s <code>collectors</code>.
 
-    1. Let |navigable| be the [=/navigable=] with id |navigable id|
-       if such [=/navigable=] exists, and null otherwise.
+      1. If |collected body|'s <code>collectors</code> is [=list/empty=]:
 
-    1. [=set/Append=] |navigable| to |top-level traversables to update| if |navigable| is not null.
+         1. Set |collected body|'s <code>bytes</code> field to null.
 
-1. Otherwise if |collector info|'s <code>userContexts</code> field is present:
-
-  1. For each |user context id| of |collector info|'s <code>userContexts</code> field:
-
-    1. Let |user context| be [=get user context=] with |user context id|.
-
-    1. If |user context| is null, continue.
-
-    1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
-       whose [=associated user context=] is |user context|:
-
-      1. [=set/Append=] |top-level traversable| to |top-level traversables to update|.
-
-1. Otherwise, set |top-level traversables to update| to the list of all [=/top-level traversables=].
-
-1. [=map/Remove=] |collector| from |session|'s [=network collectors=].
-
-1. For each |traversable| in |top-level traversables to update|, [=update navigable network collector sizes=]
-   with |session| and |traversable|.
+         1. Set |collected body|'s <code>size</code> field to null.
 
 1. Return [=success=] with data [=null=].
 
@@ -8721,7 +8790,7 @@ completed</dfn> steps given |request| and |response|:
   1. Assert: |params| matches the <code>network.ResponseCompletedParameters</code>
      production.
 
-  1. [=Maybe collect network response body=] with |session|, |request| and |response|.
+  1. [=Maybe collect network response body=] with |session| and |request|.
 
   1. Let |body| be a map matching the <code>network.ResponseCompleted</code>
      production, with the <code>params</code> field set to |params|.
@@ -10885,7 +10954,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |preload script map| be |session|'s [=preload script map=].
 
 1. Set |preload script map|[|script|] to a struct with
-   <code>function  declaration</code> |function declaration|,
+   <code>function declaration</code> |function declaration|,
    <code>arguments</code> |arguments|,
    <code>contexts</code> |navigables|,
    <code>sandbox</code> |sandbox|, and

--- a/index.bs
+++ b/index.bs
@@ -5958,6 +5958,10 @@ A [=remote end=] has a <dfn>max total data size</dfn> which is an integer repres
 the size allocated to collect network data in [=collected network data=]. Its
 value is implementation-defined.
 
+Note: This allows implementations to set sensible technical limitations, without preventing
+to collect data that is fully decoded and handled by the
+handled by the browser, such as images and fonts used on a webpage.
+
 <div algorithm>
 To <dfn>get navigable for request</dfn> given request:
 

--- a/index.bs
+++ b/index.bs
@@ -8121,7 +8121,8 @@ network data if it is available.
 
       network.GetNetworkDataParameters = {
         dataType: network.DataType,
-        ?collector: network.Collector,
+        ? collector: network.Collector,
+        ? disown: bool,
         request: network.Request,
       }
       </pre>
@@ -8154,6 +8155,14 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Set |collector id| to |command parameters|["<code>collector</code>"].
 
+1. Let |disown| be false.
+
+1. If |command parameters| [=map/contains=] "<code>disown</code>",
+   set |disown| to |command parameters|["<code>disown</code>"].
+
+1. If |disown| is true and |collector id| is null, , return [=error=]
+   with [=error code=] [=invalid argument=].
+
 1. Let |collected data| be [=get collected data=] given |request id| and |data type|.
 
 1. If |collected data| is null:
@@ -8180,6 +8189,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |body| be a [=/map=] matching the <code>script.GetNetworkDataResult</code> production,
    with the <code>bytes</code> field set to |bytes|.
+
+1. If |disown| is true, [=remove collector from data=] with |collected data| and |collector id|.
 
 1. Return [=success=] with data |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -6117,7 +6117,7 @@ and [=clone network response body=] does not clone the corresponding body.
 
       1. Set |bytes| to [=serialize protocol bytes=] with |nullOrBytes|.
 
-      1. Set |size| to |nullOrBytes|'s length.
+      1. Set |size| to |response|'s [=response body info=]'s [=encoded size=].
 
 1. Let |processBodyError| be this step: Do nothing.
 

--- a/index.bs
+++ b/index.bs
@@ -635,9 +635,6 @@ with the following additional codes:
   <dt><dfn for=errors export>no such history entry</dfn>
   <dd>Tried to havigate to an unknown [=session history entry=].
 
-  <dt><dfn for=errors export>no such collector</dfn>
-  <dd>Tried to remove an unknown [=network body collector=].
-
   <dt><dfn for=errors export>no such intercept</dfn>
   <dd>Tried to remove an unknown [=network intercept=].
 
@@ -684,7 +681,6 @@ ErrorCode = "invalid argument" /
             "no such frame" /
             "no such handle" /
             "no such history entry" /
-            "no such collector" /
             "no such intercept" /
             "no such node" /
             "no such request" /
@@ -5151,7 +5147,7 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given |navigable|
    if that is not null, or an empty [=/set=] otherwise.
 
 1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
-   with |session| and |navigable|.
+   with |session|, |navigable| and null.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextDestroyed</code>" and |related navigables|:
@@ -5576,7 +5572,7 @@ given |navigable| and |navigation status|:
 1. [=Resume=] with "<code>navigation committed</code>", |navigation id|, and |navigation status|.
 
 1. For each |session| in [=active BiDi sessions=], [=delete collected response bodies=]
-   with |session| and |navigable|.
+   with |session|, |navigable| and |navigation id|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.navigationCommitted</code>" and |related navigables|:
@@ -5882,7 +5878,6 @@ relating to network requests.
 
 NetworkCommand = (
   network.AddIntercept //
-  network.AddBodyCollector //
   network.ContinueRequest //
   network.ContinueResponse //
   network.ContinueWithAuth //
@@ -5890,7 +5885,6 @@ NetworkCommand = (
   network.GetResponseBody //
   network.ProvideResponse //
   network.RemoveIntercept //
-  network.RemoveBodyCollector //
   network.SetBodyCollectorConfiguration //
   network.SetCacheBehavior
 )
@@ -6088,75 +6082,66 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 
 ### Network Responses ### {#network-responses}
 
-A <dfn>network body collector</dfn> is a mechanism to allow remote ends to collect
-the content of network request and response bodies.
+A <dfn>network body collector configuration</dfn> is a struct which defines how
+a navigable should collect the content of network request and response bodies.
 
-A [=BiDi session=] has a <dfn>network body collector map</dfn> which is a [=/map=] between
-network body collector id and a [=struct=] with fields <code>url patterns</code>,
-<code>contexts</code> and <code>user contexts</code> that define the properties
-of active network body collectors. It is initially empty.
+A [=BiDi session=] has <dfn>navigable network collector configurations</dfn> which is a weak map between [=navigables=] and [=network body collector configuration=]. It is initially empty.
 
-A [=BiDi session=] has a <dfn>response map</dfn> which is a [=/map=] between
-request id and a [=struct=] with fields <code>context</code> and <code>response</code>
-that define the collected network response bodies for the current session. It is initially empty.
+A [=BiDi session=] has <dfn>user context network collector configurations</dfn>
+which is a weak map between [=user contexts=] and [=network body collector configuration=].
+It is initially empty.
 
-A [=BiDi session=] has a <dfn>network maximum body size</dfn> which is a number defining
-the maximum size (in bytes) that should be collected for a single network body. It is
-initially null.
+A [=BiDi session=] has a <dfn>global network collector configuration</dfn> which is a [=network body collector configuration=]. It is initially null.
 
+A [=BiDi session=] has <dfn>collected responses</dfn> which is a list of
+[=struct=] with fields <code>navigable id</code>, <code>navigation</code>,
+<code>request id</code> and <code>response</code> that contains the collected
+network responses for the current session. It is initially empty.
 
 <div algorithm>
-To <dfn>match body collector</dfn> given |request|, |navigable| and |collector|:
+To <dfn>get network body collector configuration</dfn> given |session| and
+|navigable|:
 
-1. Let |url patterns| be |collector|'s url patterns.
+1. Let |top-level navigable| be [=/top-level traversable=] for |navigable|.
 
-1. Let |contexts| be |collector|'s contexts.
+1. If |session|'s [=navigable network collector configurations=]
+   [=map/contains=] |top-level navigable|:
 
-1. Let |user contexts| be |collector|'s user contexts.
+   1. Return |session|'s [=navigable network collector configurations=][|top-level navigable|].
 
-1. Let |url| be the result of running the [=URL serializer=] with |request|'s
-   [=request/URL=].
+1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. If |url patterns| is not [=list/empty=]:
+1. If |session|'s [=user context network collector configurations=]
+   [=map/contains=] |user context|:
 
-  1. Let |match| be false.
+   1. Return |session|'s [=user context network collector configurations=][|user context|].
 
-  1. For each |url pattern| in |url patterns|:
-
-    1. If [=match URL pattern=] with |url pattern| and |url|:
-
-      1. Set |match| to true.
-
-      1. Break.
-
-  1. If |match| is false, return false.
-
-1. If |contexts| is not [=list/empty=]:
-
-  1. Let |top-level navigable id| be [=/top-level traversable=]'s [=navigable id=] for |navigable|.
-
-  1. If |contexts| does not [=set/contains|contain=] |top-level navigable id|, return false.
-
-1. If |user contexts| is not [=list/empty=]:
-
-  1. Let |match| be false.
-
-  1. For each |user context id| in |user contexts|:
-
-    1. Set |user context| to [=get user context=] with |user context id|.
-
-    1. If |navigable|'s [=associated user context=] is |user context|:
-
-      1. Set |match| to true.
-
-      1. Break.
-
-  1. If |match| is false, return false.
-
-1. Return true.
+1. Return |session|'s [=global network collector configuration=].
 
 </div>
 
+<div algorithm>
+To <dfn>get available collector size</dfn> given |session|, |navigable| and |max total body size|:
+
+1. Let |available size| be |max total body size|.
+
+1. Let |collected responses| be |session|'s [=collected responses=].
+
+1. For each |collected response| of |collected responses|:
+
+  1. If the <code>response</code> field of |collected response| is null,
+     continue.
+
+  1. If the <code>navigable</code> field of |collected response| is not
+     |navigable|, continue.
+
+  1. Let |response| be the <code>response</code> field of |collected response|.
+
+  1. Remove |response|'s [=response body info=]'s [=decoded size=] from |available size|.
+
+1. Return |available size|.
+
+</div>
 
 <div algorithm>
 To <dfn>maybe collect the response body</dfn> given |session|, |request| and |response|:
@@ -6173,42 +6158,70 @@ To <dfn>maybe collect the response body</dfn> given |session|, |request| and |re
 
 1. If |navigable| is null, return.
 
-1. For each |collector| in |session|'s [=network body collector map=]:
+1. Let |collected responses| be |session|'s [=collected responses=].
 
-  1. If the result of [=match body collector=] with |request|, |navigable| and |collector| is true:
+1. Let |network body collector configuration| be the result of [=get network body collector configuration=] with |session| and |navigable|.
 
-    1. Let |response map| be |session|'s [=response map=].
+1. If |network body collector configuration| is not null:
 
-    1. Let |request id| be request's [=request id=].
+  1. Let |max total body size| be |network body collector configuration|'s
+     <code>max total body size</code>.
 
-    1. Let |navigable id| be the [=navigable id=] for |navigable|.
+  1. Let |max resource body size| be |network body collector configuration|'s
+     <code>max resource body size</code>.
 
-    1. Let |response size| be |response|'s [=response body info=]'s [=decoded size=]
+  1. Let |response size| be |response|'s [=response body info=]'s
+     [=decoded size=].
 
-    1. Let |response to collect| be null.
+  1. Let |response to collect| be null.
 
-    1. Let |maximum  size| be |session|'s [=network maximum body size=].
+  1. Let |request id| be request's [=request id=].
 
-    1. If |maximum  size| is not null and |response size|
-       is smaller than or equal to |maximum  size|:
+  1. If |response size| is less than or equal to |max resource body size|:
 
-      1. Set |response to collect| to |response|.
+    1. Set |response to collect| to |response|.
 
-    1. Set |response map|[|request id|] to a struct with <code>response</code>
-       |response to collect| and <code>context</code> |navigable id|.
+    1. If |response size| is greater than [=get available collector size=] with
+       |session|, |navigable| and |max total body size|:
 
-    1. Break.
+      1. For each |collected response| of |collected responses|:
+
+        1. If the <code>response</code> field of |collected response| is null,
+           continue.
+
+        1. If the <code>navigable</code> field of |collected response| is not
+           |navigable|, continue.
+
+        1. Set the <code>response</code> field of |collected response| to null.
+
+        1. If [=get available collector size=] with |session|, |navigable| and
+           |max total body size| is greater than |response size|, break.
+
+  1. [=list/Add=] a struct with <code>navigation</code> |navigable|'s
+     [=ongoing navigation=], <code>navigable id</code> |navigable|'s
+     [=navigable id=], <code>request id</code> |request id|,
+     <code>response</code> |response to collect| to |collected responses|.
 
 </div>
 
 
 <div algorithm>
-To <dfn>delete collected response bodies</dfn> given |session| and |navigable|:
+To <dfn>delete collected response bodies</dfn> given |session|, |navigable| and
+|navigation|:
 
-1. For each |collected response| in |session|'s [=response map=]:
+1. For each |collected response| in |session|'s [=collected responses=]:
 
-  1. If |collected response|'s [=navigable=] is |navigabke id|, set
-     |collected response|'s <code>response</code> field to null.
+  1. Let |response navigation| be collected response|'s <code>navigation</code>
+     field.
+
+  1. Let |response navigable id| be collected response|'s <code>navigable id</code>
+     field.
+
+  1. If |response navigable id| is not |navigable|'s [=navigable id=], continue.
+
+  1. If |navigation| is not null, |response navigation| is |navigation|, continue.
+
+  1. Set |collected response|'s <code>response</code> field to null.
 
 </div>
 
@@ -6398,16 +6411,6 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
    with |value| set to |text|.
 
 </div>
-
-#### The network.Collector Type #### {#type-network-Collector}
-
-[=Remote end definition=] and [=local end definition=]
-
-<pre class="cddl local-cddl remote-cddl">
-network.Collector = text
-</pre>
-
-The <code>network.Collector</code> type represents the id of a [=network body collector=].
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
@@ -7481,116 +7484,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-#### The network.addBodyCollector Command ####  {#command-network-addBodyCollector}
-
-The <dfn export for=commands>network.addBodyCollector</dfn> command adds a
-[=network body collector=].
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-      <pre class="cddl remote-cddl">
-      network.AddBodyCollector = (
-        method: "network.addBodyCollector",
-        params: network.AddBodyCollectorParameters
-      )
-
-      network.AddBodyCollectorParameters = {
-        ? contexts: [+browsingContext.BrowsingContext],
-        ? urlPatterns: [*network.UrlPattern],
-        ? userContexts: [+browser.UserContext],
-      }
-      </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <pre class="cddl local-cddl">
-      network.AddBodyCollectorResult = {
-        collector: network.Collector
-      }
-    </pre>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for network.addBodyCollector">
-The [=remote end steps=] given |session| and |command parameters| are:
-
-1. Let |collector| be the string representation of a [[!RFC9562|UUID]].
-
-1. Let |url patterns| be the <code>urlPatterns</code> field of |command
-   parameters| if present, or an empty [=/list=] otherwise.
-
-1. Let |input user context ids| be [=set/create|create a set=] with |command parameters|[<code>userContexts</code>].
-
-1. Let |input context ids| be [=set/create|create a set=] with |command parameters|[<code>contexts</code>].
-
-1. If |input user context ids| is not empty and |input context ids| is not empty,
-   return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |top-level traversable context ids| be a [=/set=].
-
-1. If |input context ids| is not empty:
-
-   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
-
-   1. If [=list/size=] of |navigables| does not equal [=list/size=] of |input context ids|:
-
-      1. Return [=error=] with [=error code=] [=invalid argument=].
-
-   1. Set |subscription navigables| be [=get top-level traversables=] with |navigables|.
-
-   1. For each |navigable| in |subscription navigables|:
-
-      1. [=set/Append=] |navigable|'s [=navigable id=] to |top-level traversable context ids|.
-
-1. Otherwise, if |input user context ids| is not empty:
-
-    1. [=list/For each=] |user context id| of |input user context ids|:
-
-       1. Let |user context| be [=get user context=] with |user context id|.
-
-       1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
-
-
-1. If the <code>contexts</code> field of |command parameters| is present:
-
-   1. Set |navigables| to an empty [=/set=].
-
-   1. For each |navigable id| of |command parameters|["<code>contexts</code>"]
-
-      1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
-         with |navigable id|.
-
-      1. If |navigable| is not a [=/top-level traversable=], return [=error=]
-         with [=error code=] [=invalid argument=].
-
-      1. Append |navigable| to |navigables|.
-
-   1. If |navigables| is an empty [=/set=], return [=error=] with [=error code=]
-      [=invalid argument=].
-
-1. Let |collector map| be |session|'s [=network body collector map=].
-
-1. Let |parsed patterns| be an empty [=/list=].
-
-1. For each |url pattern| in |url patterns|:
-
-  1. Let |parsed| be the result of [=trying=] to [=parse url pattern=] with |url
-     pattern|.
-
-  1. [=list/Append=] |parsed| to |parsed patterns|.
-
-1. Set |collector map|[|collector|] to a struct with <code>url patterns</code>
-   |parsed patterns|, <code>userContexts</code>
-   |input user context ids| and <code>contexts</code>
-   |top-level traversable context ids|.
-
-1. Return a new [=/map=] matching the
-   <code>network.AddBodyCollectorResult</code> production with the
-   <code>collector</code> field set to |collector|.
-
-</div>
-
 #### The network.continueRequest Command ####  {#command-network-continueRequest}
 
 The <dfn export for=commands>network.continueRequest</dfn> command continues a request
@@ -7935,17 +7828,26 @@ response body data if it is available.
 </dl>
 
 <div algorithm="remote end steps for network.getResponseBody">
-The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
+The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |request id| be |command parameters|["<code>request</code>"].
 
-1. If [=response map=] does not [=map/contain=] |request id|:
+1. Let |collected responses| be |session|'s [=collected responses=].
+
+1. Let |match| be null.
+
+1. For each |collected response| of |collected responses|:
+
+  1. If the <code>request id</code> field of |collected response| is |request id|,
+     set |match| to |collected response|, break.
+
+1. If |match| is null:
 
   1. Return [=error=] with [=error code=] [=no such response=].
 
-1. Let |response| be [=response map=][|request id|].
+1. Let |response| the <code>response</code> field of |match|.
 
-1. If |response|'s [=response/body=] is null,
+1. If |response| is null,
 
   1. Return [=error=] with [=error code=] [=no response body=].
 
@@ -8068,50 +7970,6 @@ requests will be affected.
 
 </div>
 
-#### The network.removeBodyCollector Command ####  {#command-network-removeBodyCollector}
-
-The <dfn export for=commands>network.removeBodyCollector</dfn> command removes a
-[=network body collector=].
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl remote-cddl">
-      network.RemoveBodyCollector = (
-        method: "network.removeBodyCollector",
-        params: network.RemoveBodyCollectorParameters
-      )
-
-      network.RemoveBodyCollectorParameters = {
-        collector: network.Collector
-      }
-    </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <code>
-      EmptyResult
-    </code>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for network.removeBodyCollector">
-The [=remote end steps=] given |session| and |command parameters| are:
-
-1. Let |collector| be the value of the "<code>collector</code>" field in |command
-   parameters|.
-
-1. Let |collector map| be |session|'s [=network body collector map=].
-
-1. If |collector map| does not [=map/contain=] |collector|, return
-   [=error=] with [=error code=] [=no such collector=].
-
-1. [=map/Remove=] |collector| from |collector map|.
-
-1. Return [=success=] with data [=null=].
-
-</div>
-
 #### The network.setBodyCollectorConfiguration Command ####  {#command-network-setBodyCollectorConfiguration}
 
 The <dfn export for=commands>network.setBodyCollectorConfiguration</dfn> command configures
@@ -8127,7 +7985,10 @@ the network body collectors.
       )
 
       network.SetBodyCollectorConfigurationParameters = {
-        maximumBodySize: js-uint,
+        ? contexts: [+browsingContext.BrowsingContext],
+        maxTotalBodySize: js-uint,
+        ?maxResourceBodySize: js-uint,
+        ? userContexts: [+browser.UserContext],
       }
     </pre>
    </dd>
@@ -8142,9 +8003,74 @@ the network body collectors.
 <div algorithm="remote end steps for network.setBodyCollectorConfiguration">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |size| be |command parameters|["<code>maximumBodySize</code>"].
+1. Let |input context ids| be [=set/create|create a set=] with
+   |command parameters|[<code>contexts</code>].
 
-1. Set |session|'s [=network maximum body size=] to |size|.
+1. Let |max total body size| be |command parameters|
+   ["<code>maxTotalBodySize</code>"].
+
+1. Let |max resource body size| be |command parameters|
+   ["<code>maxResourceBodySize</code>"].
+
+1. Let |input user context ids| be [=set/create|create a set=] with
+   |command parameters|[<code>userContexts</code>].
+
+1. If |input user context ids| is not empty and |input context ids| is not
+   empty, return [=error=] with [=error code=] [=invalid argument=].
+
+1. If |input user context ids| is not empty and |input context ids| is not
+   empty, return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |body collector configuration| be a struct with <code>max total body size</code>
+   |max total body size| and <code>max resource body size</code> |max resource body size|.
+
+1. If |input context ids| is not empty:
+
+   1. Let |navigables| be [=get navigables by ids=] with |input context ids|.
+
+   1. If [=list/size=] of |navigables| does not equal [=list/size=] of
+      |input context ids|:
+
+      1. Return [=error=] with [=error code=] [=invalid argument=].
+
+   1. Set |collector navigables| to [=get top-level traversables=] with
+      |navigables|.
+
+   1. For each |navigable| in |collector navigables|:
+
+     1. Let |navigable configurations| be |session|'s
+        [=navigable network collector configurations=].
+
+     1. [=map/Set=] |navigable configurations|[|navigable|] to |body collector configuration|.
+
+1. Otherwise, if |input user context ids| is not empty:
+
+    1. [=list/For each=] |user context id| of |input user context ids|:
+
+       1. Let |user context| be [=get user context=] with |user context id|.
+
+       1. If |user context| is null, return [=error=] with [=error code=]
+          [=invalid argument=].
+
+       1. For each |traversable| in remote end's [=/top-level traversables=]:
+
+          1. If |traversable|'s [=associated user context=] is |user context|,
+             [=map/Remove=] |session|'s [=navigable network collector configurations=][|traversable|].
+
+       1. Let |user context configurations| be |session|'s
+          [=user context network collector configurations=].
+
+       1. [=map/Set=] |user context configurations|[|user context|] to |body collector configuration|.
+
+1. Otherwise:
+
+   1. Set |session|'s [=user context network collector configurations=] to an
+      empty [=/map=].
+
+   1. Set |session|'s [=navigable network collector configurations=] to an empty
+      [=/map=].
+
+   1. Set |session|'s [=global network collector configuration=] to |body collector configuration|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -6480,7 +6480,7 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 #### The network.DataType Type #### {#type-network-dataType}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.DataType = "response"
@@ -6545,7 +6545,7 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 
 #### The network.Collector Type #### {#type-network-Collector}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Collector = text
@@ -6555,7 +6555,7 @@ The <code>network.Collector</code> type represents the id of a [=network/collect
 
 #### The network.CollectorType Type #### {#type-network-CollectorType}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.CollectorType = "blob"


### PR DESCRIPTION
Overview of what this PR aims to add:

- Concept of network body collector A network body collector is a concept similar to intercepts and events subscriptions. Clients can add/remove collectors. In theory this should be used for both requests and responses but is only applied to responses in this PR. A network body collector is a struct with contexts or userContexts, and urlPatterns. All are optional so you can potentially define a collector which will match everything (to be discussed)  

New BiDi session items:
- BiDi session has a network body collector map, similar to the intercept map. Simply stores the active body collectors
- BiDi session has a network maximum body size, js-uint to define the maximum size of collected bodies. 
- BiDi session has a network response map, which contains all the collected bodies, keyed by request id. This map is stored at session level because different sessions might have different configurations about what kind of network bodies can be collected (eg max size).

New commands: 
- new command addBodyCollector to add a new network body collector
- new command removeBodyCollector to remove an existing network body collector
- new command setNetworkBodyCollectorConfiguration, which can be used to set session's network maximum body size. In the future we might have more configuration available here, this is why this is setting a generic configuration.
- also getResponseBody, but is mostly identical to the one in https://github.com/w3c/webdriver-bidi/pull/856 . It defaults to base64 at the moment, we probably want to make it easier to receive the body as string if possible? (but I prefered to leave this command as close to the existing PR as possible)

New error:
- new error no such body collector, for removeBodyCollector

Updates to existing commands
- When a response is caught in network.responseCompleted, we attempt to collect the body if it is related to a navigable
- On navigation committed we remove the bodies of all responses linked to this navigable
- On context destroyed we also remove the bodies of all responses linked to this navigable

Note that I haven't added extra limitations to which responses are collected in responseCompleted, but we can definitely add them (eg no worker requests etc...)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/877.html" title="Last updated on Jun 20, 2025, 10:06 AM UTC (97bf084)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/877/fded1d4...juliandescottes:97bf084.html" title="Last updated on Jun 20, 2025, 10:06 AM UTC (97bf084)">Diff</a>