### PR TITLE
Use Event production in 'emit an event' assertion

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1215,8 +1215,7 @@ To <dfn>get valid top-level traversables by ids</dfn> given a [=/list=] of conte
 
 <div algorithm> To <dfn export>emit an event</dfn> given |session|, and |body|:
 
-1. [=Assert=]: |body| has [=map/size=] 2 and [=map/contains=] "<code>method</code>"
-   and "<code>params</code>".
+1. [=Assert=]: |body| matches the <code>Event</code> production.
 
 1. Let |serialized| be the result of [=serialize an infra value to JSON
    bytes=] given |body|.


### PR DESCRIPTION
The `emit an event` algorithm previously asserted that the event body only contains `method` and `params`, which is no longer the case after #484 added the `type` field.

Instead of such low-level assertion, this commit changes the assertion to match against the Event type production.