### PR TITLE
`browsingContext.downloadEnd` event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5424,8 +5424,11 @@ started</dfn> steps given |navigable| and |navigation status|:
          params: browsingContext.DownloadFinishedParams
         )
 
+        browsingContext.DownloadFinishedStatus = "canceled" / "complete"
+
         browsingContext.DownloadFinishedParams = {
-          filepath: text,
+          status: browsingContext.DownloadFinishedStatus
+          ? filepath: text,
           browsingContext.BaseNavigationInfo
         }
       </pre>
@@ -5443,7 +5446,8 @@ steps given |navigable| and |navigation status|:
    production, with the <code>context</code> field set to |navigation info|["<code>context</code>"],
    the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"], the
    <code>timestamp</code> field set to |navigation info|["<code>timestamp</code>"], the
-   <code>url</code> field set to |navigation info|["<code>url</code>"] and
+   <code>url</code> field set to |navigation info|["<code>url</code>"], the
+   <code>status</code> field set to |navigation info|["<code>status</code>"], and
    <code>filepath</code> field set to |navigation status|'s
    <code>downloadedFilepath</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -5428,7 +5428,7 @@ started</dfn> steps given |navigable| and |navigation status|:
 
         browsingContext.DownloadFinishedParams = {
           status: browsingContext.DownloadFinishedStatus
-          ? filepath: text,
+          ? filepath: text / null,
           browsingContext.BaseNavigationInfo
         }
       </pre>
@@ -5439,30 +5439,38 @@ started</dfn> steps given |navigable| and |navigation status|:
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download finished</dfn>
 steps given |navigable| and |navigation status|:
 
- 1. Let |navigation info| be the result of [=get the navigation info=] given |navigable| and
-    |navigation status|.
+1. Let |navigation info| be the result of [=get the navigation info=] given
+   |navigable| and |navigation status|.
 
-1. Let |params| be a [=/map=] matching the <code>browsingContext.DownloadFinishedParams</code>
-   production, with the <code>context</code> field set to |navigation info|["<code>context</code>"],
-   the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"], the
-   <code>timestamp</code> field set to |navigation info|["<code>timestamp</code>"], the
-   <code>url</code> field set to |navigation info|["<code>url</code>"], the
-   <code>status</code> field set to |navigation info|["<code>status</code>"], and
-   <code>filepath</code> field set to |navigation status|'s
+1. Assert |navigation info|["<code>status</code>"] is not "<code>pending</code>".
+
+1. Let |params| be a [=/map=] matching the
+   <code>browsingContext.DownloadFinishedParams</code> production, with the
+   <code>status</code> field set to |navigation info|["<code>status</code>"], the <code>context</code> field set to
+   |navigation info|["<code>context</code>"], the <code>navigation</code> field set
+   to |navigation info|["<code>navigation</code>"], the <code>timestamp</code> field
+   set to |navigation info|["<code>timestamp</code>"], and the <code>url</code> field
+   set to |navigation info|["<code>url</code>"].
+
+1. If |navigation info|["<code>status</code>"] is "<code>complete</code>", set
+   |params|["<code>filepath</code>"] to |navigation status|'s
    <code>downloadedFilepath</code>.
 
- 1. Let |body| be a [=/map=] matching the
-     <code>browsingContext.DownloadFinished</code> production, with the
-     <code>params</code> field set to |params|.
+   Note: <code>downloadedFilepath</code> can be null for completed download if the
+   file is not available for whatever reason.
 
- 1. Let |navigation id| be |navigation status|'s id.
+1. Let |body| be a [=/map=] matching the
+   <code>browsingContext.DownloadFinished</code> production, with the
+   <code>params</code> field set to |params|.
 
- 1. Let |related navigables| be a [=/set=] containing |navigable|.
+1. Let |navigation id| be |navigation status|'s id.
 
- 1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+1. Let |related navigables| be a [=/set=] containing |navigable|.
 
- 1. For each |session| in the [=set of sessions for which an event is enabled=]
-    given "<code>browsingContext.downloadFinished</code>" and |related navigables|:
+1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>browsingContext.downloadFinished</code>" and |related navigables|:
 
    1. [=Emit an event=] with |session| and |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -5429,7 +5429,7 @@ started</dfn> steps given |navigable| and |navigation status|:
         browsingContext.DownloadFinishedParams = {
           (
             browsingContext.DownloadCanceledParams //
-            browsingContext.DownloadCompleteParams //
+            browsingContext.DownloadCompleteParams
           )
         }
 

--- a/index.bs
+++ b/index.bs
@@ -5484,7 +5484,7 @@ steps given |navigable| and |navigation status|:
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
-1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+1. [=Resume=].
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.downloadFinished</code>" and |related navigables|:

--- a/index.bs
+++ b/index.bs
@@ -3056,7 +3056,7 @@ BrowsingContextEvent = (
   browsingContext.ContextCreated //
   browsingContext.ContextDestroyed //
   browsingContext.DomContentLoaded //
-  browsingContext.DownloadFinished //
+  browsingContext.DownloadEnd //
   browsingContext.DownloadWillBegin //
   browsingContext.FragmentNavigated //
   browsingContext.HistoryUpdated //
@@ -5415,18 +5415,18 @@ started</dfn> steps given |navigable| and |navigation status|:
 
 </div>
 
-#### The browsingContext.downloadFinished Event #### {#event-browsingContext-downloadFinished}
+#### The browsingContext.downloadEnd Event #### {#event-browsingContext-downloadEnd}
 
 <dl>
    <dt>Event Type</dt>
    <dd>
       <pre class="cddl local-cddl">
-        browsingContext.DownloadFinished = (
-          method: "browsingContext.downloadFinished",
-          params: browsingContext.DownloadFinishedParams
+        browsingContext.DownloadEnd = (
+          method: "browsingContext.downloadEnd",
+          params: browsingContext.DownloadEndParams
         )
 
-        browsingContext.DownloadFinishedParams = {
+        browsingContext.DownloadEndParams = {
           (
             browsingContext.DownloadCanceledParams //
             browsingContext.DownloadCompleteParams
@@ -5480,13 +5480,13 @@ steps given |navigable| and |navigation status|:
    |navigation info|["<code>url</code>"].
 
 1. Let |body| be a [=/map=] matching the
-   <code>browsingContext.DownloadFinished</code> production, with the
+   <code>browsingContext.DownloadEnd</code> production, with the
    <code>params</code> field set to |params|.
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]
-   given "<code>browsingContext.downloadFinished</code>" and |related navigables|:
+   given "<code>browsingContext.downloadEnd</code>" and |related navigables|:
 
    1. [=Emit an event=] with |session| and |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -5437,7 +5437,7 @@ started</dfn> steps given |navigable| and |navigation status|:
 
         browsingContext.DownloadCompleteParams = {
           status: "complete"
-          ? filepath: text / null,
+          filepath: text / null,
           browsingContext.BaseNavigationInfo
         }
       </pre>

--- a/index.bs
+++ b/index.bs
@@ -3014,7 +3014,8 @@ The progress of navigation is communicated using an immutable
   <dd>If the navigation is a download, suggested filename, otherwise null.</dd>
 
   <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-downloaded-filepath">downloadedFilepath</dfn></dt>
-  <dd>If the navigation is a download which is finished, absolute filepath of the downloaded file, otherwise null.</dd>
+  <dd>If the navigation is a download which is finished and the downloaded file is
+  available, absolute filepath of the downloaded file, otherwise null.</dd>
 </dl>
 
 ### Definition ### {#module-browsingContext-definition}

--- a/index.bs
+++ b/index.bs
@@ -3056,6 +3056,7 @@ BrowsingContextEvent = (
   browsingContext.ContextCreated //
   browsingContext.ContextDestroyed //
   browsingContext.DomContentLoaded //
+  browsingContext.DownloadFinished //
   browsingContext.DownloadWillBegin //
   browsingContext.FragmentNavigated //
   browsingContext.HistoryUpdated //
@@ -5421,8 +5422,8 @@ started</dfn> steps given |navigable| and |navigation status|:
    <dd>
       <pre class="cddl local-cddl">
         browsingContext.DownloadFinished = (
-         method: "browsingContext.downloadFinished",
-         params: browsingContext.DownloadFinishedParams
+          method: "browsingContext.downloadFinished",
+          params: browsingContext.DownloadFinishedParams
         )
 
         browsingContext.DownloadFinishedParams = (

--- a/index.bs
+++ b/index.bs
@@ -5426,21 +5426,23 @@ started</dfn> steps given |navigable| and |navigation status|:
           params: browsingContext.DownloadFinishedParams
         )
 
-        browsingContext.DownloadFinishedParams = (
-          browsingContext.DownloadCanceledParams //
-          browsingContext.DownloadCompleteParams //
-        )
-
-        browsingContext.DownloadCanceledParams = {
-          status: "canceled",
-          browsingContext.BaseNavigationInfo
+        browsingContext.DownloadFinishedParams = {
+          (
+            browsingContext.DownloadCanceledParams //
+            browsingContext.DownloadCompleteParams //
+          )
         }
 
-        browsingContext.DownloadCompleteParams = {
+        browsingContext.DownloadCanceledParams = (
+          status: "canceled",
+          browsingContext.BaseNavigationInfo
+        )
+
+        browsingContext.DownloadCompleteParams = (
           status: "complete",
           filepath: text / null,
           browsingContext.BaseNavigationInfo
-        }
+        )
       </pre>
    </dd>
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -5450,8 +5450,8 @@ steps given |navigable| and |navigation status|:
 1. Let |navigation info| be the result of [=get the navigation info=] given
    |navigable| and |navigation status|.
 
-1. Assert |navigation info|["<code>status</code>"] is "<code>complete</code>" or
-   "<code>canceled</code>".
+1. Assert |navigation info|["<code>status</code>"] is equal to either
+   "<code>complete</code>" or "<code>canceled</code>".
 
 1. If |navigation info|["<code>status</code>"] is "<code>complete</code>", let
    |params| be a [=/map=] matching the

--- a/index.bs
+++ b/index.bs
@@ -5432,12 +5432,12 @@ started</dfn> steps given |navigable| and |navigation status|:
         )
 
         browsingContext.DownloadCanceledParams = {
-          status: "canceled"
+          status: "canceled",
           browsingContext.BaseNavigationInfo
         }
 
         browsingContext.DownloadCompleteParams = {
-          status: "complete"
+          status: "complete",
           filepath: text / null,
           browsingContext.BaseNavigationInfo
         }

--- a/index.bs
+++ b/index.bs
@@ -5453,9 +5453,6 @@ steps given |navigable| and |navigation status|:
 1. Assert |navigation info|["<code>status</code>"] is "<code>complete</code>" or
    "<code>canceled</code>".
 
-   Note: <code>downloadedFilepath</code> can be null for completed download if the
-   filepath is not available for whatever reason.
-
 1. If |navigation info|["<code>status</code>"] is "<code>complete</code>", let
    |params| be a [=/map=] matching the
    <code>browsingContext.DownloadCompleteParams</code> production, with the
@@ -5466,6 +5463,9 @@ steps given |navigable| and |navigation status|:
    the <code>timestamp</code> field set to
    |navigation info|["<code>timestamp</code>"], and the <code>url</code> field set to
    |navigation info|["<code>url</code>"].
+
+   Note: <code>filepath</code> can be null for completed downloads if the filepath is
+   not available for whatever reason.
 
 1. Otherwise, let |params| be a [=/map=] matching the
    <code>browsingContext.DownloadCanceledParams</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -5424,10 +5424,18 @@ started</dfn> steps given |navigable| and |navigation status|:
          params: browsingContext.DownloadFinishedParams
         )
 
-        browsingContext.DownloadFinishedStatus = "canceled" / "complete"
+        browsingContext.DownloadFinishedParams = (
+          browsingContext.DownloadCanceledParams //
+          browsingContext.DownloadCompleteParams //
+        )
 
-        browsingContext.DownloadFinishedParams = {
-          status: browsingContext.DownloadFinishedStatus
+        browsingContext.DownloadCanceledParams = {
+          status: "canceled"
+          browsingContext.BaseNavigationInfo
+        }
+
+        browsingContext.DownloadCompleteParams = {
+          status: "complete"
           ? filepath: text / null,
           browsingContext.BaseNavigationInfo
         }
@@ -5442,22 +5450,30 @@ steps given |navigable| and |navigation status|:
 1. Let |navigation info| be the result of [=get the navigation info=] given
    |navigable| and |navigation status|.
 
-1. Assert |navigation info|["<code>status</code>"] is not "<code>pending</code>".
-
-1. Let |params| be a [=/map=] matching the
-   <code>browsingContext.DownloadFinishedParams</code> production, with the
-   <code>status</code> field set to |navigation info|["<code>status</code>"], the <code>context</code> field set to
-   |navigation info|["<code>context</code>"], the <code>navigation</code> field set
-   to |navigation info|["<code>navigation</code>"], the <code>timestamp</code> field
-   set to |navigation info|["<code>timestamp</code>"], and the <code>url</code> field
-   set to |navigation info|["<code>url</code>"].
-
-1. If |navigation info|["<code>status</code>"] is "<code>complete</code>", set
-   |params|["<code>filepath</code>"] to |navigation status|'s
-   <code>downloadedFilepath</code>.
+1. Assert |navigation info|["<code>status</code>"] is "<code>complete</code>" or
+   "<code>canceled</code>".
 
    Note: <code>downloadedFilepath</code> can be null for completed download if the
-   file is not available for whatever reason.
+   filepath is not available for whatever reason.
+
+1. If |navigation info|["<code>status</code>"] is "<code>complete</code>", let
+   |params| be a [=/map=] matching the
+   <code>browsingContext.DownloadCompleteParams</code> production, with the
+   <code>filepath</code> field set to
+   |navigation info|["<code>downloadedFilepath</code>"], the <code>context</code>
+   field set to |navigation info|["<code>context</code>"], the
+   <code>navigation</code> field set to |navigation info|["<code>navigation</code>"],
+   the <code>timestamp</code> field set to
+   |navigation info|["<code>timestamp</code>"], and the <code>url</code> field set to
+   |navigation info|["<code>url</code>"].
+
+1. Otherwise, let |params| be a [=/map=] matching the
+   <code>browsingContext.DownloadCanceledParams</code> production, with the
+   <code>context</code> field set to |navigation info|["<code>context</code>"], the
+   <code>navigation</code> field set to |navigation info|["<code>navigation</code>"],
+   the <code>timestamp</code> field set to
+   |navigation info|["<code>timestamp</code>"], and the <code>url</code> field set to
+   |navigation info|["<code>url</code>"].
 
 1. Let |body| be a [=/map=] matching the
    <code>browsingContext.DownloadFinished</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -5485,8 +5485,6 @@ steps given |navigable| and |navigation status|:
 
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
-1. [=Resume=].
-
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.downloadFinished</code>" and |related navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -3012,6 +3012,9 @@ The progress of navigation is communicated using an immutable
 
   <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-suggested-filename">suggestedFilename</dfn></dt>
   <dd>If the navigation is a download, suggested filename, otherwise null.</dd>
+
+  <dt><dfn export for="WebDriver BiDi navigation status" id="navigation-status-downloaded-filepath">downloadedFilepath</dfn></dt>
+  <dd>If the navigation is a download which is finished, absolute filepath of the downloaded file, otherwise null.</dd>
 </dl>
 
 ### Definition ### {#module-browsingContext-definition}
@@ -5405,6 +5408,57 @@ started</dfn> steps given |navigable| and |navigation status|:
 
  1. For each |session| in the [=set of sessions for which an event is enabled=]
     given "<code>browsingContext.downloadWillBegin</code>" and |related navigables|:
+
+   1. [=Emit an event=] with |session| and |body|.
+
+</div>
+
+#### The browsingContext.downloadFinished Event #### {#event-browsingContext-downloadFinished}
+
+<dl>
+   <dt>Event Type</dt>
+   <dd>
+      <pre class="cddl local-cddl">
+        browsingContext.DownloadFinished = (
+         method: "browsingContext.downloadFinished",
+         params: browsingContext.DownloadFinishedParams
+        )
+
+        browsingContext.DownloadFinishedParams = {
+          filepath: text,
+          browsingContext.BaseNavigationInfo
+        }
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download finished</dfn>
+steps given |navigable| and |navigation status|:
+
+ 1. Let |navigation info| be the result of [=get the navigation info=] given |navigable| and
+    |navigation status|.
+
+1. Let |params| be a [=/map=] matching the <code>browsingContext.DownloadFinishedParams</code>
+   production, with the <code>context</code> field set to |navigation info|["<code>context</code>"],
+   the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"], the
+   <code>timestamp</code> field set to |navigation info|["<code>timestamp</code>"], the
+   <code>url</code> field set to |navigation info|["<code>url</code>"] and
+   <code>filepath</code> field set to |navigation status|'s
+   <code>downloadedFilepath</code>.
+
+ 1. Let |body| be a [=/map=] matching the
+     <code>browsingContext.DownloadFinished</code> production, with the
+     <code>params</code> field set to |params|.
+
+ 1. Let |navigation id| be |navigation status|'s id.
+
+ 1. Let |related navigables| be a [=/set=] containing |navigable|.
+
+ 1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
+
+ 1. For each |session| in the [=set of sessions for which an event is enabled=]
+    given "<code>browsingContext.downloadFinished</code>" and |related navigables|:
 
    1. [=Emit an event=] with |session| and |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -5481,8 +5481,6 @@ steps given |navigable| and |navigation status|:
    <code>browsingContext.DownloadFinished</code> production, with the
    <code>params</code> field set to |params|.
 
-1. Let |navigation id| be |navigation status|'s id.
-
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 
 1. For each |session| in the [=set of sessions for which an event is enabled=]

--- a/index.bs
+++ b/index.bs
@@ -5448,7 +5448,7 @@ started</dfn> steps given |navigable| and |navigation status|:
 </dl>
 
 <div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download finished</dfn>
+The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download end</dfn>
 steps given |navigable| and |navigation status|:
 
 1. Let |navigation info| be the result of [=get the navigation info=] given


### PR DESCRIPTION
Addressing [Access downloaded file content · Issue #894 · w3c/webdriver-bidi](https://github.com/w3c/webdriver-bidi/issues/894).

The "WebDriver BiDi download finished" hook is to be engaged in HTML spec [[WebDriver BiDi] report download complete / failed / canceled by sadym-chromium · Pull Request #11289 · whatwg/html](https://github.com/whatwg/html/pull/11289)

### Open questions:
* [ ] Should we provide `totalBytes`?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/923.html" title="Last updated on Jun 3, 2025, 10:48 AM UTC (b4f260d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/923/13ec5ab...b4f260d.html" title="Last updated on Jun 3, 2025, 10:48 AM UTC (b4f260d)">Diff</a>