### PR TITLE
fix(cddl): fix usage of .and operator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8412,10 +8412,10 @@ script.LocalValue = (
   script.PrimitiveProtocolValue /
   script.ChannelValue /
   script.ArrayLocalValue /
-  script.DateLocalValue /
+  { script.DateLocalValue } /
   script.MapLocalValue /
   script.ObjectLocalValue /
-  script.RegExpLocalValue /
+  { script.RegExpLocalValue } /
   script.SetLocalValue
 )
 

--- a/index.bs
+++ b/index.bs
@@ -8426,10 +8426,10 @@ script.ArrayLocalValue = {
   value: script.ListLocalValue,
 }
 
-script.DateLocalValue = {
+script.DateLocalValue = (
   type: "date",
   value: text
-}
+)
 
 script.MappingLocalValue = [*[(script.LocalValue / text), script.LocalValue]];
 
@@ -8448,10 +8448,10 @@ script.RegExpValue = {
   ? flags: text,
 }
 
-script.RegExpLocalValue = {
+script.RegExpLocalValue = (
   type: "regexp",
   value: script.RegExpValue,
-}
+)
 
 script.SetLocalValue = {
   type: "set",
@@ -9204,15 +9204,17 @@ script.FunctionRemoteValue = {
   ? internalId: script.InternalId,
 }
 
-script.RegExpRemoteValue = {
+script.RegExpRemoteValue = &(
+  script.RegExpLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-} .and script.RegExpLocalValue
+)
 
-script.DateRemoteValue = {
+script.DateRemoteValue = &(
+  script.DateLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-} .and script.DateLocalValue
+)
 
 script.MapRemoteValue = {
   type: "map",

--- a/index.bs
+++ b/index.bs
@@ -9204,17 +9204,17 @@ script.FunctionRemoteValue = {
   ? internalId: script.InternalId,
 }
 
-script.RegExpRemoteValue = &(
+script.RegExpRemoteValue = {
   script.RegExpLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-)
+}
 
-script.DateRemoteValue = &(
+script.DateRemoteValue = {
   script.DateLocalValue,
   ? handle: script.Handle,
   ? internalId: script.InternalId,
-)
+}
 
 script.MapRemoteValue = {
   type: "map",


### PR DESCRIPTION
Section 3.8.5 of [RFC 8610](https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.5) does define two control operators: `.within` and `.and`. These are used in type controls — not as top-level structural merging operators like &.

`.and` is a valid CDDL control operator — but its use is limited. It is a control operator, not a general-purpose group or map merging operator like `&`. `.and` is used to constrain a value to conform to both a structural schema and a semantic type.
It takes two types, and a data item matches the type `X .and Y` if it matches both X and Y.

So this:

```
mytype = text .and tstr
```

Means: the data must match both `text` (the CDDL type) and `tstr` (presumably a semantic constraint/type definition).

It is not valid to write:

```
{ a: int } .and SomeOtherMap
```

IMHO this is not a valid application of `.and`, because you’re not applying it to a value, you’re trying to merge map structures — which is outside `.and`'s purpose.

A valid way to write:

```
color = text .and "red" / "green" / "blue"
```

This would mean: a string, constrained to only be "red", "green", or "blue".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/915.html" title="Last updated on May 6, 2025, 11:10 PM UTC (4a7735e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/915/5e3b177...4a7735e.html" title="Last updated on May 6, 2025, 11:10 PM UTC (4a7735e)">Diff</a>