### PR TITLE
Add "emulation.setGeolocationOverride" command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5629,6 +5629,10 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
 
 The [=remote end steps=] with |command parameters| are:
 
+1. If |command parameters| [=map/contains=] "<code>altitudeAccuracy</code>"
+   and |command parameters| doesn't [=map/contain=] "<code>altitude</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
    and |command parameters| [=map/contains=] "<code>context</code>",
    return [=error=] with [=error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5575,12 +5575,12 @@ EmulationCommand = (
 
 A <dfn>geolocation override</dfn> is a [=struct=] with an [=struct/item=] named
 <dfn attribute for="geolocation override">latitude</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">longitude</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">accuracy</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">altitude</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">altitudeAccuracy</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">heading</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="viewport-dimensions">speed</dfn> which is a float or null.
+a [=struct/item=] named <dfn attribute for="geolocation override">longitude</dfn> which is a float,
+a [=struct/item=] named <dfn attribute for="geolocation override">accuracy</dfn> which is a float,
+a [=struct/item=] named <dfn attribute for="geolocation override">altitude</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="geolocation override">altitudeAccuracy</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="geolocation override">heading</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="geolocation override">speed</dfn> which is a float or null.
 
 A [=remote end=] has a <dfn>geolocation overrides map</dfn> which is a weak map between [=user contexts=] and [=geolocation override=].
 

--- a/index.bs
+++ b/index.bs
@@ -5574,8 +5574,7 @@ EmulationCommand = (
 </pre>
 
 A <dfn>geolocation override</dfn> is a [=struct=] with:
-* [=struct/item=] named
-<dfn attribute for="geolocation override">latitude</dfn> which is a float;
+* [=struct/item=] named <dfn attribute for="geolocation override">latitude</dfn> which is a float;
 * [=struct/item=] named <dfn attribute for="geolocation override">longitude</dfn> which is a float;
 * [=struct/item=] named <dfn attribute for="geolocation override">accuracy</dfn> which is a float;
 * [=struct/item=] named <dfn attribute for="geolocation override">altitude</dfn> which is a float or null;

--- a/index.bs
+++ b/index.bs
@@ -180,6 +180,9 @@ spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
     text: y coordinate; url: rectangle-y-coordinate
     text: width dimension; url: rectangle-width-dimension
     text: height dimension; url: rectangle-height-dimension
+spec: GEOLOCATION; urlPrefix: https://www.w3.org/TR/geolocation/
+  type: dfn
+    text: set emulated position data; url: #dfn-set-emulated-position-data
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     text: 2D context creation algorithm; url: canvas.html#2d-context-creation-algorithm
@@ -12270,10 +12273,6 @@ Insert the following steps at the start of the [=determine the device pixel rati
 
 1. If [=device pixel ratio overrides=] [=map/contains=] <var ignore>window</var>'s [=window/navigable=], return [=device pixel ratio overrides=][<var ignore>window</var>'s [=window/navigable=]].
 
-
-## Geolocation ## {#patchs-geolocation}
-
-<dfn>Set emulated position data</dfn> algorithm is going to be added in the geolocation specification.
 
 # Appendices # {#appendices}
 

--- a/index.bs
+++ b/index.bs
@@ -1191,6 +1191,25 @@ To <dfn>get valid navigables by ids</dfn> given a [=/list=] of context ids |navi
 
 </div>
 
+<div algorithm>
+
+To <dfn>get valid top-level traversables by ids</dfn> given a [=/list=] of context ids |navigable ids|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each |navigable id| in |navigable ids|:
+
+   1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |navigable id|.
+
+   1. If |navigable| is not a [=/top-level traversable=], return [=error=]
+      with [=error code=] [=invalid argument=].
+
+   1. [=set/Append=] |navigable| to |result|.
+
+1. Return [=success=] with data |result|.
+
+</div>
+
 <div algorithm> To <dfn export>emit an event</dfn> given |session|, and |body|:
 
 1. [=Assert=]: |body| has [=map/size=] 2 and [=map/contains=] "<code>method</code>"
@@ -1517,6 +1536,24 @@ To <dfn export>get user context</dfn> given |user context id|:
    1. Return |user context|.
 
 1. Return null.
+
+</div>
+
+<div algorithm>
+
+To <dfn export>get valid user contexts</dfn> given |user context ids|:
+
+1. Let |result| be an empty [=/set=].
+
+1. For each |user context id| of |user context ids|:
+
+   1. Set |user context| to [=get user context=] with |user context id|.
+
+   1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
+
+   1. [=set/Append=] |user context| to |result|.
+
+1. Return |result|.
 
 </div>
 
@@ -4770,15 +4807,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Otherwise, if the <code>userContexts</code> field of |command parameters| is present:
 
-   1. Let |user contexts| be a [=/set=].
-
-   1. For each |user context id| of |command parameters|["<code>userContexts</code>"]:
-
-      1. Set |user context| to [=get user context=] with |user context id|.
-
-      1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
-
-      1. [=set/Append=] |user context| to |user contexts|.
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with |command parameters|["<code>userContexts</code>"].
 
    1. For each |user context| of |user contexts|:
 
@@ -5604,31 +5633,19 @@ The [=remote end steps=] with |command parameters| are:
    and |command parameters| [=map/contains=] "<code>context</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
+1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
+   and |command parameters| doesn't [=map/contains=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
 1. Let |navigables| be a [=/set=].
 
 1. If the <code>contexts</code> field of |command parameters| is present:
 
-   1. For each |context| of |command parameters|["<code>contexts</code>"]:
-
-      1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with
-         |context|.
-
-      1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
-         [=error code=] [=invalid argument=].
-
-      1. [=set/Append=] |navigable| to |navigables|.
+   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=] with |command parameters|["<code>contexts</code>"].
 
 1. Otherwise, if the <code>userContexts</code> field of |command parameters| is present:
 
-   1. Let |user contexts| be a [=/set=].
-
-   1. For each |user context id| of |command parameters|["<code>userContexts</code>"]:
-
-      1. Set |user context| to [=get user context=] with |user context id|.
-
-      1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
-
-      1. [=set/Append=] |user context| to |user contexts|.
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with |command parameters|["<code>userContexts</code>"].
 
    1. For each |user context| of |user contexts|:
 
@@ -5638,8 +5655,6 @@ The [=remote end steps=] with |command parameters| are:
          whose [=associated user context=] is |user context|:
 
          1. [=list/Append=] |top-level traversable| to |navigables|.
-
-1. Otherwise, return [=error=] with [=error code=] [=invalid argument=].
 
 1. For each |navigable| of |navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -5573,14 +5573,15 @@ EmulationCommand = (
 )
 </pre>
 
-A <dfn>geolocation override</dfn> is a [=struct=] with an [=struct/item=] named
-<dfn attribute for="geolocation override">latitude</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="geolocation override">longitude</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="geolocation override">accuracy</dfn> which is a float,
-a [=struct/item=] named <dfn attribute for="geolocation override">altitude</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="geolocation override">altitudeAccuracy</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="geolocation override">heading</dfn> which is a float or null,
-a [=struct/item=] named <dfn attribute for="geolocation override">speed</dfn> which is a float or null.
+A <dfn>geolocation override</dfn> is a [=struct=] with:
+* [=struct/item=] named
+<dfn attribute for="geolocation override">latitude</dfn> which is a float;
+* [=struct/item=] named <dfn attribute for="geolocation override">longitude</dfn> which is a float;
+* [=struct/item=] named <dfn attribute for="geolocation override">accuracy</dfn> which is a float;
+* [=struct/item=] named <dfn attribute for="geolocation override">altitude</dfn> which is a float or null;
+* [=struct/item=] named <dfn attribute for="geolocation override">altitudeAccuracy</dfn> which is a float or null;
+* [=struct/item=] named <dfn attribute for="geolocation override">heading</dfn> which is a float or null;
+* [=struct/item=] named <dfn attribute for="geolocation override">speed</dfn> which is a float or null.
 
 A [=remote end=] has a <dfn>geolocation overrides map</dfn> which is a weak map between [=user contexts=] and [=geolocation override=].
 

--- a/index.bs
+++ b/index.bs
@@ -427,6 +427,7 @@ Command = {
 CommandData = (
   BrowserCommand //
   BrowsingContextCommand //
+  EmulationCommand //
   InputCommand //
   NetworkCommand //
   ScriptCommand //
@@ -4713,7 +4714,7 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 </div>
 
-<div algorithm="set viewport when a navigable is created">
+<div algorithm="set viewport and geolocation override when a navigable is created">
 
 After creating a document in a new [=/navigable=] |navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
@@ -4721,6 +4722,11 @@ before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
 TODO: Move it as a hook in the html spec instead.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
+
+1. If [=geolocation overrides map=] [=map/contains=] |user context| and
+   |navigable| is a [=/top-level traversable=]:
+
+   1. [=Set the system coordinates=] with [=geolocation overrides map=][|user context|] and |navigable|.
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
@@ -5520,6 +5526,126 @@ opened</dfn> steps given |window|, |type|, |message|, and optional |default valu
 1. If |handler| is "<code>ignore</code>", set handler to "<code>none</code>".
 
 1. Return |handler|.
+
+</div>
+
+## The emulation Module ## {#module-emulation}
+
+The <dfn export for=modules>emulation</dfn> module contains commands and events
+relating to emulation of browser APIs.
+
+### Definition ### {#module-emulation-definition}
+
+[=remote end definition=]
+
+<pre class="cddl remote-cddl">
+EmulationCommand = (
+  emulation.setGeolocationOverride
+)
+</pre>
+
+A <dfn>geolocation override</dfn> is a [=struct=] with an [=struct/item=] named
+<dfn attribute for="geolocation override">latitude</dfn> which is a float,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">longitude</dfn> which is a float,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">accuracy</dfn> which is a float,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">altitude</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">altitudeAccuracy</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">heading</dfn> which is a float or null,
+a [=struct/item=] named <dfn attribute for="viewport-dimensions">speed</dfn> which is a float or null.
+
+A [=remote end=] has a <dfn>geolocation overrides map</dfn> which is a weak map between [=user contexts=] and [=geolocation override=].
+
+
+### Commands ### {#module-emulation-commands}
+
+#### The emulation.setGeolocationOverride Command ####  {#command-emulation-setGeolocationOverride}
+
+The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modifies geolocation characteristics on the given top-level traversables or user contexts.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      emulation.SetGeolocationOverride = (
+        method: "emulation.setGeolocationOverride",
+        params: emulation.SetGeolocationOverrideParameters
+      )
+
+      emulation.SetGeolocationOverrideParameters = {
+        coordinates: emulation.GeolocationCoordinates / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+
+      emulation.GeolocationCoordinates = {
+         latitude: float,
+         longitude: float,
+         ? accuracy: float .default 1.0,
+         ? altitude: float / null .default null,
+         ? altitudeAccuracy: float / null .default null,
+         ? heading: float / null .default null,
+         ? speed: float / null .default null,
+      }
+    </pre>
+   </dd>
+   <dt>Result Type</dt>
+   <dd>
+    <code>
+     EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for emulation.setGeolocationOverride">
+
+The [=remote end steps=] with |command parameters| are:
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |navigables| be a [=/set=].
+
+1. If the <code>contexts</code> field of |command parameters| is present:
+
+   1. For each |context| of |command parameters|["<code>contexts</code>"]:
+
+      1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with
+         |context|.
+
+      1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
+         [=error code=] [=invalid argument=].
+
+      1. [=set/Append=] |navigable| to |navigables|.
+
+1. Otherwise, if the <code>userContexts</code> field of |command parameters| is present:
+
+   1. Let |user contexts| be a [=/set=].
+
+   1. For each |user context id| of |command parameters|["<code>userContexts</code>"]:
+
+      1. Set |user context| to [=get user context=] with |user context id|.
+
+      1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
+
+      1. [=set/Append=] |user context| to |user contexts|.
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=map/Set=] [=geolocation overrides map=][|user context|] to a |command parameters|["<code>coordinates</code>"].
+
+      1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]
+         whose [=associated user context=] is |user context|:
+
+         1. [=list/Append=] |top-level traversable| to |navigables|.
+
+1. Otherwise, return [=error=] with [=error code=] [=invalid argument=].
+
+1. For each |navigable| of |navigables|:
+
+   1. [=Set the system coordinates=] with |command parameters|["<code>coordinates</code>"] and |navigable|.
+
+1. Return [=success=] with data null.
 
 </div>
 
@@ -12125,6 +12251,10 @@ Insert the following steps at the start of the [=determine the device pixel rati
 
 1. If [=device pixel ratio overrides=] [=map/contains=] <var ignore>window</var>'s [=window/navigable=], return [=device pixel ratio overrides=][<var ignore>window</var>'s [=window/navigable=]].
 
+
+## Geolocation ## {#patchs-geolocation}
+
+<dfn>Set the system coordinates</dfn> algorithm is going to be added in the geolocation specification.
 
 # Appendices # {#appendices}
 

--- a/index.bs
+++ b/index.bs
@@ -4751,7 +4751,7 @@ To <dfn>set viewport</dfn> given |navigable| and |viewport|:
 
 </div>
 
-<div algorithm="set viewport and geolocation override when a navigable is created">
+<div algorithm="configure new navigable">
 
 After creating a document in a new [=/navigable=] |navigable| and
 before the [=run WebDriver BiDi preload scripts=] algorithm is invoked:
@@ -4760,10 +4760,10 @@ TODO: Move it as a hook in the html spec instead.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. If [=geolocation overrides map=] [=map/contains=] |user context| and
-   |navigable| is a [=/top-level traversable=]:
+1. If |navigable| is a [=/top-level traversable=]:
 
-   1. [=Set the system coordinates=] with [=geolocation overrides map=][|user context|] and |navigable|.
+   1. If [=geolocation overrides map=] [=map/contains=] |user context|,
+      [=set the system coordinates=] with [=geolocation overrides map=][|user context|] and |navigable|.
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 

--- a/index.bs
+++ b/index.bs
@@ -5638,7 +5638,7 @@ The [=remote end steps=] with |command parameters| are:
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
-   and |command parameters| doesn't [=map/contains=] "<code>context</code>",
+   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |navigables| be a [=/set=].

--- a/index.bs
+++ b/index.bs
@@ -4763,7 +4763,7 @@ TODO: Move it as a hook in the html spec instead.
 1. If |navigable| is a [=/top-level traversable=]:
 
    1. If [=geolocation overrides map=] [=map/contains=] |user context|,
-      [=set the system coordinates=] with [=geolocation overrides map=][|user context|] and |navigable|.
+      [=set emulated position data=] with |navigable| and [=geolocation overrides map=][|user context|].
 
 1. If [=viewport overrides map=] [=map/contains=] |user context|:
 
@@ -5662,7 +5662,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. For each |navigable| of |navigables|:
 
-   1. [=Set the system coordinates=] with |command parameters|["<code>coordinates</code>"] and |navigable|.
+   1. [=Set emulated position data=] with |navigable| and |command parameters|["<code>coordinates</code>"].
 
 1. Return [=success=] with data null.
 
@@ -12273,7 +12273,7 @@ Insert the following steps at the start of the [=determine the device pixel rati
 
 ## Geolocation ## {#patchs-geolocation}
 
-<dfn>Set the system coordinates</dfn> algorithm is going to be added in the geolocation specification.
+<dfn>Set emulated position data</dfn> algorithm is going to be added in the geolocation specification.
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
Closes #343

PR in the geolocation spec: https://github.com/w3c/geolocation/pull/170


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/888.html" title="Last updated on Mar 20, 2025, 4:24 PM UTC (3629b26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/888/3a04347...lutien:3629b26.html" title="Last updated on Mar 20, 2025, 4:24 PM UTC (3629b26)">Diff</a>