### PR TITLE
fix(session.ProxyConfiguration): make it a group to allow group choices

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1713,13 +1713,13 @@ with parameter |value| is:
 [=remote end definition=] and [=local end definition=]
 
 <pre class="cddl remote-cddl local-cddl">
-session.ProxyConfiguration = {
+session.ProxyConfiguration = (
    session.AutodetectProxyConfiguration //
    session.DirectProxyConfiguration //
    session.ManualProxyConfiguration //
    session.PacProxyConfiguration //
    session.SystemProxyConfiguration
-}
+)
 
 session.AutodetectProxyConfiguration = (
    proxyType: "autodetect",


### PR DESCRIPTION
As we have established in similar PRs, group choices can only be done with groups, __not__ maps.

This is similar to other places in the spec, e.g.:

- `BrowserCommand`
- `BrowsingContextCommand`
- `BrowsingContextEvent`
- etc.