### PR TITLE
emulate geolocation POSITION_UNAVAILABLE error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5624,8 +5624,10 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
       )
 
       emulation.SetGeolocationOverrideParameters = {
-        ? coordinates: emulation.GeolocationCoordinates / null,
-        ? error: emulation.GeolocationPositionError,
+        (
+          (coordinates: emulation.GeolocationCoordinates / null) //
+          (error: emulation.GeolocationPositionError)
+        ),
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }

--- a/index.bs
+++ b/index.bs
@@ -182,6 +182,7 @@ spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
     text: height dimension; url: rectangle-height-dimension
 spec: GEOLOCATION; urlPrefix: https://www.w3.org/TR/geolocation/
   type: dfn
+    text: POSITION_UNAVAILABLE; url: #dom-geolocationpositionerror-position_unavailable
     text: set emulated position data; url: #dfn-set-emulated-position-data
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
@@ -5624,7 +5625,7 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
 
       emulation.SetGeolocationOverrideParameters = {
         ? coordinates: emulation.GeolocationCoordinates / null,
-        ? error: emulation.GeolocationPositionError / null,
+        ? error: emulation.GeolocationPositionError,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }
@@ -5640,8 +5641,7 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
       }
 
       emulation.GeolocationPositionError = {
-         code: js-uint,
-         message: text
+         type: "positionUnavailable"
       }
     </pre>
    </dd>
@@ -5672,13 +5672,16 @@ The [=remote end steps=] with |command parameters| are:
    "<code>altitude</code>", return [=error=] with [=error code=]
    [=invalid argument=].
 
-1. If |command parameters| [=map/contains=] "<code>coordinates</code>", let
-   |emulated position data| be |command parameters|["<code>coordinates</code>"].
+1. If |command parameters| [=map/contains=] "<code>error</code>":
 
-1. Otherwise, let |emulated position data| be |command parameters|["<code>error</code>"].
+   1. Assert |command parameters|["<code>error</code>"]["<code>type</code>"] equals
+      "<code>positionUnavailable</code>".
 
-Note: Setting either the <code>coordinates</code> parameter or the <code>error</code>
-parameter to <code>null</code> removes the geolocation override.
+   1. Let |emulated position data| be a [=/map=] with value of
+      «"code" → [=POSITION_UNAVAILABLE=], "message" → ""».
+
+1. Otherwise, let |emulated position data| be
+   |command parameters|["<code>coordinates</code>"].
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
    and |command parameters| [=map/contains=] "<code>context</code>",

--- a/index.bs
+++ b/index.bs
@@ -5661,6 +5661,10 @@ The [=remote end steps=] with |command parameters| are:
    and |command parameters| [=map/contains=] "<code>error</code>", return [=error=]
    with [=error code=] [=invalid argument=].
 
+1. If |command parameters| doesn't [=map/contain=] "<code>coordinates</code>"
+   and |command parameters| doesn't [=map/contain=] "<code>error</code>", return
+   [=error=] with [=error code=] [=invalid argument=].
+
 1. If |command parameters| [=map/contains=] "<code>coordinates</code>" and
    |command parameters|["<code>coordinates</code>"] [=map/contains=]
    "<code>altitudeAccuracy</code>" and

--- a/index.bs
+++ b/index.bs
@@ -5623,7 +5623,8 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
       )
 
       emulation.SetGeolocationOverrideParameters = {
-        coordinates: emulation.GeolocationCoordinates / null,
+        ? coordinates: emulation.GeolocationCoordinates / null,
+        ? error: emulation.GeolocationPositionError / null,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }
@@ -5636,6 +5637,11 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
          ? altitudeAccuracy: (float .ge 0.0) / null .default null,
          ? heading: (0.0...360.0) / null .default null,
          ? speed: (float .ge 0.0) / null .default null,
+      }
+
+      emulation.GeolocationPositionError = {
+         code: js-uint,
+         message: text
       }
     </pre>
    </dd>
@@ -5651,9 +5657,24 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
 
 The [=remote end steps=] with |command parameters| are:
 
-1. If |command parameters| [=map/contains=] "<code>altitudeAccuracy</code>"
-   and |command parameters| doesn't [=map/contain=] "<code>altitude</code>",
-   return [=error=] with [=error code=] [=invalid argument=].
+1. If |command parameters| [=map/contains=] "<code>coordinates</code>"
+   and |command parameters| [=map/contains=] "<code>error</code>", return [=error=]
+   with [=error code=] [=invalid argument=].
+
+1. If |command parameters| [=map/contains=] "<code>coordinates</code>" and
+   |command parameters|["<code>coordinates</code>"] [=map/contains=]
+   "<code>altitudeAccuracy</code>" and
+   |command parameters|["<code>coordinates</code>"] doesn't [=map/contain=]
+   "<code>altitude</code>", return [=error=] with [=error code=]
+   [=invalid argument=].
+
+1. If |command parameters| [=map/contains=] "<code>coordinates</code>", let
+   |emulated position data| be |command parameters|["<code>coordinates</code>"].
+
+1. Otherwise, let |emulated position data| be |command parameters|["<code>error</code>"].
+
+Note: Setting either the <code>coordinates</code> parameter or the <code>error</code>
+parameter to <code>null</code> removes the geolocation override.
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
    and |command parameters| [=map/contains=] "<code>context</code>",
@@ -5675,7 +5696,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |user context| of |user contexts|:
 
-      1. [=map/Set=] [=geolocation overrides map=][|user context|] to |command parameters|["<code>coordinates</code>"].
+      1. [=map/Set=] [=geolocation overrides map=][|user context|] to |emulated position data|.
 
       1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]
          whose [=associated user context=] is |user context|:
@@ -5684,7 +5705,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. For each |navigable| of |navigables|:
 
-   1. [=Set emulated position data=] with |navigable| and |command parameters|["<code>coordinates</code>"].
+   1. [=Set emulated position data=] with |navigable| and |emulated position data|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -5684,6 +5684,8 @@ The [=remote end steps=] with |command parameters| are:
       production, with <code>code</code> field set to [=POSITION_UNAVAILABLE=] and
       <code>message</code> field set to the empty string.
 
+      Note: <code>message</code> will be ignored by implementation according to the geolocation spec.
+
 1. Otherwise, let |emulated position data| be
    |command parameters|["<code>coordinates</code>"].
 

--- a/index.bs
+++ b/index.bs
@@ -5660,14 +5660,6 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
 
 The [=remote end steps=] with |command parameters| are:
 
-1. If |command parameters| [=map/contains=] "<code>coordinates</code>"
-   and |command parameters| [=map/contains=] "<code>error</code>", return [=error=]
-   with [=error code=] [=invalid argument=].
-
-1. If |command parameters| doesn't [=map/contain=] "<code>coordinates</code>"
-   and |command parameters| doesn't [=map/contain=] "<code>error</code>", return
-   [=error=] with [=error code=] [=invalid argument=].
-
 1. If |command parameters| [=map/contains=] "<code>coordinates</code>" and
    |command parameters|["<code>coordinates</code>"] [=map/contains=]
    "<code>altitudeAccuracy</code>" and

--- a/index.bs
+++ b/index.bs
@@ -182,6 +182,7 @@ spec: GEOMETRY; urlPrefix: https://drafts.fxtf.org/geometry/
     text: height dimension; url: rectangle-height-dimension
 spec: GEOLOCATION; urlPrefix: https://www.w3.org/TR/geolocation/
   type: dfn
+    text: GeolocationPositionError; url: #dom-geolocationpositionerror
     text: POSITION_UNAVAILABLE; url: #dom-geolocationpositionerror-position_unavailable
     text: set emulated position data; url: #dfn-set-emulated-position-data
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -5679,8 +5680,9 @@ The [=remote end steps=] with |command parameters| are:
    1. Assert |command parameters|["<code>error</code>"]["<code>type</code>"] equals
       "<code>positionUnavailable</code>".
 
-   1. Let |emulated position data| be a [=/map=] with value of
-      «"code" → [=POSITION_UNAVAILABLE=], "message" → ""».
+   1. Let |emulated position data| be a [=/map=] matching [=GeolocationPositionError=]
+      production, with <code>code</code> field set to [=POSITION_UNAVAILABLE=] and
+      <code>message</code> field set to the empty string.
 
 1. Otherwise, let |emulated position data| be
    |command parameters|["<code>coordinates</code>"].


### PR DESCRIPTION
WPT tests: https://github.com/web-platform-tests/wpt/pull/52250

I don't think we need to emulate other errors (PERMISSION_DENIED, TIMEOUT), as it can be tested without emulation.

The geolocation emulation spec was written to support any kind of error emulations, which is an overkill, and is tricky to be implemented, so I propose to limit the error emulation only to "POSITION_UNAVAILABLE" on the WebDriver BiDi side.

From geolocation spec:
> If `emulatedPositionData` is a [GeolocationPositionError](https://www.w3.org/TR/geolocation/#dom-geolocationpositionerror):
[Call back with error](https://www.w3.org/TR/geolocation/#dfn-call-back-with-error) passing errorCallback and emulatedPositionData.