### PR TITLE
hook "accept insecure certificates" to "WebDriver BiDi before request sent"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7901,7 +7901,7 @@ request sent</dfn> steps given |request|:
 
 1. For each |user context| in the [=set of user contexts=]:
 
-   1. If  [=request originates in user context=] steps with |request| and
+   1. If the [=request originates in user context=] steps with |request| and
       |user context| return true:
 
       1. For each |session| in [=active BiDI sessions=]

--- a/index.bs
+++ b/index.bs
@@ -2765,10 +2765,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
-   1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
+   1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
    1. Take implementation-defined steps to ensure that requests originating from the
-      |user context| use the proxy defined by the |proxy| configuration. If the
+      |user context| use the proxy defined by the |proxy configuration|. If the
       defined proxy cannot be configured return [=error=] with [=error code=]
       [=invalid argument=].
 

--- a/index.bs
+++ b/index.bs
@@ -7925,7 +7925,7 @@ request sent</dfn> steps given |request|:
                   implementation-defined certificate validation steps.
 
             1. Otherwise, when running the [=Basic Certificate Processing=] steps
-               for the |request|, the step a, along with any other
+               for |request|, perform step a, along with any other
                implementation-defined certificate validation steps, must not be
                skipped.
 

--- a/index.bs
+++ b/index.bs
@@ -7920,7 +7920,7 @@ request sent</dfn> steps given |request|:
                1. Assert [=endpoint node=] supports accepting insecure TLS
                   connections.
 
-               1. When running the [=Basic Certificate Processing=] steps for the
+               1. When running the [=Basic Certificate Processing=] steps for
                   |request|, skip step a, along with any other
                   implementation-defined certificate validation steps.
 

--- a/index.bs
+++ b/index.bs
@@ -64,7 +64,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: close the session; url: dfn-close-the-session
     text: cookie domain; url: dfn-cookie-domain
     text: cookie expiry time; url: dfn-cookie-expiry-time
-    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: cookie HTTP only; url: dfn-cookie-http-only
     text: cookie name; url: dfn-cookie-name
     text: cookie path; url: dfn-cookie-path

--- a/index.bs
+++ b/index.bs
@@ -7925,9 +7925,8 @@ request sent</dfn> steps given |request|:
                   implementation-defined certificate validation steps.
 
             1. Otherwise, when running the [=Basic Certificate Processing=] steps
-               for |request|, perform step a, along with any other
-               implementation-defined certificate validation steps, must not be
-               skipped.
+               for |request|, perform all steps along with any implementation-defined
+               certificate validation steps.
 
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.

--- a/index.bs
+++ b/index.bs
@@ -1511,8 +1511,11 @@ contexts=] that are not [=empty user contexts=] must not be removed from the
 [=set of user contexts=].
 
 A [=BiDi session=] has a
-<dfn>user contexts with insecure certificates overrides</dfn>, which is a [=/set=] of
-[=user contexts=].
+<dfn>user context to accept insecure certificates override map</dfn>, which is a
+[=/map=] between [=user contexts=] and boolean.
+
+A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
+a [=/map=] between [=user contexts=] and [=proxy configuration=].
 
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
@@ -1617,13 +1620,13 @@ To <dfn>cleanup the session</dfn> given |session|:
 
 1. [=Close the WebSocket connections=] with |session|.
 
-1. For each |user context| in the |session|'s
-   [=user contexts with insecure certificates overrides=]:
+1. For each |user context| in the [=set of user contexts=]:
 
-   1. [=Restore insecure certificates behavior=] with |user context|.
+   1. [=map/Remove=] |session|'s
+      [=user context to accept insecure certificates override map=][|user context|].
 
-   1. [=set/Remove=] |user context| from |session|'s
-      [=user contexts with insecure certificates overrides=].
+   1. [=map/Remove=] |session|'s
+      [=user context to proxy configuration map=][|user context|].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -2692,61 +2695,6 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 
 <div algorithm="remote end steps for browser.createUserContext">
 
-<div algorithm>
-The steps to check if <dfn>request originates in user context</dfn> given |request|
-and |user context| are:
-
-1. Let |settings| be |request|'s [=request/client=].
-
-1. Let |related navigables| be [=get related navigables=] with |settings|.
-
-1. For |navigable| in |related navigables|:
-
-  1. If |navigable|'s [=associated user context=] is |user context| return true.
-
-1. Return false.
-
-</div>
-
-<div algorithm>
-To <dfn>restore insecure certificates behavior</dfn> given |user context|:
-
-1. If [=endpoint node=]'s [=accept insecure TLS=] flag is true and [=endpoint node=]
-   supports accepting insecure TLS connections,
-   [=override insecure certificates behavior=] with |user context| and true.
-
-1. Otherwise, [=override insecure certificates behavior=] with |user context| and
-   false.
-
-</div>
-
-<div algorithm>
-To <dfn>override insecure certificates behavior</dfn> given |user context| and
-|acceptInsecureCerts|:
-
-1. If |acceptInsecureCerts| is true:
-
-   1. If [=endpoint node=] doesn't support accepting insecure TLS connections,
-      return [=error=] with [=error code=] [=unsupported operation=].
-
-   1. For any network request |request| for which the
-      [=request originates in user context=] steps with |request| and |user context|
-      return true, when running the [=Basic Certificate Processing=] steps for that
-      request, skip step a, along with any other implementation-specific certificate
-      validation steps.
-
-   1. Return.
-
-1. Assert |acceptInsecureCerts| is false.
-
-1. For any network request |request| for which the
-   [=request originates in user context=] steps with |request| and |user context|
-   return true, when running the [=Basic Certificate Processing=] steps for that
-   request, the step a, along with any other implementation-specific certificate
-   validation steps, must not be skipped.
-
-</div>
-
 The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |user context| be a new [=user context=].
@@ -2756,20 +2704,27 @@ The [=remote end steps=] with |session| and |command parameters| are:
   Note: If "<code>acceptInsecureCerts</code>" is set, it overrides the
   [=accept insecure TLS=] flag's behavior.
 
-  1. [=Override insecure certificates behavior=] with |user context| and
-     |command parameters|["<code>acceptInsecureCerts</code>"].
+   1. Let |acceptInsecureCerts| be
+      |command parameters|["<code>acceptInsecureCerts</code>"]:
 
-  1. [=set/Append=] |user context| to |session|'s
-     [=user contexts with insecure certificates overrides=].
+   1. If |acceptInsecureCerts| is true and [=endpoint node=] doesn't support
+      accepting insecure TLS connections, return [=error=] with [=error code=]
+      [=unsupported operation=].
+
+   1. [=map/Set=] |session|'s
+      [=user context to accept insecure certificates override map=][|user context|]
+      to |acceptInsecureCerts|.
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
    1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
-   1. Take implementation-defined steps to ensure that requests originating from the
-      |user context| use the proxy defined by the |proxy configuration|. If the
-      defined proxy cannot be configured return [=error=] with [=error code=]
-      [=invalid argument=].
+   1. If the |proxy configuration| cannot be configured return [=error=] with
+      [=error code=] [=invalid argument=].
+
+   1. [=map/Set=] |session|'s
+      [=user context to proxy configuration map=][|user context|]
+      to |proxy configuration|.
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -7943,8 +7898,67 @@ This event is emitted before a request is sent (either over the network or
 before it's handled by a serviceworker or a local cache).
 
 <div algorithm>
+The steps to check if <dfn>request originates in user context</dfn> given |request|
+and |user context| are:
+
+1. Let |settings| be |request|'s [=request/client=].
+
+1. Let |related navigables| be [=get related navigables=] with |settings|.
+
+1. For |navigable| in |related navigables|:
+
+  1. If |navigable|'s [=associated user context=] is |user context| return true.
+
+1. Return false.
+</div>
+
+<div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi before
 request sent</dfn> steps given |request|:
+
+1. For each |session| in [=active BiDI sessions=]
+
+   1. For each |user context| in the [=set of user contexts=]:
+
+      1. If  [=request originates in user context=] steps with |request| and
+         |user context| return true:
+
+         Note: |user context| can be in not more then one
+         [=user context to accept insecure certificates override map=].
+
+         1. If |session|'s [=user context to accept insecure certificates override map=]
+            [=map/contains|contain=] |user context|:
+
+            1. Let |accept insecure certificates| be |session|'s
+               [=user context to accept insecure certificates override map=][|user context|].
+
+            1. If |accept insecure certificates| is true:
+
+               1. Assert [=endpoint node=] supports accepting insecure TLS
+                  connections.
+
+               1. When running the [=Basic Certificate Processing=] steps for the
+                  |request|, skip step a, along with any other
+                  implementation-defined certificate validation steps.
+
+            1. Otherwise, when running the [=Basic Certificate Processing=] steps
+               for the |request|, the step a, along with any other
+               implementation-defined certificate validation steps, must not be
+               skipped.
+
+         Note: |user context| can be in not more then one
+         [=user context to proxy configuration map=].
+
+         1. If |session|'s [=user context to proxy configuration map=]
+            [=set/contains|contain=] |user context|:
+
+            1. Let |proxy configuration| be |session|'s
+               [=user context to proxy configuration map=][|user context|].
+
+            1. Assert |proxy configuration| can be configured.
+
+            1. Take implementation-defined steps to ensure that |request| uses
+               the proxy defined by the |proxy configuration|.
 
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.

--- a/index.bs
+++ b/index.bs
@@ -1514,9 +1514,6 @@ A [=BiDi session=] has a
 <dfn>user context to accept insecure certificates override map</dfn>, which is a
 [=/map=] between [=user contexts=] and boolean.
 
-A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
-a [=/map=] between [=user contexts=] and [=proxy configuration=].
-
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
 
@@ -1624,9 +1621,6 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. [=map/Remove=] |session|'s
       [=user context to accept insecure certificates override map=][|user context|].
-
-   1. [=map/Remove=] |session|'s
-      [=user context to proxy configuration map=][|user context|].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -2680,8 +2674,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       )
 
       browser.CreateUserContextParameters = {
-        ? acceptInsecureCerts: bool,
-        ? proxy: session.ProxyConfiguration
+        ? acceptInsecureCerts: bool
       }
       </pre>
    </dd>
@@ -2714,17 +2707,6 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. [=map/Set=] |session|'s
       [=user context to accept insecure certificates override map=][|user context|]
       to |acceptInsecureCerts|.
-
-1. If |command parameters| [=map/contains=] "<code>proxy</code>":
-
-   1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
-
-   1. If the |proxy configuration| cannot be configured return [=error=] with
-      [=error code=] [=invalid argument=].
-
-   1. [=map/Set=] |session|'s
-      [=user context to proxy configuration map=][|user context|]
-      to |proxy configuration|.
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 
@@ -7910,18 +7892,19 @@ and |user context| are:
   1. If |navigable|'s [=associated user context=] is |user context| return true.
 
 1. Return false.
+
 </div>
 
 <div algorithm>
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi before
 request sent</dfn> steps given |request|:
 
-1. For each |session| in [=active BiDI sessions=]
+1. For each |user context| in the [=set of user contexts=]:
 
-   1. For each |user context| in the [=set of user contexts=]:
+   1. If  [=request originates in user context=] steps with |request| and
+      |user context| return true:
 
-      1. If  [=request originates in user context=] steps with |request| and
-         |user context| return true:
+      1. For each |session| in [=active BiDI sessions=]
 
          Note: |user context| can be in not more then one
          [=user context to accept insecure certificates override map=].
@@ -7945,20 +7928,6 @@ request sent</dfn> steps given |request|:
                for the |request|, the step a, along with any other
                implementation-defined certificate validation steps, must not be
                skipped.
-
-         Note: |user context| can be in not more then one
-         [=user context to proxy configuration map=].
-
-         1. If |session|'s [=user context to proxy configuration map=]
-            [=set/contains|contain=] |user context|:
-
-            1. Let |proxy configuration| be |session|'s
-               [=user context to proxy configuration map=][|user context|].
-
-            1. Assert |proxy configuration| can be configured.
-
-            1. Take implementation-defined steps to ensure that |request| uses
-               the proxy defined by the |proxy configuration|.
 
 1. If [=before request sent map=] does not contain |request|, set [=before
    request sent map=][|request|] to a new set.

--- a/index.bs
+++ b/index.bs
@@ -2767,9 +2767,10 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
    1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
 
-   1. Take implementation-defined steps to set the |user context|'s proxy using the
-      |proxy| proxy configuration. If the |proxy| cannot be configured return
-      [=error=] with [=error code=] [=invalid argument=].
+   1. Take implementation-defined steps to ensure that requests originating from the
+      |user context| use the proxy defined by the |proxy| configuration. If the
+      defined proxy cannot be configured return [=error=] with [=error code=]
+      [=invalid argument=].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -64,6 +64,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: close the session; url: dfn-close-the-session
     text: cookie domain; url: dfn-cookie-domain
     text: cookie expiry time; url: dfn-cookie-expiry-time
+    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: cookie HTTP only; url: dfn-cookie-http-only
     text: cookie name; url: dfn-cookie-name
     text: cookie path; url: dfn-cookie-path
@@ -2677,7 +2678,8 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
       )
 
       browser.CreateUserContextParameters = {
-        ? acceptInsecureCerts: bool
+        ? acceptInsecureCerts: bool,
+        ? proxy: session.ProxyConfiguration
       }
       </pre>
    </dd>
@@ -2760,6 +2762,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
   1. [=set/Append=] |user context| to |session|'s
      [=user contexts with insecure certificates overrides=].
+
+1. If |command parameters| [=map/contains=] "<code>proxy</code>":
+
+   1. Let |proxy| be [=deserialize as a proxy=] with |command parameters|["<code>proxy</code>"].
+
+   1. Take implementation-defined steps to set the |user context|'s proxy using the
+      |proxy| proxy configuration. If the |proxy| cannot be configured return
+      [=error=] with [=error code=] [=invalid argument=].
 
 1. [=set/Append=] |user context| to the [=set of user contexts=].
 


### PR DESCRIPTION
This makes defining of "accept insecure certificates" and "proxy configuration" more precise.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/917.html" title="Last updated on May 13, 2025, 6:07 PM UTC (2f10ea3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/917/56a43e4...2f10ea3.html" title="Last updated on May 13, 2025, 6:07 PM UTC (2f10ea3)">Diff</a>