### PR TITLE
editorial: fix cddl

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5588,7 +5588,7 @@ relating to emulation of browser APIs.
 
 <pre class="cddl remote-cddl">
 EmulationCommand = (
-  emulation.setGeolocationOverride
+  emulation.SetGeolocationOverride
 )
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -3303,11 +3303,15 @@ TODO: Link to the definition in the HTML spec.
 [=local end definition=]:
 
 <pre class="cddl local-cddl">
-browsingContext.NavigationInfo = {
+NavigationInfo = (
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
   timestamp: js-uint,
   url: text,
+)
+
+browsingContext.NavigationInfo = {
+  NavigationInfo
 }
 </pre>
 
@@ -5313,7 +5317,7 @@ complete</dfn> steps given |navigable| and |navigation status|:
 
         browsingContext.DownloadWillBeginParams = {
           suggestedFilename: text,
-          browsingContext.NavigationInfo
+          NavigationInfo
         }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -3303,15 +3303,11 @@ TODO: Link to the definition in the HTML spec.
 [=local end definition=]:
 
 <pre class="cddl local-cddl">
-NavigationInfo = (
+browsingContext.NavigationInfo = {
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
   timestamp: js-uint,
   url: text,
-)
-
-browsingContext.NavigationInfo = {
-  NavigationInfo
 }
 </pre>
 
@@ -5317,7 +5313,7 @@ complete</dfn> steps given |navigable| and |navigation status|:
 
         browsingContext.DownloadWillBeginParams = {
           suggestedFilename: text,
-          NavigationInfo
+          browsingContext.NavigationInfo
         }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -3303,11 +3303,15 @@ TODO: Link to the definition in the HTML spec.
 [=local end definition=]:
 
 <pre class="cddl local-cddl">
-browsingContext.NavigationInfo = {
+browsingContext.BaseNavigationInfo = (
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
   timestamp: js-uint,
   url: text,
+)
+
+browsingContext.NavigationInfo = {
+  browsingContext.BaseNavigationInfo
 }
 </pre>
 
@@ -5313,7 +5317,7 @@ complete</dfn> steps given |navigable| and |navigation status|:
 
         browsingContext.DownloadWillBeginParams = {
           suggestedFilename: text,
-          browsingContext.NavigationInfo
+          browsingContext.BaseNavigationInfo
         }
       </pre>
    </dd>


### PR DESCRIPTION
* Fix name in `emulation.SetGeolocationOverride`.
* Extract type `browsingContext.BaseNavigationInfo`. Required, as CDDL + cddlconv do not allow extending a map with another map.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/892.html" title="Last updated on Mar 24, 2025, 3:22 PM UTC (e573dd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/892/c47fc2b...e573dd9.html" title="Last updated on Mar 24, 2025, 3:22 PM UTC (e573dd9)">Diff</a>