### PR TITLE
Extend `browsingContext.DownloadWillBegin` with `suggestedFilename`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2913,6 +2913,9 @@ The progress of navigation is communicated using an immutable
 
   <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-url">url</dfn></dt>
   <dd>The URL which is being loaded in the navigation</dd>
+
+  <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-suggested-filename">suggestedFilename</dfn></dt>
+  <dd>An optional suggested filename. Provided if the navigation is a download</dd>
 </dl>
 
 ### Definition ### {#module-browsingContext-definition}
@@ -5267,8 +5270,13 @@ complete</dfn> steps given |navigable| and |navigation status|:
       <pre class="cddl local-cddl">
         browsingContext.DownloadWillBegin = (
          method: "browsingContext.downloadWillBegin",
-         params: browsingContext.NavigationInfo
+         params: browsingContext.DownloadWillBeginParams
         )
+
+        browsingContext.DownloadWillBeginParams = {
+          suggestedFilename: text,
+          browsingContext.NavigationInfo
+        }
       </pre>
    </dd>
 </dl>
@@ -5277,8 +5285,16 @@ complete</dfn> steps given |navigable| and |navigation status|:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download
 started</dfn> steps given |navigable| and |navigation status|:
 
- 1. Let |params| be the result of [=get the navigation info=] given |navigable|
-    and |navigation status|.
+ 1. Let |navigation info| be the result of [=get the navigation info=] given |navigable| and
+    |navigation status|.
+
+1. Let |params| be a [=/map=] matching the <code>browsingContext.DownloadWillBeginParams</code>
+   production, with the <code>context</code> field set to |navigation info|["<code>context</code>"],
+   the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"], the
+   <code>timestamp</code> field set to |navigation info|["<code>timestamp</code>"], the
+   <code>url</code> field set to |navigation info|["<code>url</code>"] and
+   <code>suggestedFilename</code> field set to |navigation status|'s
+   <code>suggestedFilename</code>.
 
  1. Let |body| be a [=/map=] matching the
      <code>browsingContext.DownloadWillBegin</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -2915,7 +2915,7 @@ The progress of navigation is communicated using an immutable
   <dd>The URL which is being loaded in the navigation</dd>
 
   <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-suggested-filename">suggestedFilename</dfn></dt>
-  <dd>An optional suggested filename. Provided if the navigation is a download</dd>
+  <dd>If the navigation is a download, suggested filename, otherwise null.</dd>
 </dl>
 
 ### Definition ### {#module-browsingContext-definition}


### PR DESCRIPTION
Address https://github.com/w3c/webdriver-bidi/issues/840:
* Extend `browsingContext.DownloadWillBegin` with `suggestedFilename`

The hook will be engaged in HTML spec after https://github.com/whatwg/html/pull/11139 is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/890.html" title="Last updated on Mar 21, 2025, 12:17 PM UTC (9aa865e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/890/682f673...9aa865e.html" title="Last updated on Mar 21, 2025, 12:17 PM UTC (9aa865e)">Diff</a>