### PR TITLE
Do not use request's window concept

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6121,15 +6121,14 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 1. Let |top-level navigable id| be null.
 
-1. If |request|'s [=request/window=] is an [=environment settings object=]:
+1. If |request|'s [=request/client=] is an [=environment settings object=]:
 
-  1. Let |environment settings| be |request|'s [=request/window=]
+  1. Let |environment settings| be |request|'s [=request/client=].
 
   1. If there is a [=/navigable=] whose [=active window=] is |environment
      settings|' [=environment settings object/global object=], set |navigable id|
-     to the [=navigable id=] for that navigable, and set |top-level navigable id|
-     to be [=/top-level traversable=]'s [=navigable id=] for that
-     context.
+     to that navigable's [=navigable id=], and set |top-level navigable id| to
+     that navigable's [=navigable/top-level traversable=]'s [=navigable id=].
 
 1. Let |intercepts| be the result of [=get the network intercepts=] with
    |session|, |event|, |request|, and |top-level navigable id|.
@@ -7733,13 +7732,13 @@ The <dfn export>WebDriver BiDi cache behavior</dfn> steps given |request| are:
 
 1. Let |navigable| be null.
 
-1. If |request|'s [=request/window=] is an [=environment settings object=]:
+1. If |request|'s [=request/client=] is an [=environment settings object=]:
 
-  1. Let |environment settings| be |request|'s [=request/window=]
+  1. Let |environment settings| be |request|'s [=request/client=].
 
   1. If there is a [=/navigable=] whose [=active window=] is |environment
-     settings|' [=environment settings object/global object=], set |navigable| to
-     the [=top-level browsing context=] for that browsing context.
+     settings|' [=environment settings object/global object=], set |navigable|
+     to that navigable's [=navigable/top-level traversable=].
 
 1. If |navigable| is not null and [=navigable cache behavior map=] [=set/contains=]
    |navigable|, return [=navigable cache behavior map=][|navigable|].


### PR DESCRIPTION
Per https://github.com/whatwg/fetch/pull/1823, this concept is going away. Instead, use the request's client, which is equivalent for this spec's purposes.

----

This needs careful review by experts as, unlike almost all other update PRs linked from https://github.com/whatwg/fetch/pull/1823, it's possible that WebDriver BiDi actually does care about the distinction between client and window. But, I think this change is correct.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/webdriver-bidi/pull/918.html" title="Last updated on May 13, 2025, 5:29 AM UTC (7c99d8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/918/56a43e4...domenic:7c99d8f.html" title="Last updated on May 13, 2025, 5:29 AM UTC (7c99d8f)">Diff</a>