### PR TITLE
`input.fileDialogOpened` + `unhandledPromptBehavior:file`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11778,7 +11778,7 @@ The [=remote end event trigger=] is the
          "<code>ignore</code>", set |dismissed| to true.
 
    1. Otherwise if |user prompt handler| [=map/contains=] "<code>default</code>" and
-      |user prompt handler|["<code>fileDialog</code>"] is not equal to
+      |user prompt handler|["<code>default</code>"] is not equal to
       "<code>ignore</code>", set |dismissed| to true.
 
 1. Return |dismissed|.

--- a/index.bs
+++ b/index.bs
@@ -11725,7 +11725,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
          input.FileDialogInfo = {
             context: browsingContext.BrowsingContext,
-            element: script.SharedReference,
+            ? element: script.SharedReference,
             multiple: bool,
          }
       </pre>
@@ -11734,28 +11734,34 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 <div algorithm>
 The [=remote end event trigger=] is the
-<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element|:
-
-1. Assert |element| implements {{HTMLInputElement}}.
+<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element| and |options|:
 
 1. Let |navigable| be the |element|'s [=node document=]'s [=/navigable=].
 
 1. Let |navigable id| be |navigable|'s [=navigable id=].
 
-1. Let |multiple| be <code>true</code> if |element|'s <{input/multiple}> attribute is
-   set, or <code>false</code> otherwise.
+1. Let |multiple| be <code>false</code>.
+
+1. If |element| is not null and |element|'s <{input/multiple}> attribute is set,
+    set |multiple| to <code>true</code>.
+
+1. If |options| is not null and |options|["<code>multiple</code>"] is true,
+   set |multiple| to <code>true</code>.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
    "<code>input.fileDialogOpened</code>" and |related navigables|:
 
-  1. Let |shared id| be [=get shared id for a node=] with |element| and |session|.
-
   1. Let |params| be a [=/map=] matching the <code>input.FileDialogInfo</code>
-     production with the <code>context</code> field set to |navigable id|, the
-     <code>element</code> field set to |shared id| and <code>multiple</code> field
-     set to |multiple|.
+     production with the <code>context</code> field set to |navigable id| and
+     <code>multiple</code> field set to |multiple|.
+
+  1. If |element| is not null:
+
+    1. Let |shared id| be [=get shared id for a node=] with |element| and |session|.
+
+    1. Set |params|["<code>element</code>"] to |shared id|.
 
   1. Let |body| be a [=/map=] matching the <code>input.fileDialogOpened</code>
      production, with the <code>params</code> field set to |params|.

--- a/index.bs
+++ b/index.bs
@@ -11763,7 +11763,7 @@ steps given |session|, |element| and |picker type|.
 
 1. Let |intercepted| be <code>false</code>.
 
-Issue: Set |intercepted| based on capabilities.
+Issue: Set |intercepted| based on capabilities in WebDriver Classic.
 
 1. Return |intercepted|.
 

--- a/index.bs
+++ b/index.bs
@@ -1719,8 +1719,9 @@ session.UserPromptHandler = {
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
 
-Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" suppresses
-the dialog, but does not emit <code>cancel</code> or <code>change</code> DOM events.
+Note: <code>fileDialog</code> handles file picker. "accept" suppresses the picker but
+does not cancel nor accept it. "dismiss" cancels the picker. "ignore" keeps the
+picker open.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
 

--- a/index.bs
+++ b/index.bs
@@ -11734,7 +11734,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 <div algorithm>
 The [=remote end event trigger=] is the
-<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element|.
+<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element|:
 
 1. Assert |element| implements {{HTMLInputElement}}.
 

--- a/index.bs
+++ b/index.bs
@@ -11705,6 +11705,70 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
+### Events ### {#module-input-events}
+
+#### The input.fileDialogOpened Event #### {#event-input-fileDialogOpened}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl remote-cddl">
+         input.FileDialogOpened = (
+            method: "input.fileDialogOpened",
+            params: input.FileDialogInfo
+         )
+
+         input.FileDialogInfo = {
+            context: browsingContext.BrowsingContext,
+            element: script.SharedReference,
+            multiple: bool,
+         }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi picker shown</dfn>
+steps given |session|, |element| and |picker type|.
+
+1. If |picker type| is null, return false.
+
+1. Assert |picker type| is "<code>file upload</code>".
+
+1. Assert |element| implements {{HTMLInputElement}}.
+
+1. Let |navigable| be the |element|'s [=node document=]'s [=/navigable=].
+
+1. Let |navigable id| be |navigable|'s [=navigable id=].
+
+1. Let |multiple| be <code>true</code> if |element|'s <{input/multiple}> attribute is
+   set, or <code>false</code> otherwise.
+
+1. Let |related navigables| be a [=/set=] containing |navigable|.
+
+1. For each |session| in the [=set of sessions for which an event is enabled=] given
+   "<code>input.fileDialogOpened</code>" and |related navigables|:
+
+  1. Let |shared id| be [=get shared id for a node=] with |element| and |session|.
+
+  1. Let |params| be a [=/map=] matching the <code>input.FileDialogInfo</code>
+     production with the <code>context</code> field set to |navigable id|, the
+     <code>element</code> field set to |shared id| and <code>multiple</code> field
+     set to |multiple|.
+
+  1. Let |body| be a [=/map=] matching the <code>input.fileDialogOpened</code>
+     production, with the <code>params</code> field set to |params|.
+
+  1. [=Emit an event=] with |session| and |body|.
+
+1. Let |intercepted| be <code>false</code>.
+
+Issue: Set |intercepted| based on capabilities.
+
+1. Return |intercepted|.
+
+</div>
+
 
 ## The webExtension Module ## {#module-webExtension}
 

--- a/index.bs
+++ b/index.bs
@@ -1711,12 +1711,16 @@ session.UserPromptHandler = {
   ? beforeUnload: session.UserPromptHandlerType,
   ? confirm: session.UserPromptHandlerType,
   ? default: session.UserPromptHandlerType,
+  ? fileDialog: session.UserPromptHandlerType,
   ? prompt: session.UserPromptHandlerType,
 };
 </pre>
 
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
+
+Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" suppresses
+the dialog, but does not emit <code>cancel</code> or <code>change</code> DOM events.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
 

--- a/index.bs
+++ b/index.bs
@@ -11773,7 +11773,7 @@ The [=remote end event trigger=] is the
 
 1. Let |dismissed| be false.
 
-1. For each |session| in [=active BiDI sessions=]:
+1. For each |session| in [=active BiDi sessions=]:
 
   1. Let |user prompt handler| be |session|'s [=user prompt handler=].
 

--- a/index.bs
+++ b/index.bs
@@ -11727,7 +11727,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
             context: browsingContext.BrowsingContext,
             ? element: script.SharedReference,
             multiple: bool,
-            directory: bool,
          }
       </pre>
    </dd>
@@ -11744,8 +11743,6 @@ The [=remote end event trigger=] is the
 
 1. Let |multiple| be <code>false</code>.
 
-1. Let |directory| be <code>false</code>.
-
 1. If |element| is not null and |element|'s <{input/multiple}> attribute is set,
     set |multiple| to <code>true</code>.
 
@@ -11754,18 +11751,14 @@ The [=remote end event trigger=] is the
    1. If |file picker options|["<code>multiple</code>"] is true, set |multiple| to
       <code>true</code>.
 
-   1. If |file picker options|["<code>directory</code>"] is true, set |directory| to
-      <code>true</code>.
-
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
    "<code>input.fileDialogOpened</code>" and |related navigables|:
 
   1. Let |params| be a [=/map=] matching the <code>input.FileDialogInfo</code>
-     production with the <code>context</code> field set to |navigable id|,
-     <code>multiple</code> field set to |multiple| and <code>directory</code> field
-     set to |directory|.
+     production with the <code>context</code> field set to |navigable id| and
+     <code>multiple</code> field set to |multiple|.
 
   1. If |element| is not null:
 

--- a/index.bs
+++ b/index.bs
@@ -1712,7 +1712,7 @@ session.UserPromptHandler = {
   ? beforeUnload: session.UserPromptHandlerType,
   ? confirm: session.UserPromptHandlerType,
   ? default: session.UserPromptHandlerType,
-  ? fileDialog: session.UserPromptHandlerType,
+  ? file: session.UserPromptHandlerType,
   ? prompt: session.UserPromptHandlerType,
 };
 </pre>
@@ -1720,7 +1720,7 @@ session.UserPromptHandler = {
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
 
-Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" dismisses
+Note: <code>file</code> handles file picker. "accept" and "dismiss" dismisses
 the picker. "ignore" keeps the picker open.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
@@ -11772,9 +11772,9 @@ The [=remote end event trigger=] is the
 
    1. Assert |user prompt handler| is a [=/map=].
 
-   1. If |user prompt handler| [=map/contains=] "<code>fileDialog</code>":
+   1. If |user prompt handler| [=map/contains=] "<code>file</code>":
 
-      1. if |user prompt handler|["<code>fileDialog</code>"] is not equal to
+      1. if |user prompt handler|["<code>file</code>"] is not equal to
          "<code>ignore</code>", set |dismissed| to true.
 
    1. Otherwise if |user prompt handler| [=map/contains=] "<code>default</code>" and

--- a/index.bs
+++ b/index.bs
@@ -11734,7 +11734,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 <div algorithm>
 The [=remote end event trigger=] is the
-<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element| and |options|:
+<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element| and optionally
+|file picker options| (default: null):
 
 1. Let |navigable| be the |element|'s [=node document=]'s [=/navigable=].
 
@@ -11745,7 +11746,7 @@ The [=remote end event trigger=] is the
 1. If |element| is not null and |element|'s <{input/multiple}> attribute is set,
     set |multiple| to <code>true</code>.
 
-1. If |options| is not null and |options|["<code>multiple</code>"] is true,
+1. If |file picker options| is not null and |file picker options|["<code>multiple</code>"] is true,
    set |multiple| to <code>true</code>.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.

--- a/index.bs
+++ b/index.bs
@@ -11813,11 +11813,11 @@ steps given |session|, |element| and |picker type|.
 
   1. If |session|'s [=suppress file dialog flag=] is true, set |suppressed| to true.
 
-1. Let |user prompt handler| be [=user prompt handler=].
+  1. Let |user prompt handler| be |session|'s [=user prompt handler=].
 
-1. Let |dismissed| be false.
+  1. Let |dismissed| be false.
 
-1. If |user prompt handler| is not null:
+  1. If |user prompt handler| is not null:
 
    1. Assert |user prompt handler| is a [=map=].
 
@@ -11830,13 +11830,7 @@ steps given |session|, |element| and |picker type|.
       |user prompt handler|["<code>fileDialog</code>"] is not equal to
       "<code>ignore</code>", set |dismissed| to true.
 
-1. If |dismissed| is true:
-
-  1. Dismiss the file dialog and return true.
-
-Issue: Specify what dismiss means.
-
-1. Return |intercepted| or |suppressed|.
+1. Return (|suppressed|, |dismissed|).
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -11727,6 +11727,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
             context: browsingContext.BrowsingContext,
             ? element: script.SharedReference,
             multiple: bool,
+            directory: bool,
          }
       </pre>
    </dd>
@@ -11743,11 +11744,18 @@ The [=remote end event trigger=] is the
 
 1. Let |multiple| be <code>false</code>.
 
+1. Let |directory| be <code>false</code>.
+
 1. If |element| is not null and |element|'s <{input/multiple}> attribute is set,
     set |multiple| to <code>true</code>.
 
-1. If |file picker options| is not null and |file picker options|["<code>multiple</code>"] is true,
-   set |multiple| to <code>true</code>.
+1. If |file picker options| is not null:
+
+   1. If |file picker options|["<code>multiple</code>"] is true, set |multiple| to
+      <code>true</code>.
+
+   1. If |file picker options|["<code>directory</code>"] is true, set |directory| to
+      <code>true</code>.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
@@ -11755,8 +11763,9 @@ The [=remote end event trigger=] is the
    "<code>input.fileDialogOpened</code>" and |related navigables|:
 
   1. Let |params| be a [=/map=] matching the <code>input.FileDialogInfo</code>
-     production with the <code>context</code> field set to |navigable id| and
-     <code>multiple</code> field set to |multiple|.
+     production with the <code>context</code> field set to |navigable id|,
+     <code>multiple</code> field set to |multiple| and <code>directory</code> field
+     set to |directory|.
 
   1. If |element| is not null:
 

--- a/index.bs
+++ b/index.bs
@@ -2287,7 +2287,7 @@ BrowserResult = (
 
 Each [=/top-level traversable=] is associated with a single <dfn>client
 window</dfn> which represents a rectangular area containing the
-<a spec=css22>viewport</a> that will be used to render that [=/top-level
+<a spec=css2>viewport</a> that will be used to render that [=/top-level
 traversable=]'s [=active document=] when its [=visibility state=] is
 "<code>visible</code>", as well as any browser-specific user interface elements
 associated with displaying the traversable (e.g. any URL bar, toolbars, or OS
@@ -11770,7 +11770,7 @@ The [=remote end event trigger=] is the
 
   1. If |user prompt handler| is not null:
 
-   1. Assert |user prompt handler| is a [=map=].
+   1. Assert |user prompt handler| is a [=/map=].
 
    1. If |user prompt handler| [=map/contains=] "<code>fileDialog</code>":
 

--- a/index.bs
+++ b/index.bs
@@ -11734,7 +11734,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 <div algorithm>
 The [=remote end event trigger=] is the
-<dfn export>WebDriver BiDi file dialog shown</dfn> steps, given |element|.
+<dfn export>WebDriver BiDi file dialog opened</dfn> steps, given |element|.
 
 1. Assert |element| implements {{HTMLInputElement}}.
 

--- a/index.bs
+++ b/index.bs
@@ -11733,12 +11733,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver BiDi picker shown</dfn>
-steps given |session|, |element| and |picker type|.
-
-1. If |picker type| is null, return false.
-
-1. Assert |picker type| is "<code>file upload</code>".
+The [=remote end event trigger=] is the
+<dfn export>WebDriver BiDi file dialog shown</dfn> steps given |session| and
+|element|.
 
 1. Assert |element| implements {{HTMLInputElement}}.
 
@@ -11768,9 +11765,9 @@ steps given |session|, |element| and |picker type|.
 
   1. [=Emit an event=] with |session| and |body|.
 
-  1. Let |user prompt handler| be |session|'s [=user prompt handler=].
+1. 1. For each |session| in [=active BiDI sessions=]:
 
-  1. Let |dismissed| be false.
+  1. Let |user prompt handler| be |session|'s [=user prompt handler=].
 
   1. If |user prompt handler| is not null:
 

--- a/index.bs
+++ b/index.bs
@@ -1711,7 +1711,7 @@ session.UserPromptHandler = {
   ? beforeUnload: session.UserPromptHandlerType,
   ? confirm: session.UserPromptHandlerType,
   ? default: session.UserPromptHandlerType,
-  ? fileDialog: session.UserPromptHandlerType,
+  ? fileUpload: session.UserPromptHandlerType,
   ? prompt: session.UserPromptHandlerType,
 };
 </pre>
@@ -1719,9 +1719,8 @@ session.UserPromptHandler = {
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
 
-Note: <code>fileDialog</code> handles file picker. "accept" suppresses the picker but
-does not cancel nor accept it. "dismiss" cancels the picker. "ignore" keeps the
-picker open.
+Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" cancels
+the picker. "ignore" keeps the picker open.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
 

--- a/index.bs
+++ b/index.bs
@@ -112,6 +112,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: unable to capture screen; url: dfn-unable-to-capture-screen
     text: unknown command; url: dfn-unknown-command
     text: unknown error; url: dfn-unknown-error
+    text: user prompt handler; url: dfn-user-prompt-handler
     text: unsupported operation; url: dfn-unsupported-operation
     text: web element reference; url: dfn-web-element-reference
     text: webdriver-active flag; url: dfn-webdriver-active-flag
@@ -1293,6 +1294,16 @@ with parameters |session|, |capabilities|, and |flags| is:
 
 1. Set |session|'s [=BiDi flag=] to true.
 
+1. Let |suppress file dialog flag| be false.
+
+1. If |capabilities| contains a property named "<code>suppressFileDialog</code>":
+
+   1. Assert |capabilities|["<code>suppressFileDialog</code>"] is a boolean.
+
+   1. Set |suppress file dialog flag| to |capabilities|["<code>suppressFileDialog</code>"].
+
+1. Set |session|'s [=suppress file dialog flag=] to |suppress file dialog flag|.
+
 1. Append "<code>bidi</code>" to flags.
 
 </div>
@@ -1610,6 +1621,7 @@ session.CapabilityRequest = {
   ? browserVersion: text,
   ? platformName: text,
   ? proxy: session.ProxyConfiguration,
+  ? suppressFileDialog: bool,
   ? unhandledPromptBehavior: session.UserPromptHandler,
   Extensible
 };
@@ -1629,6 +1641,13 @@ Value type: boolean
 Description: Defines the current session's support for bidirectional connection.
 </pre>
 
+<pre class=simpledef>
+Capability: <dfn>suppress file dialog</dfn>
+Key: "<code>suppressFileDialog</code>"
+Value type: boolean
+Description: Defines whether the remote end should suppress file dialogs.
+</pre>
+
 <div algorithm="webSocketUrl capability deserialization algorithm">
 The [=additional capability deserialization algorithm=] for the
 "<code>webSocketUrl</code>" capability, with parameter |value| is:
@@ -1643,6 +1662,27 @@ The [=additional capability deserialization algorithm=] for the
 <div algorithm="webSocketUrl capability serialization algorithm">
 The [=matched capability serialization algorithm=] for the "<code>webSocketUrl</code>" capability,
 with parameter |value| is:
+
+1. If |value| is false, return [=success=] with data null.
+
+1. Return [=success=] with data true.
+
+</div>
+
+<div algorithm="suppressFileDialog capability deserialization algorithm">
+The [=additional capability deserialization algorithm=] for the
+"<code>suppressFileDialog</code>" capability, with parameter |value| is:
+
+1. If |value| is not a boolean, return [=error=] with [=error code|code=]
+   [=invalid argument=].
+
+1. Return [=success=] with data |value|.
+
+</div>
+
+<div algorithm="suppressFileDialog capability serialization algorithm">
+The [=matched capability serialization algorithm=] for the
+"<code>suppressFileDialog</code>" capability, with parameter |value| is:
 
 1. If |value| is false, return [=success=] with data null.
 
@@ -1711,7 +1751,7 @@ session.UserPromptHandler = {
   ? beforeUnload: session.UserPromptHandlerType,
   ? confirm: session.UserPromptHandlerType,
   ? default: session.UserPromptHandlerType,
-  ? fileUpload: session.UserPromptHandlerType,
+  ? fileDialog: session.UserPromptHandlerType,
   ? prompt: session.UserPromptHandlerType,
 };
 </pre>
@@ -1865,6 +1905,7 @@ This is a [=static command=].
           browserVersion: text,
           platformName: text,
           setWindowRect: bool,
+          suppressFileDialog: bool,
           userAgent: text,
           ? proxy: session.ProxyConfiguration,
           ? unhandledPromptBehavior: session.UserPromptHandler,
@@ -11711,6 +11752,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 ### Events ### {#module-input-events}
 
+A [=BiDi session=] has an <dfn>suppress file dialog flag</dfn> which is a boolean. It
+indicates whether the file dialogs should be suppressed.
+
 #### The input.fileDialogOpened Event #### {#event-input-fileDialogOpened}
 
 <dl>
@@ -11750,6 +11794,8 @@ steps given |session|, |element| and |picker type|.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
+1. Let |suppressed| be false.
+
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
    "<code>input.fileDialogOpened</code>" and |related navigables|:
 
@@ -11765,11 +11811,32 @@ steps given |session|, |element| and |picker type|.
 
   1. [=Emit an event=] with |session| and |body|.
 
-1. Let |intercepted| be <code>false</code>.
+  1. If |session|'s [=suppress file dialog flag=] is true, set |suppressed| to true.
 
-Issue: Set |intercepted| based on capabilities in WebDriver Classic.
+1. Let |user prompt handler| be [=user prompt handler=].
 
-1. Return |intercepted|.
+1. Let |dismissed| be false.
+
+1. If |user prompt handler| is not null:
+
+   1. Assert |user prompt handler| is a [=map=].
+
+   1. If |user prompt handler| [=map/contains=] "<code>fileDialog</code>":
+
+      1. if |user prompt handler|["<code>fileDialog</code>"] is not equal to
+         "<code>ignore</code>", set |dismissed| to true.
+
+   1. Otherwise if |user prompt handler| [=map/contains=] "<code>default</code>" and
+      |user prompt handler|["<code>fileDialog</code>"] is not equal to
+      "<code>ignore</code>", set |dismissed| to true.
+
+1. If |dismissed| is true:
+
+  1. Dismiss the file dialog and return true.
+
+Issue: Specify what dismiss means.
+
+1. Return |intercepted| or |suppressed|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -11734,8 +11734,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 <div algorithm>
 The [=remote end event trigger=] is the
-<dfn export>WebDriver BiDi file dialog shown</dfn> steps given |session| and
-|element|.
+<dfn export>WebDriver BiDi file dialog shown</dfn> steps, given |element|.
 
 1. Assert |element| implements {{HTMLInputElement}}.
 
@@ -11747,8 +11746,6 @@ The [=remote end event trigger=] is the
    set, or <code>false</code> otherwise.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
-
-1. Let |dismissed| be false.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
    "<code>input.fileDialogOpened</code>" and |related navigables|:
@@ -11764,6 +11761,8 @@ The [=remote end event trigger=] is the
      production, with the <code>params</code> field set to |params|.
 
   1. [=Emit an event=] with |session| and |body|.
+
+1. Let |dismissed| be false.
 
 1. 1. For each |session| in [=active BiDI sessions=]:
 

--- a/index.bs
+++ b/index.bs
@@ -1720,7 +1720,7 @@ session.UserPromptHandler = {
 The <code>session.UserPromptHandler</code> type represents the configuration of
 the user prompt handler.
 
-Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" cancels
+Note: <code>fileDialog</code> handles file picker. "accept" and "dismiss" dismisses
 the picker. "ignore" keeps the picker open.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}

--- a/index.bs
+++ b/index.bs
@@ -1294,16 +1294,6 @@ with parameters |session|, |capabilities|, and |flags| is:
 
 1. Set |session|'s [=BiDi flag=] to true.
 
-1. Let |suppress file dialog flag| be false.
-
-1. If |capabilities| contains a property named "<code>suppressFileDialog</code>":
-
-   1. Assert |capabilities|["<code>suppressFileDialog</code>"] is a boolean.
-
-   1. Set |suppress file dialog flag| to |capabilities|["<code>suppressFileDialog</code>"].
-
-1. Set |session|'s [=suppress file dialog flag=] to |suppress file dialog flag|.
-
 1. Append "<code>bidi</code>" to flags.
 
 </div>
@@ -1621,7 +1611,6 @@ session.CapabilityRequest = {
   ? browserVersion: text,
   ? platformName: text,
   ? proxy: session.ProxyConfiguration,
-  ? suppressFileDialog: bool,
   ? unhandledPromptBehavior: session.UserPromptHandler,
   Extensible
 };
@@ -1641,13 +1630,6 @@ Value type: boolean
 Description: Defines the current session's support for bidirectional connection.
 </pre>
 
-<pre class=simpledef>
-Capability: <dfn>suppress file dialog</dfn>
-Key: "<code>suppressFileDialog</code>"
-Value type: boolean
-Description: Defines whether the remote end should suppress file dialogs.
-</pre>
-
 <div algorithm="webSocketUrl capability deserialization algorithm">
 The [=additional capability deserialization algorithm=] for the
 "<code>webSocketUrl</code>" capability, with parameter |value| is:
@@ -1662,27 +1644,6 @@ The [=additional capability deserialization algorithm=] for the
 <div algorithm="webSocketUrl capability serialization algorithm">
 The [=matched capability serialization algorithm=] for the "<code>webSocketUrl</code>" capability,
 with parameter |value| is:
-
-1. If |value| is false, return [=success=] with data null.
-
-1. Return [=success=] with data true.
-
-</div>
-
-<div algorithm="suppressFileDialog capability deserialization algorithm">
-The [=additional capability deserialization algorithm=] for the
-"<code>suppressFileDialog</code>" capability, with parameter |value| is:
-
-1. If |value| is not a boolean, return [=error=] with [=error code|code=]
-   [=invalid argument=].
-
-1. Return [=success=] with data |value|.
-
-</div>
-
-<div algorithm="suppressFileDialog capability serialization algorithm">
-The [=matched capability serialization algorithm=] for the
-"<code>suppressFileDialog</code>" capability, with parameter |value| is:
 
 1. If |value| is false, return [=success=] with data null.
 
@@ -1905,7 +1866,6 @@ This is a [=static command=].
           browserVersion: text,
           platformName: text,
           setWindowRect: bool,
-          suppressFileDialog: bool,
           userAgent: text,
           ? proxy: session.ProxyConfiguration,
           ? unhandledPromptBehavior: session.UserPromptHandler,
@@ -11752,9 +11712,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 ### Events ### {#module-input-events}
 
-A [=BiDi session=] has an <dfn>suppress file dialog flag</dfn> which is a boolean. It
-indicates whether the file dialogs should be suppressed.
-
 #### The input.fileDialogOpened Event #### {#event-input-fileDialogOpened}
 
 <dl>
@@ -11794,7 +11751,7 @@ steps given |session|, |element| and |picker type|.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
-1. Let |suppressed| be false.
+1. Let |dismissed| be false.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
    "<code>input.fileDialogOpened</code>" and |related navigables|:
@@ -11810,8 +11767,6 @@ steps given |session|, |element| and |picker type|.
      production, with the <code>params</code> field set to |params|.
 
   1. [=Emit an event=] with |session| and |body|.
-
-  1. If |session|'s [=suppress file dialog flag=] is true, set |suppressed| to true.
 
   1. Let |user prompt handler| be |session|'s [=user prompt handler=].
 
@@ -11830,7 +11785,7 @@ steps given |session|, |element| and |picker type|.
       |user prompt handler|["<code>fileDialog</code>"] is not equal to
       "<code>ignore</code>", set |dismissed| to true.
 
-1. Return (|suppressed|, |dismissed|).
+1. Return |dismissed|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -11764,7 +11764,7 @@ The [=remote end event trigger=] is the
 
 1. Let |dismissed| be false.
 
-1. 1. For each |session| in [=active BiDI sessions=]:
+1. For each |session| in [=active BiDI sessions=]:
 
   1. Let |user prompt handler| be |session|'s [=user prompt handler=].
 

--- a/index.bs
+++ b/index.bs
@@ -11783,7 +11783,7 @@ The [=remote end event trigger=] is the
 
    1. If |user prompt handler| [=map/contains=] "<code>file</code>":
 
-      1. if |user prompt handler|["<code>file</code>"] is not equal to
+      1. If |user prompt handler|["<code>file</code>"] is not equal to
          "<code>ignore</code>", set |dismissed| to true.
 
    1. Otherwise if |user prompt handler| [=map/contains=] "<code>default</code>" and


### PR DESCRIPTION
This PR implements `input.fileDialogOpened` event and defines `unhandledPromptBehavior` for `file`. It should be accompanied by the following changes:
HTML spec: https://github.com/whatwg/html/pull/11030
WebDriver Classic spec: https://github.com/w3c/webdriver/pull/1884
File system access: https://github.com/WICG/file-system-access/pull/452

Open questions:
1. Should the dialogs be dismissed, or just suppressed in case of user passes "accept" / "ignore"? Current implementation cancels the dialog, which is consistent with other user prompts.
2. Should the event be merged into `browsingContext.userPromptOpened`? If so, there will be no way of subscribing only for `input.fileDialogOpened` event. Also, file dialogs are specific, as it does not support `browsingContext.handleUserPrompt`.

Re-imagining the https://github.com/w3c/webdriver-bidi/pull/568, addressing https://github.com/w3c/webdriver-bidi/issues/494.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/883.html" title="Last updated on Mar 5, 2025, 2:12 PM UTC (fa3aba7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/883/198ddae...fa3aba7.html" title="Last updated on Mar 5, 2025, 2:12 PM UTC (fa3aba7)">Diff</a>