### PR TITLE
Editorial: "WebDriver BiDi navigation status"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2896,22 +2896,22 @@ rather than <code>navigable</code>, and the protocol uses the term
 <code>context</code> to refer to navigables, particularly as a field in command
 and response parameters.
 
-The progress of navigation is communicated using an immutable <dfn export>WebDriver
-navigation status</dfn> struct, which has the following items:
+The progress of navigation is communicated using an immutable
+<dfn export>WebDriver BiDi navigation status</dfn> struct, which has the following items:
 
 <dl>
-  <dt><dfn export for="WebDriver navigation status" id="navigation-status-id">id</dfn></dt>
+  <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-id">id</dfn></dt>
   <dd>The [=navigation id=] for the navigation, or null when the navigation is
   canceled before making progress.</dd>
 
-  <dt><dfn export for="WebDriver navigation status" id="navigation-status-status">status</dfn></dt>
+  <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-status">status</dfn></dt>
     <dd>A status code that is either
       "<dfn export id="navigation-status-canceled"><code>canceled</code></dfn>",
       "<dfn export id="navigation-status-pending"><code>pending</code></dfn>", or
       "<dfn export id="navigation-status-complete"><code>complete</code></dfn>".
     </dd>
 
-  <dt><dfn export for="WebDriver navigation status" id="navigation-status-url">url</dfn></dt>
+  <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-url">url</dfn></dt>
   <dd>The URL which is being loaded in the navigation</dd>
 </dl>
 


### PR DESCRIPTION
Rename "WebDriver navigation status" to "WebDriver BiDi navigation status" in order to align with HTML spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/891.html" title="Last updated on Mar 17, 2025, 12:37 PM UTC (1c10404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/891/3fe641c...1c10404.html" title="Last updated on Mar 17, 2025, 12:37 PM UTC (1c10404)">Diff</a>