### PR TITLE
Extend `browser.createUserContext` with `proxy` parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2712,10 +2712,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
-   1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
+   1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
    1. Take implementation-defined steps to ensure that requests originating from the
-      |user context| use the proxy defined by the |proxy| configuration. If the
+      |user context| use the proxy defined by the |proxy configuration|. If the
       defined proxy cannot be configured return [=error=] with [=error code=]
       [=invalid argument=].
 

--- a/index.bs
+++ b/index.bs
@@ -7960,6 +7960,20 @@ request sent</dfn> steps given |request|:
             1. Take implementation-defined steps to ensure that |request| uses
                the proxy defined by the |proxy configuration|.
 
+         Note: |user context| can be in not more then one
+         [=user context to proxy configuration map=].
+
+         1. If |session|'s [=user context to proxy configuration map=]
+            [=set/contains|contain=] |user context|:
+
+            1. Let |proxy configuration| be |session|'s
+               [=user context to proxy configuration map=][|user context|].
+
+            1. Assert |proxy configuration| can be configured.
+
+            1. Take implementation-defined steps to ensure that |request| uses
+               the proxy defined by the |proxy configuration|.
+
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.
 

--- a/index.bs
+++ b/index.bs
@@ -2720,8 +2720,9 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
-   1. If the |proxy configuration| cannot be configured return [=error=] with
-      [=error code=] [=invalid argument=].
+   1. If the [=remote end=] is unable to configure proxy settings per [=user context=], 
+       or is unable to configure the proxy with |proxy configuration|, return  [=error=] with
+       [=error code=] [=unsupported operation=].
 
    1. [=map/Set=] |session|'s
       [=user context to proxy configuration map=][|user context|]

--- a/index.bs
+++ b/index.bs
@@ -7959,7 +7959,7 @@ request sent</dfn> steps given |request|:
 
             1. Take implementation-defined steps to ensure that |request| uses
                the proxy settings defined by the |proxy configuration|.
-               
+
                Note: the settings are validated when the user context is created and so
                are assumed to be valid at this stage; any error accessing the proxy will
                be reported as a network error when handling the request.

--- a/index.bs
+++ b/index.bs
@@ -100,6 +100,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
     text: process capabilities; url: dfn-capabilities-processing
+    text: proxy configuration; url: dfn-proxy-configuration
     text: readiness state; url: dfn-readiness-state
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends

--- a/index.bs
+++ b/index.bs
@@ -64,7 +64,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: close the session; url: dfn-close-the-session
     text: cookie domain; url: dfn-cookie-domain
     text: cookie expiry time; url: dfn-cookie-expiry-time
-    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: cookie HTTP only; url: dfn-cookie-http-only
     text: cookie name; url: dfn-cookie-name
     text: cookie path; url: dfn-cookie-path

--- a/index.bs
+++ b/index.bs
@@ -2714,9 +2714,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
 
-   1. Take implementation-defined steps to set the |user context|'s proxy using the
-      |proxy| proxy configuration. If the |proxy| cannot be configured return
-      [=error=] with [=error code=] [=invalid argument=].
+   1. Take implementation-defined steps to ensure that requests originating from the
+      |user context| use the proxy defined by the |proxy| configuration. If the
+      defined proxy cannot be configured return [=error=] with [=error code=]
+      [=invalid argument=].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -1514,6 +1514,9 @@ A [=BiDi session=] has a
 <dfn>user context to accept insecure certificates override map</dfn>, which is a
 [=/map=] between [=user contexts=] and boolean.
 
+A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
+a [=/map=] between [=user contexts=] and [=proxy configuration=].
+
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
 
@@ -1621,6 +1624,9 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. [=map/Remove=] |session|'s
       [=user context to accept insecure certificates override map=][|user context|].
+
+   1. [=map/Remove=] |session|'s
+      [=user context to proxy configuration map=][|user context|].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -2713,10 +2719,12 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
-   1. Take implementation-defined steps to ensure that requests originating from the
-      |user context| use the proxy defined by the |proxy configuration|. If the
-      defined proxy cannot be configured return [=error=] with [=error code=]
-      [=invalid argument=].
+   1. If the |proxy configuration| cannot be configured return [=error=] with
+      [=error code=] [=invalid argument=].
+
+   1. [=map/Set=] |session|'s
+      [=user context to proxy configuration map=][|user context|]
+      to |proxy configuration|.
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -7937,6 +7945,20 @@ request sent</dfn> steps given |request|:
             1. Otherwise, when running the [=Basic Certificate Processing=] steps
                for |request|, perform all steps along with any implementation-defined
                certificate validation steps.
+
+         Note: |user context| can be in not more then one
+         [=user context to proxy configuration map=].
+
+         1. If |session|'s [=user context to proxy configuration map=]
+            [=set/contains|contain=] |user context|:
+
+            1. Let |proxy configuration| be |session|'s
+               [=user context to proxy configuration map=][|user context|].
+
+            1. Assert |proxy configuration| can be configured.
+
+            1. Take implementation-defined steps to ensure that |request| uses
+               the proxy defined by the |proxy configuration|.
 
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.

--- a/index.bs
+++ b/index.bs
@@ -2720,7 +2720,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
-   1. If the [=remote end=] is unable to configure proxy settings per [=user context=], 
+   1. If the [=remote end=] is unable to configure proxy settings per [=user context=],
        or is unable to configure the proxy with |proxy configuration|, return  [=error=] with
        [=error code=] [=unsupported operation=].
 
@@ -7956,8 +7956,6 @@ request sent</dfn> steps given |request|:
 
             1. Let |proxy configuration| be |session|'s
                [=user context to proxy configuration map=][|user context|].
-
-            1. Assert |proxy configuration| can be configured.
 
             1. Take implementation-defined steps to ensure that |request| uses
                the proxy defined by the |proxy configuration|.

--- a/index.bs
+++ b/index.bs
@@ -7917,12 +7917,12 @@ and |user context| are:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi before
 request sent</dfn> steps given |request|:
 
-1. For each |user context| in the [=set of user contexts=]:
+1. For each |session| in [=active BiDI sessions=]
+
+   1. For each |user context| in the [=set of user contexts=]:
 
    1. If the [=request originates in user context=] steps with |request| and
-      |user context| return true:
-
-      1. For each |session| in [=active BiDI sessions=]
+         |user context| return true:
 
          Note: |user context| can be in not more then one
          [=user context to accept insecure certificates override map=].

--- a/index.bs
+++ b/index.bs
@@ -7918,12 +7918,12 @@ and |user context| are:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi before
 request sent</dfn> steps given |request|:
 
-1. For each |session| in [=active BiDI sessions=]
-
-   1. For each |user context| in the [=set of user contexts=]:
+1. For each |user context| in the [=set of user contexts=]:
 
    1. If the [=request originates in user context=] steps with |request| and
-         |user context| return true:
+      |user context| return true:
+
+      1. For each |session| in [=active BiDI sessions=]
 
          Note: |user context| can be in not more then one
          [=user context to accept insecure certificates override map=].
@@ -7946,20 +7946,6 @@ request sent</dfn> steps given |request|:
             1. Otherwise, when running the [=Basic Certificate Processing=] steps
                for |request|, perform all steps along with any implementation-defined
                certificate validation steps.
-
-         Note: |user context| can be in not more then one
-         [=user context to proxy configuration map=].
-
-         1. If |session|'s [=user context to proxy configuration map=]
-            [=set/contains|contain=] |user context|:
-
-            1. Let |proxy configuration| be |session|'s
-               [=user context to proxy configuration map=][|user context|].
-
-            1. Assert |proxy configuration| can be configured.
-
-            1. Take implementation-defined steps to ensure that |request| uses
-               the proxy defined by the |proxy configuration|.
 
          Note: |user context| can be in not more then one
          [=user context to proxy configuration map=].

--- a/index.bs
+++ b/index.bs
@@ -7958,7 +7958,11 @@ request sent</dfn> steps given |request|:
                [=user context to proxy configuration map=][|user context|].
 
             1. Take implementation-defined steps to ensure that |request| uses
-               the proxy defined by the |proxy configuration|.
+               the proxy settings defined by the |proxy configuration|.
+               
+               Note: the settings are validated when the user context is created and so
+               are assumed to be valid at this stage; any error accessing the proxy will
+               be reported as a network error when handling the request.
 
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.

--- a/index.bs
+++ b/index.bs
@@ -64,6 +64,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: close the session; url: dfn-close-the-session
     text: cookie domain; url: dfn-cookie-domain
     text: cookie expiry time; url: dfn-cookie-expiry-time
+    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: cookie HTTP only; url: dfn-cookie-http-only
     text: cookie name; url: dfn-cookie-name
     text: cookie path; url: dfn-cookie-path
@@ -2674,7 +2675,8 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       )
 
       browser.CreateUserContextParameters = {
-        ? acceptInsecureCerts: bool
+        ? acceptInsecureCerts: bool,
+        ? proxy: session.ProxyConfiguration
       }
       </pre>
    </dd>
@@ -2707,6 +2709,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. [=map/Set=] |session|'s
       [=user context to accept insecure certificates override map=][|user context|]
       to |acceptInsecureCerts|.
+
+1. If |command parameters| [=map/contains=] "<code>proxy</code>":
+
+   1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
+
+   1. Take implementation-defined steps to set the |user context|'s proxy using the
+      |proxy| proxy configuration. If the |proxy| cannot be configured return
+      [=error=] with [=error code=] [=invalid argument=].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -7929,7 +7929,7 @@ request sent</dfn> steps given |request|:
          [=user context to accept insecure certificates override map=].
 
          1. If |session|'s [=user context to accept insecure certificates override map=]
-            [=map/contains|contain=] |user context|:
+            [=map/contains=] |user context|:
 
             1. Let |accept insecure certificates| be |session|'s
                [=user context to accept insecure certificates override map=][|user context|].
@@ -7951,7 +7951,7 @@ request sent</dfn> steps given |request|:
          [=user context to proxy configuration map=].
 
          1. If |session|'s [=user context to proxy configuration map=]
-            [=set/contains|contain=] |user context|:
+            [=set/contains=] |user context|:
 
             1. Let |proxy configuration| be |session|'s
                [=user context to proxy configuration map=][|user context|].


### PR DESCRIPTION
Extend `browser.createUserContext` with `proxy` configuration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/897.html" title="Last updated on May 20, 2025, 4:06 PM UTC (50e0c62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/897/18006eb...50e0c62.html" title="Last updated on May 20, 2025, 4:06 PM UTC (50e0c62)">Diff</a>