### PR TITLE
fix(cddl): fix CDDL syntax for emulation.SetGeolocationOverrideParameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5624,14 +5624,23 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
         params: emulation.SetGeolocationOverrideParameters
       )
 
-      emulation.SetGeolocationOverrideParameters = {
-        (
-          (coordinates: emulation.GeolocationCoordinates / null) //
-          (error: emulation.GeolocationPositionError)
-        ),
+      emulation.SetGeolocationOverrideParameters = (
+        emulation.SetGeolocationOverrideSuccessParameters /
+        emulation.SetGeolocationOverrideErrorParameters
+      )
+
+      emulation.SetGeolocationOverrideBaseParameters = (
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
-      }
+      )
+
+      emulation.SetGeolocationOverrideSuccessParameters = {
+        coordinates: emulation.GeolocationCoordinates / null
+      } & emulation.SetGeolocationOverrideBaseParameters
+
+      emulation.SetGeolocationOverrideErrorParameters = {
+        error: emulation.GeolocationPositionError
+      } & emulation.SetGeolocationOverrideBaseParameters
 
       emulation.GeolocationCoordinates = {
          latitude: -90.0..90.0,


### PR DESCRIPTION
I find the current definition of `emulation.SetGeolocationOverrideParameters` somewhat unusual and inconsistent with the style used throughout the rest of the specification.

```cddl
emulation.SetGeolocationOverrideParameters = {
   (
      (coordinates: emulation.GeolocationCoordinates / null) //
      (error: emulation.GeolocationPositionError)
   ),
   ? contexts: [+browsingContext.BrowsingContext],
   ? userContexts: [+browser.UserContext],
}
```

Aside from concerns about whether this is valid CDDL syntax—and the fact that some parsers may or may not support it—I recommend refactoring this definition to better align with the established structure used elsewhere in the spec. Specifically, we typically define separate types for success and error cases, then unify them with a top-level choice. For example:

```cddl
script.EvaluateResult = (
  script.EvaluateResultSuccess /
  script.EvaluateResultException
)

script.EvaluateResultSuccess = {
  type: "success",
  result: script.RemoteValue,
  realm: script.Realm
}

script.EvaluateResultException = {
  type: "exception",
  exceptionDetails: script.ExceptionDetails,
  realm: script.Realm
}
```

Applying a similar pattern to the emulation namespace would improve readability, tooling compatibility, and consistency across the specification.
