### PR TITLE
Fix build by referencing css2 instead of css22

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2282,7 +2282,7 @@ BrowserResult = (
 
 Each [=/top-level traversable=] is associated with a single <dfn>client
 window</dfn> which represents a rectangular area containing the
-<a spec=css22>viewport</a> that will be used to render that [=/top-level
+<a spec=css2>viewport</a> that will be used to render that [=/top-level
 traversable=]'s [=active document=] when its [=visibility state=] is
 "<code>visible</code>", as well as any browser-specific user interface elements
 associated with displaying the traversable (e.g. any URL bar, toolbars, or OS


### PR DESCRIPTION
The build started failing again because the spec CSS 2.2 got ignored, see https://github.com/w3c/browser-specs/pull/1699.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/884.html" title="Last updated on Feb 25, 2025, 1:52 PM UTC (78e0f24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/884/198ddae...lutien:78e0f24.html" title="Last updated on Feb 25, 2025, 1:52 PM UTC (78e0f24)">Diff</a>