### PR TITLE
editorial: fix grammatical error in setGeolocationOverride steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5676,7 +5676,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |user context| of |user contexts|:
 
-      1. [=map/Set=] [=geolocation overrides map=][|user context|] to a |command parameters|["<code>coordinates</code>"].
+      1. [=map/Set=] [=geolocation overrides map=][|user context|] to |command parameters|["<code>coordinates</code>"].
 
       1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]
          whose [=associated user context=] is |user context|:


### PR DESCRIPTION
Remove the extra "a" in "Set geolocation overrides map[user context] to a command parameters[coordinates]."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/webdriver-bidi/pull/893.html" title="Last updated on Mar 26, 2025, 5:56 PM UTC (b8a8416)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/893/3f131c8...reillyeon:b8a8416.html" title="Last updated on Mar 26, 2025, 5:56 PM UTC (b8a8416)">Diff</a>