### PR TITLE
Extend `browser.createUserContext` with `unhandledPromptBehavior` parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3120,7 +3120,7 @@ A <dfn>viewport configuration</dfn> is a [=struct=] with an [=struct/item=] name
 <dfn attribute for="viewport-configuration">viewport</dfn> which is a [=viewport-configuration/viewport dimensions=]
 or null and an [=struct/item=] named <dfn attribute for="viewport-configuration">devicePixelRatio</dfn> which is a float or null.
 
-A <dfn>unhandled prompt behavior</dfn> is a [=struct=] with:
+An <dfn>unhandled prompt behavior</dfn> is a [=struct=] with:
 * [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-alert">alert</dfn> which is a string or null (default: null);
 * [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-beforeUnload">beforeUnload</dfn> which is a string or null (default: null);
 * [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-confirm">confirm</dfn> which is a string or null (default: null);

--- a/index.bs
+++ b/index.bs
@@ -3120,13 +3120,13 @@ A <dfn>viewport configuration</dfn> is a [=struct=] with an [=struct/item=] name
 <dfn attribute for="viewport-configuration">viewport</dfn> which is a [=viewport-configuration/viewport dimensions=]
 or null and an [=struct/item=] named <dfn attribute for="viewport-configuration">devicePixelRatio</dfn> which is a float or null.
 
-An <dfn>unhandled prompt behavior</dfn> is a [=struct=] with:
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-alert">alert</dfn> which is a string or null (default: null);
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-beforeUnload">beforeUnload</dfn> which is a string or null (default: null);
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-confirm">confirm</dfn> which is a string or null (default: null);
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-default">default</dfn> which is a string or null (default: null);
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-file">file</dfn> which is a string or null (default: null);
-* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-prompt">prompt</dfn> which is a string or null (default: null).
+An <dfn>unhandled prompt behavior struct</dfn> is a [=struct=] with:
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-alert">alert</dfn> which is a string or null;
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-beforeUnload">beforeUnload</dfn> which is a string or null;
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-confirm">confirm</dfn> which is a string or null;
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-default">default</dfn> which is a string or null;
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-file">file</dfn> which is a string or null;
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-prompt">prompt</dfn> which is a string or null.
 
 A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map between [=user contexts=] and [=viewport configuration=].
 
@@ -3134,7 +3134,7 @@ A [=remote end=] has a <dfn>locale overrides map</dfn> which is a weak map betwe
 [=navigables=] or [=user contexts=] and string or null.
 
 A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn> which is a
-weak map between [=user contexts=] and [=unhandled prompt behavior=].
+weak map between [=user contexts=] and [=unhandled prompt behavior struct=].
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5744,12 +5744,13 @@ To <dfn>get navigable's user prompt handler</dfn> given |type| and |navigable|:
 
 1. If [=unhandled prompt behavior overrides map=] contains |user context|:
 
-  1. Let |behavior map| be [=unhandled prompt behavior overrides map=][|user context|].
+  1. Let |unhandled prompt behavior override| be [=unhandled prompt behavior overrides map=][|user context|].
 
-  1. If |behavior map|[|type|] is not null, return |behavior map|[|type|].
+  1. If |unhandled prompt behavior override|[|type|] is not null, return
+     |unhandled prompt behavior override|[|type|].
 
-  1. If |behavior map|[<code>"default"</code>] is not null, return
-     |behavior map|[<code>"default"</code>].
+  1. If |unhandled prompt behavior override|[<code>"default"</code>] is not null,
+     return |unhandled prompt behavior override|[<code>"default"</code>].
 
 1. Let |handler configuration| be [=get the prompt handler=] with |type|.
 

--- a/index.bs
+++ b/index.bs
@@ -2713,7 +2713,8 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
       browser.CreateUserContextParameters = {
         ? acceptInsecureCerts: bool,
-        ? proxy: session.ProxyConfiguration
+        ? proxy: session.ProxyConfiguration,
+        ? unhandledPromptBehavior: session.UserPromptHandler
       }
       </pre>
    </dd>
@@ -2746,6 +2747,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. [=map/Set=] |session|'s
       [=user context to accept insecure certificates override map=][|user context|]
       to |acceptInsecureCerts|.
+
+1. If |command parameters| [=map/contains=] "<code>unhandledPromptBehavior</code>",
+   [=map/set=] [=unhandled prompt behavior override map=][|user context|] to
+   |command parameters|["<code>unhandledPromptBehavior</code>"].
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
@@ -3119,6 +3124,10 @@ A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map bet
 
 A [=remote end=] has a <dfn>locale overrides map</dfn> which is a weak map between
 [=navigables=] or [=user contexts=] and string or null.
+
+A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn>
+which is a weak map between [=user contexts=] and [=/map=] matching the
+<code>session.UserPromptHandler</code> production.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5722,6 +5731,26 @@ closed</dfn> steps given |window|, |type|, |accepted| and optional |user text|
 </dl>
 
 <div algorithm>
+To <dfn>get navigable's user prompt handler</dfn> given |type| and |navigable|:
+
+1. Let |user context| be |navigable|'s [=associated user context=].
+
+1. If [=unhandled prompt behavior overrides map=] contains |user context|:
+
+  1. Let |behavior map| be [=unhandled prompt behavior overrides map=][|user context|].
+
+  1. If |behavior map| contains |type|, return |behavior map|[|type|].
+
+  1. If |behavior map| contains <code>"default"</code>, return
+     |behavior map|[<code>"default"</code>].
+
+1. Let |handler configuration| be [=get the prompt handler=] with |type|.
+
+1. Return |handler configuration|'s [=prompt handler configuration/handler=].
+
+</div>
+
+<div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi user prompt
 opened</dfn> steps given |window|, |type|, |message|, and optional |default value|
 (default: null).
@@ -5730,10 +5759,8 @@ opened</dfn> steps given |window|, |type|, |message|, and optional |default valu
 
 1. Let |navigable id| be the [=navigable id=] for |navigable|.
 
-1. Let |handler configuration| be [=get the prompt handler=] with |type|.
-
-1. Let |handler| be |handler configuration|'s [=prompt handler
-   configuration/handler=].
+1. Let |handler| be [=get navigable's user prompt handler=] with |type| and
+   |navigable|.
 
 1. Let |params| be a [=/map=] matching the
    <code>browsingContext.UserPromptOpenedParameters</code> production with the

--- a/index.bs
+++ b/index.bs
@@ -5742,7 +5742,7 @@ To <dfn>get navigable's user prompt handler</dfn> given |type| and |navigable|:
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. If [=unhandled prompt behavior overrides map=] contains |user context|:
+1. If [=unhandled prompt behavior overrides map=] [=map/contains=] |user context|:
 
   1. Let |unhandled prompt behavior override| be [=unhandled prompt behavior overrides map=][|user context|].
 

--- a/index.bs
+++ b/index.bs
@@ -2749,7 +2749,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
       to |acceptInsecureCerts|.
 
 1. If |command parameters| [=map/contains=] "<code>unhandledPromptBehavior</code>",
-   [=map/set=] [=unhandled prompt behavior override map=][|user context|] to
+   [=map/set=] [=unhandled prompt behavior overrides map=][|user context|] to
    |command parameters|["<code>unhandledPromptBehavior</code>"].
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
@@ -3120,14 +3120,21 @@ A <dfn>viewport configuration</dfn> is a [=struct=] with an [=struct/item=] name
 <dfn attribute for="viewport-configuration">viewport</dfn> which is a [=viewport-configuration/viewport dimensions=]
 or null and an [=struct/item=] named <dfn attribute for="viewport-configuration">devicePixelRatio</dfn> which is a float or null.
 
+A <dfn>unhandled prompt behavior</dfn> is a [=struct=] with:
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-alert">alert</dfn> which is a string or null (default: null);
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-beforeUnload">beforeUnload</dfn> which is a string or null (default: null);
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-confirm">confirm</dfn> which is a string or null (default: null);
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-default">default</dfn> which is a string or null (default: null);
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-file">file</dfn> which is a string or null (default: null);
+* [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-prompt">prompt</dfn> which is a string or null (default: null).
+
 A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map between [=user contexts=] and [=viewport configuration=].
 
 A [=remote end=] has a <dfn>locale overrides map</dfn> which is a weak map between
 [=navigables=] or [=user contexts=] and string or null.
 
-A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn>
-which is a weak map between [=user contexts=] and [=/map=] matching the
-<code>session.UserPromptHandler</code> production.
+A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn> which is a
+weak map between [=user contexts=] and [=unhandled prompt behavior=].
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5739,9 +5746,9 @@ To <dfn>get navigable's user prompt handler</dfn> given |type| and |navigable|:
 
   1. Let |behavior map| be [=unhandled prompt behavior overrides map=][|user context|].
 
-  1. If |behavior map| contains |type|, return |behavior map|[|type|].
+  1. If |behavior map|[|type|] is not null, return |behavior map|[|type|].
 
-  1. If |behavior map| contains <code>"default"</code>, return
+  1. If |behavior map|[<code>"default"</code>] is not null, return
      |behavior map|[<code>"default"</code>].
 
 1. Let |handler configuration| be [=get the prompt handler=] with |type|.


### PR DESCRIPTION
Addressing #789

Analogue of [`acceptInsecureCerts`](https://github.com/w3c/webdriver-bidi/pull/895), add `unhandledPromptBehavior` parameter to `browser.createUserContext`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/896.html" title="Last updated on Jul 4, 2025, 3:07 PM UTC (3ec0ea6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/896/f89d8e9...3ec0ea6.html" title="Last updated on Jul 4, 2025, 3:07 PM UTC (3ec0ea6)">Diff</a>