### PR TITLE
Extend `browser.createUserContext` with `acceptInsecureCerts` parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1615,7 +1615,7 @@ To <dfn>cleanup the session</dfn> given |session|:
 1. For each |user context| in the |session|'s
    [=user contexts with insecure certificates overrides=]:
 
-   1. [=Override insecure certificates behavior=] with |user context| and null.
+   1. [=Restore insecure certificates behavior=] with |user context|.
 
    1. [=set/Remove=] |user context| from |session|'s
       [=user contexts with insecure certificates overrides=].
@@ -2687,20 +2687,19 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 <div algorithm="remote end steps for browser.createUserContext">
 
 <div algorithm>
+To <dfn>restore insecure certificates behavior</dfn> given |user context|:
+
+1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true,
+   [=override insecure certificates behavior=] with |user context| and true.
+
+1. Otherwise, [=override insecure certificates behavior=] with |user context| and
+   false.
+
+</div>
+
+<div algorithm>
 To <dfn>override insecure certificates behavior</dfn> given |user context| and
 |acceptInsecureCerts|:
-
-1. If |acceptInsecureCerts| is null:
-
-  Note: restore default behavior.
-
-  1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true,
-     [=override insecure certificates behavior=] with |user context| and true.
-
-  1. Otherwise, [=override insecure certificates behavior=] with |user context| and
-     false.
-
-  1. Return.
 
 1. If |acceptInsecureCerts| is true:
 

--- a/index.bs
+++ b/index.bs
@@ -1505,6 +1505,10 @@ time. However they are not required to remove such [=user contexts=]. [=User
 contexts=] that are not [=empty user contexts=] must not be removed from the
 [=set of user contexts=].
 
+A [=BiDi session=] has a
+<dfn>user contexts with insecure certificates overrides</dfn>, which is a [=/set=] of
+[=user contexts=].
+
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
 
@@ -1607,6 +1611,14 @@ To <dfn>end the session</dfn> given |session|:
 To <dfn>cleanup the session</dfn> given |session|:
 
 1. [=Close the WebSocket connections=] with |session|.
+
+1. For each |user context| in the |session|'s
+   [=user contexts with insecure certificates overrides=]:
+
+   1. [=Override insecure certificates behavior=] with |user context| and null.
+
+   1. [=set/Remove=] |user context| from |session|'s
+      [=user contexts with insecure certificates overrides=].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -2674,7 +2686,46 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 <div algorithm="remote end steps for browser.createUserContext">
 
-The [=remote end steps=] with |command parameters| are:
+<div algorithm>
+To <dfn>override insecure certificates behavior</dfn> given |user context| and
+|acceptInsecureCerts|:
+
+1. If |acceptInsecureCerts| is null:
+
+  Note: restore default behavior.
+
+  1. If [=remote end=]'s [=accept insecure TLS=] flag is true,
+     [=override insecure certificates behavior=] with |user context| and true.
+
+  1. Otherwise, [=override insecure certificates behavior=] with |user context| and
+     false.
+
+  1. Return.
+
+1. If |acceptInsecureCerts| is true:
+
+   1. If [=remote end=] doesn't support accepting insecure TLS connections,
+      return [=error=] with [=error code=] [=unsupported operation=].
+
+   1. Perform implementation-defined steps to disable any certificate errors in the
+      scope of |user context|. This should affect all the network requests associated
+      with the |user context|, e.g. initiated by [=/navigable=] which
+      [=associated user context=] is |user context|.
+
+   1. Return.
+
+1. Assert |acceptInsecureCerts| is false.
+
+1. Perform implementation-defined steps to enable all the required TLS certificates
+   checks for all associated with |user context| network requests. This should affect
+   all the network requests associated with the |user context|, e.g. initiated by
+   [=/navigable=] which [=associated user context=] is |user context|.
+
+TODO: mention service workers.
+
+</div>
+
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |user context| be a new [=user context=].
 
@@ -2683,17 +2734,11 @@ The [=remote end steps=] with |command parameters| are:
   Note: If "<code>acceptInsecureCerts</code>" is set, it overrides the
   [=accept insecure TLS=] flag's behavior.
 
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is true, then
-     perform implementation-defined steps to disable any certificate errors in the
-     scope of |user context|.
+  1. [=Override insecure certificates behavior=] with |user context| and
+     |command parameters|["<code>acceptInsecureCerts</code>"].
 
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is false, then
-     perform implementation-defined steps to force certificate checks in the scope of
-     |user context|.
-
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is null, then
-     perform implementation-defined steps to restore the default handling of
-     certificate errors in the scope of |user context|.
+  1. [=set/Append=] |user context| to |session|'s
+     [=user contexts with insecure certificates overrides=].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -2690,6 +2690,22 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 <div algorithm="remote end steps for browser.createUserContext">
 
 <div algorithm>
+A <dfn>request originates in user context</dfn> given |request| and |user context|
+are:
+
+1. Let |settings| be |request|'s [=request/client=].
+
+1. Let |related navigables| be [=get related navigables=] with |settings|.
+
+1. For |navigable| in |related navigables|:
+
+  1. If |navigable|'s [=associated user context=] is |user context| return true.
+
+1. Return false.
+
+</div>
+
+<div algorithm>
 To <dfn>restore insecure certificates behavior</dfn> given |user context|:
 
 1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true,
@@ -2709,23 +2725,21 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. If [=endpoint node=] doesn't support accepting insecure TLS connections,
       return [=error=] with [=error code=] [=unsupported operation=].
 
-   1. Perform implementation-defined steps to skip steps 6.1.3.a and any other
-      implementation-specific validation steps of [=Basic Certificate Processing=]
-      for all network requests associated with |user context|. This should affect all
-      the network requests associated with the |user context|, e.g. initiated by
-      [=/navigables=] whose [=associated user context=] is |user context|.
+   1. For any network request |request| for which the
+      [=request originates in user context=] steps with |request| and |user context|
+      return true, when running the [=Basic Certificate Processing=] steps for that
+      request, skip step a, along with any other implementation-specific certificate
+      validation steps.
 
    1. Return.
 
 1. Assert |acceptInsecureCerts| is false.
 
-1. Perform implementation-defined steps to restore step 6.1.3.a and all other skipped
-   validation steps of [=Basic Certificate Processing=] for all network requests
-   associated with |user context|. This should affect all the network requests
-   associated with the |user context|, e.g. initiated by [=/navigables=] whose
-   [=associated user context=] is |user context|.
-
-TODO: mention service workers.
+1. For any network request |request| for which the
+   [=request originates in user context=] steps with |request| and |user context|
+   return true, when running the [=Basic Certificate Processing=] steps for that
+   request, the step a, along with any other implementation-specific certificate
+   validation steps, must not be skipped.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2707,7 +2707,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
       return [=error=] with [=error code=] [=unsupported operation=].
 
    1. Perform implementation-defined steps to disable all the TLS certificates checks
-      for all network requests associated with the [=user context=] with [=user context id=] |user context| . This should affect all
+      for all network requests associated with the [=user context=] |user context| . This should affect all
       the network requests associated with the |user context|, e.g. initiated by
       [=/navigable=] whose [=associated user context=]'s [=user context id=] is |user context|.
 

--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,9 @@ Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webdriver/test
 </pre>
 
 <pre class=anchors>
+spec: RFC5280; urlPrefix: https://datatracker.ietf.org/doc/html/rfc5280
+  type: dfn
+    text: Basic Certificate Processing; url: section-6.1.3
 spec: RFC6455; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455
   type: dfn
     text: WebSocket URI; url: section-3
@@ -2706,8 +2709,9 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. If [=endpoint node=] doesn't support accepting insecure TLS connections,
       return [=error=] with [=error code=] [=unsupported operation=].
 
-   1. Perform implementation-defined steps to disable all the TLS certificates checks
-      for all network requests associated with the [=user context=] |user context| . This should affect all
+   1. Perform implementation-defined steps to skip steps 6.1.3.a and any other
+      implementation-specific validation steps of [=Basic Certificate Processing=]
+      for all network requests associated with |user context|. This should affect all
       the network requests associated with the |user context|, e.g. initiated by
       [=/navigables=] whose [=associated user context=] is |user context|.
 
@@ -2715,10 +2719,11 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
 
 1. Assert |acceptInsecureCerts| is false.
 
-1. Perform implementation-defined steps to enable all the required TLS certificates
-   checks for all network requests associated with |user context|. This should affect
-   all the network requests associated with the |user context|, e.g. initiated by
-   [=/navigables=] whose [=associated user context=] is |user context|.
+1. Perform implementation-defined steps to restore step 6.1.3.a and all other skipped
+   validation steps of [=Basic Certificate Processing=] for all network requests
+   associated with |user context|. This should affect all the network requests
+   associated with the |user context|, e.g. initiated by [=/navigables=] whose
+   [=associated user context=] is |user context|.
 
 TODO: mention service workers.
 

--- a/index.bs
+++ b/index.bs
@@ -2690,8 +2690,8 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 <div algorithm="remote end steps for browser.createUserContext">
 
 <div algorithm>
-A <dfn>request originates in user context</dfn> given |request| and |user context|
-are:
+The steps to check if <dfn>request originates in user context</dfn> given |request|
+and |user context| are:
 
 1. Let |settings| be |request|'s [=request/client=].
 
@@ -2707,7 +2707,6 @@ are:
 
 <div algorithm>
 To <dfn>restore insecure certificates behavior</dfn> given |user context|:
-
 
 1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true and [=endpoint node=]
    supports accepting insecure TLS connections,

--- a/index.bs
+++ b/index.bs
@@ -2706,10 +2706,10 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. If [=endpoint node=] doesn't support accepting insecure TLS connections,
       return [=error=] with [=error code=] [=unsupported operation=].
 
-   1. Perform implementation-defined steps to disable any certificate errors in the
-      scope of |user context|. This should affect all the network requests associated
-      with the |user context|, e.g. initiated by [=/navigable=] which
-      [=associated user context=] is |user context|.
+   1. Perform implementation-defined steps to disable all the TLS certificates checks
+      for all associated with |user context| network requests. This should affect all
+      the network requests associated with the |user context|, e.g. initiated by
+      [=/navigable=] which [=associated user context=] is |user context|.
 
    1. Return.
 

--- a/index.bs
+++ b/index.bs
@@ -2718,7 +2718,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
 1. Perform implementation-defined steps to enable all the required TLS certificates
    checks for all network requests associated with |user context|. This should affect
    all the network requests associated with the |user context|, e.g. initiated by
-   [=/navigable=] which [=associated user context=] is |user context|.
+   [=/navigables=] whose [=associated user context=] is |user context|.
 
 TODO: mention service workers.
 

--- a/index.bs
+++ b/index.bs
@@ -2707,7 +2707,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
       return [=error=] with [=error code=] [=unsupported operation=].
 
    1. Perform implementation-defined steps to disable all the TLS certificates checks
-      for all associated with |user context| network requests. This should affect all
+      for all network requests associated with the [=user context=] with [=user context id=] |user context| . This should affect all
       the network requests associated with the |user context|, e.g. initiated by
       [=/navigable=] which [=associated user context=] is |user context|.
 

--- a/index.bs
+++ b/index.bs
@@ -2709,7 +2709,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. Perform implementation-defined steps to disable all the TLS certificates checks
       for all network requests associated with the [=user context=] |user context| . This should affect all
       the network requests associated with the |user context|, e.g. initiated by
-      [=/navigable=] whose [=associated user context=] is |user context|.
+      [=/navigables=] whose [=associated user context=] is |user context|.
 
    1. Return.
 

--- a/index.bs
+++ b/index.bs
@@ -2709,7 +2709,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. Perform implementation-defined steps to disable all the TLS certificates checks
       for all network requests associated with the [=user context=] with [=user context id=] |user context| . This should affect all
       the network requests associated with the |user context|, e.g. initiated by
-      [=/navigable=] which [=associated user context=] is |user context|.
+      [=/navigable=] whose [=associated user context=]'s [=user context id=] is |user context|.
 
    1. Return.
 

--- a/index.bs
+++ b/index.bs
@@ -2708,7 +2708,9 @@ are:
 <div algorithm>
 To <dfn>restore insecure certificates behavior</dfn> given |user context|:
 
-1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true,
+
+1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true and [=endpoint node=]
+   supports accepting insecure TLS connections,
    [=override insecure certificates behavior=] with |user context| and true.
 
 1. Otherwise, [=override insecure certificates behavior=] with |user context| and

--- a/index.bs
+++ b/index.bs
@@ -2656,8 +2656,12 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       <pre class="cddl remote-cddl">
       browser.CreateUserContext = (
         method: "browser.createUserContext",
-        params: EmptyParams,
+        params: browser.CreateUserContextParameters,
       )
+
+      browser.CreateUserContextParameters = {
+        ? acceptInsecureCerts: bool
+      }
       </pre>
    </dd>
    <dt>Return Type</dt>
@@ -2670,9 +2674,26 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 <div algorithm="remote end steps for browser.createUserContext">
 
-The [=remote end steps=] are:
+The [=remote end steps=] with |command parameters| are:
 
 1. Let |user context| be a new [=user context=].
+
+1. If |command parameters| [=map/contain=] "<code>acceptInsecureCerts</code>":
+
+  Note: If "<code>acceptInsecureCerts</code>" is set, it overrides the
+  [=accept insecure TLS=] flag's behavior.
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is true, then
+     perform implementation-defined steps to disable any certificate errors in the
+     scope of |user context|.
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is false, then
+     perform implementation-defined steps to force certificate checks in the scope of
+     |user context|.
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is null, then
+     perform implementation-defined steps to restore the default handling of
+     certificate errors in the scope of |user context|.
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -7713,63 +7734,6 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
     1. Otherwise:
 
       1. Set [=navigable cache behavior map=][|navigable|] to |behavior|.
-
-1. Return [=success=] with data null.
-
-</div>
-
-#### The network.setAcceptInsecureCerts Command ####  {#command-network-setAcceptInsecureCerts}
-
-The <dfn export for=commands>network.setAcceptInsecureCerts</dfn> command configures
-handling of untrusted or self-signed TLS certificates.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl remote-cddl">
-      network.SetAcceptInsecureCerts = (
-        method: "network.setAcceptInsecureCerts",
-        params: network.SetAcceptInsecureCertsParameters
-      )
-
-      network.SetAcceptInsecureCertsParameters = {
-        userContexts: [+browser.UserContext],
-        ? acceptInsecureCerts: (bool / null) .default null,
-      }
-    </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-    <code>
-      EmptyResult
-    </code>
-   </dd>
-</dl>
-
-<div algorithm="remote end steps for network.setAcceptInsecureCerts">
-
-Note: If <code>acceptInsecureCerts</code> is set, it overrides the
-[=accept insecure TLS=] flag's behavior set via capabilities.
-
-The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
-
-1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
-   with |command parameters|["<code>userContexts</code>"].
-
-1. For each |user context| of |user contexts|:
-
-
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is true, then
-     perform implementation-defined steps to disable any certificate errors in the
-     scope of |user context|.
-
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is false, then
-     perform implementation-defined steps to force certificate checks in the scope of
-     |user context|.
-
-  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is null, then
-     perform implementation-defined steps to restore the default handling of
-     certificate errors in the scope of |user context|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -51,6 +51,7 @@ spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-ht
 spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
   type: dfn
     text: WebDriver new session algorithm; url: dfn-webdriver-new-session-algorithms
+    text: accept insecure TLS; url: dfn-accept-insecure-tls
     text: actions; url: actions
     text: actions options; url: dfn-actions-options
     text: active sessions; url: dfn-active-sessions
@@ -1453,6 +1454,13 @@ A <dfn export>user context</dfn> represents a collection of zero or more
 an associated [=storage partition=], so that [=remote end=] data is not shared
 between different [=user contexts=].
 
+Each [=user context=] has an associated <dfn>accept insecure TLS override</dfn> flag
+which is an optional boolean that indicates whether untrusted or self-signed TLS
+certificates are treated as trusted. The default value of the flag is unset.
+
+Note: If [=accept insecure TLS override=] is set, it overrides the
+[=accept insecure TLS=] flag's behavior.
+
 Issue: Unclear that this is the best way to formally define the concept of a
 user context or the interaction with storage.
 
@@ -2655,8 +2663,12 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       <pre class="cddl remote-cddl">
       browser.CreateUserContext = (
         method: "browser.createUserContext",
-        params: EmptyParams,
+        params: browser.CreateUserContextParameters,
       )
+
+      browser.CreateUserContextParameters = {
+        ? acceptInsecureCerts: bool
+      }
       </pre>
    </dd>
    <dt>Return Type</dt>
@@ -2669,9 +2681,14 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 <div algorithm="remote end steps for browser.createUserContext">
 
-The [=remote end steps=] are:
+The [=remote end steps=] with |command parameters| are:
 
 1. Let |user context| be a new [=user context=].
+
+1. If |command parameters| [=map/contain=] "<code>acceptInsecureCerts</code>":
+
+  1. Set |user context|'s [=accept insecure TLS override=] to
+     |command parameters|["<code>acceptInsecureCerts</code>"].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -5124,6 +5141,14 @@ become inaccessible but not yet get discarded because bfcache.
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 started</dfn> steps given |navigable| and |navigation status|:
+
+1. If |navigable|'s [=associated user context=]'s [=accept insecure TLS override=]
+   is true, then perform implementation-defined steps to disable any certificate
+   errors that would normally hinder navigation to the requested address.
+
+1. If |navigable|'s [=associated user context=]'s [=accept insecure TLS override=]
+   is false, then perform implementation-defined steps to restore the default
+   certificate errors handling.
 
 1. Let |params| be the result of [=get the navigation info=] given |navigable|
    and |navigation status|.

--- a/index.bs
+++ b/index.bs
@@ -1454,13 +1454,6 @@ A <dfn export>user context</dfn> represents a collection of zero or more
 an associated [=storage partition=], so that [=remote end=] data is not shared
 between different [=user contexts=].
 
-Each [=user context=] has an associated <dfn>accept insecure TLS override</dfn> flag
-which is an optional boolean that indicates whether untrusted or self-signed TLS
-certificates are treated as trusted. The default value of the flag is unset.
-
-Note: If [=accept insecure TLS override=] is set, it overrides the
-[=accept insecure TLS=] flag's behavior.
-
 Issue: Unclear that this is the best way to formally define the concept of a
 user context or the interaction with storage.
 
@@ -2663,12 +2656,8 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       <pre class="cddl remote-cddl">
       browser.CreateUserContext = (
         method: "browser.createUserContext",
-        params: browser.CreateUserContextParameters,
+        params: EmptyParams,
       )
-
-      browser.CreateUserContextParameters = {
-        ? acceptInsecureCerts: bool
-      }
       </pre>
    </dd>
    <dt>Return Type</dt>
@@ -2681,14 +2670,9 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 <div algorithm="remote end steps for browser.createUserContext">
 
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] are:
 
 1. Let |user context| be a new [=user context=].
-
-1. If |command parameters| [=map/contain=] "<code>acceptInsecureCerts</code>":
-
-  1. Set |user context|'s [=accept insecure TLS override=] to
-     |command parameters|["<code>acceptInsecureCerts</code>"].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -5141,14 +5125,6 @@ become inaccessible but not yet get discarded because bfcache.
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi navigation
 started</dfn> steps given |navigable| and |navigation status|:
-
-1. If |navigable|'s [=associated user context=]'s [=accept insecure TLS override=]
-   is true, then perform implementation-defined steps to disable any certificate
-   errors that would normally hinder navigation to the requested address.
-
-1. If |navigable|'s [=associated user context=]'s [=accept insecure TLS override=]
-   is false, then perform implementation-defined steps to restore the default
-   certificate errors handling.
 
 1. Let |params| be the result of [=get the navigation info=] given |navigable|
    and |navigation status|.
@@ -7737,6 +7713,63 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
     1. Otherwise:
 
       1. Set [=navigable cache behavior map=][|navigable|] to |behavior|.
+
+1. Return [=success=] with data null.
+
+</div>
+
+#### The network.setAcceptInsecureCerts Command ####  {#command-network-setAcceptInsecureCerts}
+
+The <dfn export for=commands>network.setAcceptInsecureCerts</dfn> command configures
+handling of untrusted or self-signed TLS certificates.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl remote-cddl">
+      network.SetAcceptInsecureCerts = (
+        method: "network.setAcceptInsecureCerts",
+        params: network.SetAcceptInsecureCertsParameters
+      )
+
+      network.SetAcceptInsecureCertsParameters = {
+        userContexts: [+browser.UserContext],
+        ? acceptInsecureCerts: (bool / null) .default null,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <code>
+      EmptyResult
+    </code>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for network.setAcceptInsecureCerts">
+
+Note: If <code>acceptInsecureCerts</code> is set, it overrides the
+[=accept insecure TLS=] flag's behavior set via capabilities.
+
+The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
+
+1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
+   with |command parameters|["<code>userContexts</code>"].
+
+1. For each |user context| of |user contexts|:
+
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is true, then
+     perform implementation-defined steps to disable any certificate errors in the
+     scope of |user context|.
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is false, then
+     perform implementation-defined steps to force certificate checks in the scope of
+     |user context|.
+
+  1. If |command parameters|["<code>acceptInsecureCerts</code>"] is null, then
+     perform implementation-defined steps to restore the default handling of
+     certificate errors in the scope of |user context|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -2694,7 +2694,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
 
   Note: restore default behavior.
 
-  1. If [=remote end=]'s [=accept insecure TLS=] flag is true,
+  1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true,
      [=override insecure certificates behavior=] with |user context| and true.
 
   1. Otherwise, [=override insecure certificates behavior=] with |user context| and
@@ -2704,7 +2704,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
 
 1. If |acceptInsecureCerts| is true:
 
-   1. If [=remote end=] doesn't support accepting insecure TLS connections,
+   1. If [=endpoint node=] doesn't support accepting insecure TLS connections,
       return [=error=] with [=error code=] [=unsupported operation=].
 
    1. Perform implementation-defined steps to disable any certificate errors in the

--- a/index.bs
+++ b/index.bs
@@ -2709,7 +2709,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
    1. Perform implementation-defined steps to disable all the TLS certificates checks
       for all network requests associated with the [=user context=] |user context| . This should affect all
       the network requests associated with the |user context|, e.g. initiated by
-      [=/navigable=] whose [=associated user context=]'s [=user context id=] is |user context|.
+      [=/navigable=] whose [=associated user context=] is |user context|.
 
    1. Return.
 

--- a/index.bs
+++ b/index.bs
@@ -2716,7 +2716,7 @@ To <dfn>override insecure certificates behavior</dfn> given |user context| and
 1. Assert |acceptInsecureCerts| is false.
 
 1. Perform implementation-defined steps to enable all the required TLS certificates
-   checks for all associated with |user context| network requests. This should affect
+   checks for all network requests associated with |user context|. This should affect
    all the network requests associated with the |user context|, e.g. initiated by
    [=/navigable=] which [=associated user context=] is |user context|.
 


### PR DESCRIPTION
Addressing #789. Allow for setting `acceptInsecureCerts` for per user context.

Open questions: 
* [ ] How to tight service worker to a user context?
* [ ] Do we need even better integration with Classic? In order to properly specify behavior in case of capability set to "acceptInsecureCerts: true", and user context to "acceptInsecureCerts: false", the classic command on the user context's browsing context will still ignore certificate errors due to this:
> If the [remote end](https://w3c.github.io/webdriver/#dfn-remote-ends)'s [accept insecure TLS](https://w3c.github.io/webdriver/#dfn-accept-insecure-tls) flag is true, no certificate errors that would normally cause the user agent to abort and show a security warning are to hinder navigation to the requested address.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/895.html" title="Last updated on May 7, 2025, 2:44 PM UTC (0fa3d18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/895/c1c706c...0fa3d18.html" title="Last updated on May 7, 2025, 2:44 PM UTC (0fa3d18)">Diff</a>