### PR TITLE
Adapt CDDL declarations to new version of Bikeshed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5424,7 +5424,7 @@ started</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.DownloadEnd = (
           method: "browsingContext.downloadEnd",
           params: browsingContext.DownloadEndParams

--- a/index.bs
+++ b/index.bs
@@ -413,8 +413,8 @@ protocol. These terms are distinct from their representation at the
 
 The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
 convenience of implementers two separate CDDL definitions are defined; the
-<dfn export>remote end definition</dfn> which defines the format of messages produced
-on the [=local end=] and consumed on the [=remote end=], and the <dfn export>local end
+<dfn cddl-module export lt="remote end definition|remote-cddl">remote end definition</dfn> which defines the format of messages produced
+on the [=local end=] and consumed on the [=remote end=], and the <dfn cddl-module export lt="local end definition|local-cddl">local end
 definition</dfn> which defines the format of messages produced on the [=remote end=]
 and consumed on the [=local end=]
 
@@ -428,7 +428,7 @@ the remainder of the specification.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 Command = {
   id: js-uint,
   CommandData,
@@ -454,7 +454,7 @@ EmptyParams = {
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 Message = (
   CommandResponse /
   ErrorResponse /
@@ -508,7 +508,7 @@ EventData = (
 
 [=Remote end definition=] and [=Local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 Extensible = (*text => any)
 
 js-int = -9007199254740991..9007199254740991
@@ -667,7 +667,7 @@ with the following additional codes:
   <dd>Tried to set a file input, but failed to do so.
 </dl>
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 ErrorCode = "invalid argument" /
             "invalid selector" /
             "invalid session id" /
@@ -1585,7 +1585,7 @@ events for monitoring the status of the remote end.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 SessionCommand = (
   session.End //
   session.New //
@@ -1597,7 +1597,7 @@ SessionCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 SessionResult = (
    session.NewResult /
    session.StatusResult /
@@ -1654,7 +1654,7 @@ To <dfn>cleanup remote end state</dfn>.
 
 #### The session.CapabilitiesRequest Type #### {#type-session-CapabilitiesRequest}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.CapabilitiesRequest = {
   ? alwaysMatch: session.CapabilityRequest,
   ? firstMatch: [*session.CapabilityRequest]
@@ -1668,7 +1668,7 @@ for a session.
 
 [=remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.CapabilityRequest = {
   ? acceptInsecureCerts: bool,
   ? browserName: text,
@@ -1719,7 +1719,7 @@ with parameter |value| is:
 
 [=remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.ProxyConfiguration = {
    session.AutodetectProxyConfiguration //
    session.DirectProxyConfiguration //
@@ -1770,7 +1770,7 @@ session.SystemProxyConfiguration = (
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.UserPromptHandler = {
   ? alert: session.UserPromptHandlerType,
   ? beforeUnload: session.UserPromptHandlerType,
@@ -1791,7 +1791,7 @@ the picker. "ignore" keeps the picker open.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
 </pre>
 
@@ -1800,7 +1800,7 @@ of the user prompt handler.
 
 #### The session.Subscription Type #### {#type-session-Subscription}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.Subscription = text
 </pre>
 
@@ -1808,7 +1808,7 @@ The <code>session.Subscription</code> type represents a unique subscription iden
 
 #### The session.SubscriptionRequest Type #### {#type-session-SubscriptionRequest}
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 session.SubscriptionRequest = {
   events: [+text],
   ? contexts: [+browsingContext.BrowsingContext],
@@ -1821,7 +1821,7 @@ subscribe to or unsubscribe from a specific set of events.
 
 #### The session.UnsubscribeByIDRequest Type #### {#type-session-UnsubscribeByIDRequest}
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 session.UnsubscribeByIDRequest = {
   subscriptions: [+session.Subscription],
 }
@@ -1834,7 +1834,7 @@ remove event subscriptions identified by subscription IDs.
 
 Note: contexts param is deprecated and will be removed in the future versions.
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 session.UnsubscribeByAttributesRequest = {
   events: [+text],
   ? contexts: [+browsingContext.BrowsingContext],
@@ -1858,7 +1858,7 @@ This is a [=static command=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       session.Status = (
         method: "session.status",
         params: EmptyParams,
@@ -1867,7 +1867,7 @@ This is a [=static command=].
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
       session.StatusResult = {
         ready: bool,
         message: text,
@@ -1908,7 +1908,7 @@ This is a [=static command=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       session.New = (
         method: "session.new",
         params: session.NewParameters
@@ -1921,7 +1921,7 @@ This is a [=static command=].
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
       session.NewResult = {
         sessionId: text,
         capabilities: {
@@ -1982,7 +1982,7 @@ The <dfn export for=commands>session.end</dfn> command ends the current
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       session.End = (
         method: "session.end",
         params: EmptyParams
@@ -2028,7 +2028,7 @@ Issue: This needs to be generalized to work with realms too.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       session.Subscribe = (
         method: "session.subscribe",
         params: session.SubscriptionRequest
@@ -2037,7 +2037,7 @@ Issue: This needs to be generalized to work with realms too.
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         session.SubscribeResult = {
           subscription: session.Subscription,
         }
@@ -2151,7 +2151,7 @@ and will be removed in the future versions.
 <dl>
    <dt>Command Type</dt>
    <dd>
-     <pre class="cddl remote-cddl">
+     <pre class="cddl" data-cddl-module="remote-cddl">
      session.Unsubscribe = (
        method: "session.unsubscribe",
        params: session.UnsubscribeParameters,
@@ -2324,7 +2324,7 @@ managing the remote end browser process.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 BrowserCommand = (
   browser.Close //
   browser.CreateUserContext //
@@ -2338,7 +2338,7 @@ BrowserCommand = (
 [=local end definition=]
 
 <!-- Nothing yet -->
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 BrowserResult = (
    browser.CreateUserContextResult /
    browser.GetUserContextsResult
@@ -2524,7 +2524,7 @@ To <dfn>set the client window state</dfn> given |window| and |state|:
 
 #### The browser.ClientWindow Type #### {#type-browser-ClientWindow}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browser.ClientWindow = text;
 </pre>
 
@@ -2532,7 +2532,7 @@ The <code>browser.ClientWindow</code> uniquely identifies a [=client window=].
 
 #### The browser.ClientWindowInfo Type #### {#type-browser-ClientWindowInfo}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browser.ClientWindowInfo = {
   active: bool,
   clientWindow: browser.ClientWindow,
@@ -2577,7 +2577,7 @@ To <dfn>get the client window info</dfn> given |client window|:
 
 #### The browser.UserContext Type #### {#type-browser-UserContext}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browser.UserContext = text;
 </pre>
 
@@ -2585,7 +2585,7 @@ The <code>browser.UserContext</code> unique identifies a [=user context=].
 
 #### The browser.UserContextInfo Type #### {#type-browser-UserContextInfo}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browser.UserContextInfo = {
   userContext: browser.UserContext
 }
@@ -2604,7 +2604,7 @@ WebDriver sessions and cleans up automation state in the remote browser instance
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.Close = (
         method: "browser.close",
         params: EmptyParams,
@@ -2674,7 +2674,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.CreateUserContext = (
         method: "browser.createUserContext",
         params: browser.CreateUserContextParameters,
@@ -2688,7 +2688,7 @@ The <dfn export for=commands>browser.createUserContext</dfn> command creates a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       browser.CreateUserContextResult = browser.UserContextInfo
     </pre>
    </dd>
@@ -2746,7 +2746,7 @@ list of [=client window=]s.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.GetClientWindows = (
         method: "browser.getClientWindows",
         params: EmptyParams,
@@ -2755,7 +2755,7 @@ list of [=client window=]s.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       browser.GetClientWindowsResult = {
         clientWindows: [ * browser.ClientWindowInfo]
       }
@@ -2803,7 +2803,7 @@ list of [=user context=]s.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.GetUserContexts = (
         method: "browser.getUserContexts",
         params: EmptyParams,
@@ -2812,7 +2812,7 @@ list of [=user context=]s.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       browser.GetUserContextsResult = {
         userContexts: [ + browser.UserContextInfo]
       }
@@ -2852,7 +2852,7 @@ user context and all navigables in it without running
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.RemoveUserContext = (
         method: "browser.removeUserContext",
         params: browser.RemoveUserContextParameters
@@ -2904,7 +2904,7 @@ dimensions of a [=client window=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browser.SetClientWindowState = (
         method: "browser.setClientWindowState",
         params: browser.SetClientWindowStateParameters
@@ -3022,7 +3022,7 @@ The progress of navigation is communicated using an immutable
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 BrowsingContextCommand = (
   browsingContext.Activate //
   browsingContext.CaptureScreenshot //
@@ -3041,7 +3041,7 @@ BrowsingContextCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 BrowsingContextResult = (
   browsingContext.CaptureScreenshotResult /
   browsingContext.CreateResult /
@@ -3092,7 +3092,7 @@ A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map bet
 
 [=remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.BrowsingContext = text;
 </pre>
 
@@ -3127,7 +3127,7 @@ To <dfn export>get a navigable</dfn> given |navigable id|:
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 browsingContext.InfoList = [*browsingContext.Info]
 
 browsingContext.Info = {
@@ -3298,7 +3298,7 @@ To <dfn>await a navigation</dfn> given |navigable|, |request|, |wait condition|,
 
 [=remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.Locator = (
    browsingContext.AccessibilityLocator /
    browsingContext.CssLocator /
@@ -3348,7 +3348,7 @@ for locating a node in a document.
 
 [=remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.Navigation = text;
 </pre>
 
@@ -3362,7 +3362,7 @@ TODO: Link to the definition in the HTML spec.
 
 [=local end definition=]:
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 browsingContext.BaseNavigationInfo = (
   context: browsingContext.BrowsingContext,
   navigation: browsingContext.Navigation / null,
@@ -3398,7 +3398,7 @@ To <dfn>get the navigation info</dfn>, given |navigable| and |navigation status|
 
 #### The browsingContext.ReadinessState Type #### {#type-browsingContext-ReadinessState}
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 browsingContext.ReadinessState = "none" / "interactive" / "complete"
 </pre>
 
@@ -3409,7 +3409,7 @@ document loading at which a navigation command will return.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.UserPromptType = "alert" / "beforeunload" / "confirm" / "prompt";
 </pre>
 
@@ -3425,7 +3425,7 @@ The <dfn export for=commands>browsingContext.activate</dfn> command activates an
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Activate = (
         method: "browsingContext.activate",
         params: browsingContext.ActivateParameters
@@ -3484,7 +3484,7 @@ Base64-encoded string.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.CaptureScreenshot = (
         method: "browsingContext.captureScreenshot",
         params: browsingContext.CaptureScreenshotParameters
@@ -3523,7 +3523,7 @@ Base64-encoded string.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.CaptureScreenshotResult = {
           data: text
         }
@@ -3780,7 +3780,7 @@ The <dfn export for=commands>browsingContext.close</dfn> command closes a
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Close = (
         method: "browsingContext.close",
         params: browsingContext.CloseParameters
@@ -3843,7 +3843,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Create = (
         method: "browsingContext.create",
         params: browsingContext.CreateParameters
@@ -3861,7 +3861,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.CreateResult = {
           context: browsingContext.BrowsingContext
         }
@@ -3951,7 +3951,7 @@ or all top-level contexts when no parent is provided.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.GetTree = (
         method: "browsingContext.getTree",
         params: browsingContext.GetTreeParameters
@@ -3965,7 +3965,7 @@ or all top-level contexts when no parent is provided.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.GetTreeResult = {
           contexts: browsingContext.InfoList
         }
@@ -4012,7 +4012,7 @@ command allows closing an open prompt
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.HandleUserPrompt = (
         method: "browsingContext.handleUserPrompt",
         params: browsingContext.HandleUserPromptParameters
@@ -4077,7 +4077,7 @@ list of all nodes matching the specified locator.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.LocateNodes = (
         method: "browsingContext.locateNodes",
         params: browsingContext.LocateNodesParameters
@@ -4094,7 +4094,7 @@ list of all nodes matching the specified locator.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.LocateNodesResult = {
             nodes: [ * script.NodeRemoteValue ]
         }
@@ -4466,7 +4466,7 @@ navigable to the given URL.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Navigate = (
         method: "browsingContext.navigate",
         params: browsingContext.NavigateParameters
@@ -4481,7 +4481,7 @@ navigable to the given URL.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.NavigateResult = {
           navigation: browsingContext.Navigation / null,
           url: text,
@@ -4537,7 +4537,7 @@ PDF document represented as a Base64-encoded string.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Print = (
         method: "browsingContext.print",
         params: browsingContext.PrintParameters
@@ -4571,7 +4571,7 @@ PDF document represented as a Base64-encoded string.
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.PrintResult = {
           data: text
         }
@@ -4686,7 +4686,7 @@ navigable.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.Reload = (
         method: "browsingContext.reload",
         params: browsingContext.ReloadParameters
@@ -4746,7 +4746,7 @@ The <dfn export for=commands>browsingContext.setViewport</dfn> command modifies 
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.SetViewport = (
         method: "browsingContext.setViewport",
         params: browsingContext.SetViewportParameters
@@ -4933,7 +4933,7 @@ traverses the history of a given navigable by a delta.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       browsingContext.TraverseHistory = (
         method: "browsingContext.traverseHistory",
         params: browsingContext.TraverseHistoryParameters
@@ -4947,7 +4947,7 @@ traverses the history of a given navigable by a delta.
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.TraverseHistoryResult = {
         }
     </pre>
@@ -5043,7 +5043,7 @@ ignore>context</var> and |navigation status| are:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.ContextCreated = (
          method: "browsingContext.contextCreated",
          params: browsingContext.Info
@@ -5118,7 +5118,7 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 1, given
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.ContextDestroyed = (
          method: "browsingContext.contextDestroyed",
          params: browsingContext.Info
@@ -5172,7 +5172,7 @@ become inaccessible but not yet get discarded because bfcache.
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.NavigationStarted = (
          method: "browsingContext.navigationStarted",
          params: browsingContext.NavigationInfo
@@ -5211,7 +5211,7 @@ started</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.FragmentNavigated = (
          method: "browsingContext.fragmentNavigated",
          params: browsingContext.NavigationInfo
@@ -5250,7 +5250,7 @@ navigated</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.HistoryUpdated = (
           method: "browsingContext.historyUpdated",
           params: browsingContext.HistoryUpdatedParameters
@@ -5296,7 +5296,7 @@ The [=remote end event trigger=] is the <dfn export>WebDriver BiDi history updat
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.DomContentLoaded = (
          method: "browsingContext.domContentLoaded",
          params: browsingContext.NavigationInfo
@@ -5335,7 +5335,7 @@ loaded</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.Load = (
          method: "browsingContext.load",
          params: browsingContext.NavigationInfo
@@ -5373,7 +5373,7 @@ complete</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.DownloadWillBegin = (
          method: "browsingContext.downloadWillBegin",
          params: browsingContext.DownloadWillBeginParams
@@ -5501,7 +5501,7 @@ steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.NavigationAborted = (
          method: "browsingContext.navigationAborted",
          params: browsingContext.NavigationInfo
@@ -5539,7 +5539,7 @@ aborted</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.NavigationCommitted = (
          method: "browsingContext.navigationCommitted",
          params: browsingContext.NavigationInfo
@@ -5578,7 +5578,7 @@ given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.NavigationFailed = (
          method: "browsingContext.navigationFailed",
          params: browsingContext.NavigationInfo
@@ -5616,7 +5616,7 @@ failed</dfn> steps given |navigable| and |navigation status|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.UserPromptClosed = (
           method: "browsingContext.userPromptClosed",
           params: browsingContext.UserPromptClosedParameters
@@ -5666,7 +5666,7 @@ closed</dfn> steps given |window|, |type|, |accepted| and optional |user text|
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.UserPromptOpened = (
           method: "browsingContext.userPromptOpened",
           params: browsingContext.UserPromptOpenedParameters
@@ -5731,7 +5731,7 @@ relating to emulation of browser APIs.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 EmulationCommand = (
   emulation.SetGeolocationOverride
 )
@@ -5758,7 +5758,7 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       emulation.SetGeolocationOverride = (
         method: "emulation.setGeolocationOverride",
         params: emulation.SetGeolocationOverrideParameters
@@ -5865,7 +5865,7 @@ relating to network requests.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 
 NetworkCommand = (
   network.AddIntercept //
@@ -5882,7 +5882,7 @@ NetworkCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 
 NetworkResult = (
    network.AddInterceptResult
@@ -6077,7 +6077,7 @@ To <dfn>update the response</dfn> given |session|, |command| and |command parame
 
 #### The network.AuthChallenge Type #### {#type-network-AuthChallenge}
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.AuthChallenge = {
   scheme: text,
   realm: text,
@@ -6131,7 +6131,7 @@ Issue: Should we include parameters other than realm?
 
 #### The network.AuthCredentials Type #### {#type-network-AuthCredentials}
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 network.AuthCredentials = {
   type: "password",
   username: text,
@@ -6144,7 +6144,7 @@ request for authorization credentials.
 
 #### The network.BaseParameters Type #### {#type-network-BaseParameters}
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.BaseParameters = (
     context: browsingContext.BrowsingContext / null,
     isBlocked: bool,
@@ -6207,7 +6207,7 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 #### The network.BytesValue Type #### {#type-network-BytesValue}
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.BytesValue = network.StringValue / network.Base64Value;
 
 network.StringValue = {
@@ -6263,7 +6263,7 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 
 network.SameSite = "strict" / "lax" / "none"
 
@@ -6332,7 +6332,7 @@ samesite-flag, which is from [[SAME-SITE-COOKIES]].
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 network.CookieHeader = {
     name: text,
     value: network.BytesValue,
@@ -6361,7 +6361,7 @@ To <dfn>serialize cookie header</dfn> given |protocol cookie|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.FetchTimingInfo = {
     timeOrigin: float,
     requestTime: float,
@@ -6457,7 +6457,7 @@ TODO: Add service worker fields
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Header = {
   name: text,
   value: network.BytesValue,
@@ -6497,7 +6497,7 @@ To <dfn>deserialize header</dfn> given |protocol header|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.Initiator = {
     ? columnNumber: js-uint,
     ? lineNumber: js-uint,
@@ -6554,7 +6554,7 @@ To <dfn>get the initiator</dfn> given |request|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Intercept = text
 </pre>
 
@@ -6564,7 +6564,7 @@ The <code>network.Intercept</code> type represents the id of a [=network interce
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Request = text;
 </pre>
 
@@ -6576,7 +6576,7 @@ redirect matches that of the request that initiated it.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.RequestData = {
     request: network.Request,
     url: text,
@@ -6658,7 +6658,7 @@ To <dfn>get the request data</dfn> given |request|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.ResponseContent = {
     size: js-uint
 }
@@ -6683,7 +6683,7 @@ To <dfn>get the response content info</dfn> given |response|.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 network.ResponseData = {
     url: text,
     protocol: text,
@@ -6797,7 +6797,7 @@ To <dfn>get the response data</dfn> given |response|:
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 <!--
 Modifications to this definition should be reflected in
 `network.Cookie`, `storage.CookieFilter`, and `storage.PartialCookie`.
@@ -6929,7 +6929,7 @@ To <dfn>serialize set-cookie header</dfn> given |protocol cookie|:
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 network.UrlPattern = (
   network.UrlPatternPattern /
   network.UrlPatternString
@@ -7256,7 +7256,7 @@ The <dfn export for=commands>network.addIntercept</dfn> command adds a
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.AddIntercept = (
         method: "network.addIntercept",
         params: network.AddInterceptParameters
@@ -7274,7 +7274,7 @@ The <dfn export for=commands>network.addIntercept</dfn> command adds a
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       network.AddInterceptResult = {
         intercept: network.Intercept
       }
@@ -7339,7 +7339,7 @@ that's blocked by a [=network intercept=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.ContinueRequest = (
         method: "network.continueRequest",
         params: network.ContinueRequestParameters
@@ -7477,7 +7477,7 @@ response, but still provide the network response body.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.ContinueResponse = (
         method: "network.continueResponse",
         params: network.ContinueResponseParameters
@@ -7525,7 +7525,7 @@ response that's blocked by a [=network intercept=] at the
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.ContinueWithAuth = (
         method: "network.continueWithAuth",
         params: network.ContinueWithAuthParameters
@@ -7599,7 +7599,7 @@ fetch that's blocked by a [=network intercept=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.FailRequest = (
         method: "network.failRequest",
         params: network.FailRequestParameters
@@ -7657,7 +7657,7 @@ lifecycle, and therefore emitting other events as it progresses.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       network.ProvideResponse = (
         method: "network.provideResponse",
         params: network.ProvideResponseParameters
@@ -7712,7 +7712,7 @@ The <dfn export for=commands>network.removeIntercept</dfn> command removes a
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       network.RemoveIntercept = (
         method: "network.removeIntercept",
         params: network.RemoveInterceptParameters
@@ -7760,7 +7760,7 @@ the network cache behavior for certain requests.
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       network.SetCacheBehavior = (
         method: "network.setCacheBehavior",
         params: network.SetCacheBehaviorParameters
@@ -7888,7 +7888,7 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
       network.AuthRequired = (
         method: "network.authRequired",
         params: network.AuthRequiredParameters
@@ -7967,7 +7967,7 @@ steps given |request| and |response|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         network.BeforeRequestSent = (
          method: "network.beforeRequestSent",
          params: network.BeforeRequestSentParameters
@@ -8113,7 +8113,7 @@ request sent</dfn> steps given |request|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         network.FetchError = (
          method: "network.fetchError",
          params: network.FetchErrorParameters
@@ -8171,7 +8171,7 @@ error</dfn> steps given |request|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         network.ResponseCompleted = (
          method: "network.responseCompleted",
          params: network.ResponseCompletedParameters
@@ -8230,7 +8230,7 @@ completed</dfn> steps given |request| and |response|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         network.ResponseStarted = (
          method: "network.responseStarted",
          params: network.ResponseStartedParameters
@@ -8312,7 +8312,7 @@ relating to script realms and execution.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 ScriptCommand = (
   script.AddPreloadScript //
   script.CallFunction //
@@ -8325,7 +8325,7 @@ ScriptCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 ScriptResult = (
   script.AddPreloadScriptResult /
   script.EvaluateResult /
@@ -8447,7 +8447,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Channel = text;
 </pre>
 
@@ -8458,7 +8458,7 @@ used to send custom messages from the [=remote end=] to the [=local end=].
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.ChannelValue = {
   type: "channel",
   value: script.ChannelProperties,
@@ -8495,7 +8495,7 @@ To <dfn>create a channel</dfn> given |session|, |realm| and |protocol value|:
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.EvaluateResult = (
   script.EvaluateResultSuccess /
   script.EvaluateResultException
@@ -8524,7 +8524,7 @@ completes with a thrown exception.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.ExceptionDetails = {
   columnNumber: js-uint,
   exception: script.RemoteValue,
@@ -8579,7 +8579,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Handle = text;
 </pre>
 
@@ -8593,7 +8593,7 @@ strong [=/map=] from handle ids to their corresponding objects.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.InternalId = text;
 </pre>
 
@@ -8606,7 +8606,7 @@ a previously serialized <code>script.RemoteValue</code> during
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.LocalValue = (
   script.RemoteReference /
   script.PrimitiveProtocolValue /
@@ -8807,7 +8807,7 @@ To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.PreloadScript = text;
 </pre>
 
@@ -8818,7 +8818,7 @@ on realm creation.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Realm = text;
 </pre>
 
@@ -8852,7 +8852,7 @@ Issue: This has the wrong error code
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.PrimitiveProtocolValue = (
   script.UndefinedValue /
   script.NullValue /
@@ -9020,7 +9020,7 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 script.RealmInfo = (
   script.WindowRealmInfo /
   script.DedicatedWorkerRealmInfo /
@@ -9228,7 +9228,7 @@ Note: Future variations of this specification will retain the invariant that
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.RealmType = "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
                    "worker" / "paint-worklet" / "audio-worklet" / "worklet"
 </pre>
@@ -9239,7 +9239,7 @@ The <code>script.RealmType</code> type represents the different types of Realm.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 <!-- This is specifically ordered in the order in which matches need to be -->
 <!-- evaluated, since the definitions are overlapping -->
 script.RemoteReference = (
@@ -9349,7 +9349,7 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.RemoteValue = (
   script.PrimitiveProtocolValue /
   script.SymbolRemoteValue /
@@ -10043,7 +10043,7 @@ To <dfn>serialize as a mapping</dfn> given |iterable|, |serialization options|,
 
 #### The script.ResultOwnership Type #### {#type-script-ResultOwnership}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.ResultOwnership = "root" / "none"
 </pre>
 
@@ -10054,7 +10054,7 @@ ownership will be treated.
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.SerializationOptions = {
   ? maxDomDepth: (js-uint / null) .default 0,
   ? maxObjectDepth: (js-uint / null) .default null,
@@ -10069,7 +10069,7 @@ objects will be serialized.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.SharedId = text;
 </pre>
 
@@ -10080,7 +10080,7 @@ is usable in any realm (including <a href=#sandbox-realm>Sandbox Realms</a>).
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.StackFrame = {
   columnNumber: js-uint,
   functionName: text,
@@ -10099,7 +10099,7 @@ properties, which represent the line and column number of the executed code.
 
 [=Remote end definition=] and [=local end definition=]
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.StackTrace = {
   callFrames: [*script.StackFrame],
 }
@@ -10183,7 +10183,7 @@ Record=] of type <code>throw</code>, |exception|, is given by:
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 script.Source = {
   realm: script.Realm,
   ? context: browsingContext.BrowsingContext
@@ -10225,7 +10225,7 @@ To <dfn>get the source</dfn> given |source realm|:
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 script.RealmTarget = {
   realm: script.Realm
 }
@@ -10308,7 +10308,7 @@ script=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       script.AddPreloadScript = (
         method: "script.addPreloadScript",
         params: script.AddPreloadScriptParameters
@@ -10325,7 +10325,7 @@ script=].
    </dd>
    <dt>Return Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       script.AddPreloadScriptResult = {
         script: script.PreloadScript
       }
@@ -10400,7 +10400,7 @@ other handles or strong ECMAScript references.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       script.Disown = (
         method: "script.disown",
         params: script.DisownParameters
@@ -10451,7 +10451,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       script.CallFunction = (
         method: "script.callFunction",
         params: script.CallFunctionParameters
@@ -10635,7 +10635,7 @@ the promise is returned.
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       script.Evaluate = (
         method: "script.evaluate",
         params: script.EvaluateParameters
@@ -10739,7 +10739,7 @@ realm associated with a [=/navigable=]'s [=active document=].
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       script.GetRealms = (
         method: "script.getRealms",
         params: script.GetRealmsParameters
@@ -10753,7 +10753,7 @@ realm associated with a [=/navigable=]'s [=active document=].
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       script.GetRealmsResult = {
         realms: [*script.RealmInfo]
       }
@@ -10823,7 +10823,7 @@ The <dfn export for=commands>script.removePreloadScript</dfn> command removes a
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       script.RemovePreloadScript = (
         method: "script.removePreloadScript",
         params: script.RemovePreloadScriptParameters
@@ -10867,7 +10867,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         script.Message = (
          method: "script.message",
          params: script.MessageParameters
@@ -10929,7 +10929,7 @@ given |session|, |realm|, |channel properties|, and |message|:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         script.RealmCreated = (
          method: "script.realmCreated",
          params: script.RealmInfo
@@ -11016,7 +11016,7 @@ Issue: Should the order here be better defined?
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
        script.RealmDestroyed = (
          method: "script.realmDestroyed",
          params: script.RealmDestroyedParameters
@@ -11111,7 +11111,7 @@ A <dfn>storage partition key</dfn> is a [=/map=] which uniquely identifies a [=s
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 StorageCommand = (
   storage.DeleteCookies //
   storage.GetCookies //
@@ -11121,7 +11121,7 @@ StorageCommand = (
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 StorageResult = (
   storage.DeleteCookiesResult /
   storage.GetCookiesResult /
@@ -11135,7 +11135,7 @@ StorageResult = (
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 storage.PartitionKey = {
   ? userContext: text,
   ? sourceOrigin: text,
@@ -11296,7 +11296,7 @@ The <dfn export for=commands>storage.getCookies</dfn> command retrieves zero or 
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
         storage.GetCookies = (
           method: "storage.getCookies",
           params: storage.GetCookiesParameters
@@ -11344,7 +11344,7 @@ The <dfn export for=commands>storage.getCookies</dfn> command retrieves zero or 
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       storage.GetCookiesResult = {
         cookies: [*network.Cookie],
         partitionKey: storage.PartitionKey,
@@ -11392,7 +11392,7 @@ The <dfn export for=commands>storage.setCookie</dfn> command creates a new [=coo
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
         storage.SetCookie = (
           method: "storage.setCookie",
           params: storage.SetCookieParameters,
@@ -11422,7 +11422,7 @@ The <dfn export for=commands>storage.setCookie</dfn> command creates a new [=coo
    </dd>
    <dt>Result Type</dt>
    <dd>
-    <pre class="cddl local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       storage.SetCookieResult = {
         partitionKey: storage.PartitionKey
       }
@@ -11487,7 +11487,7 @@ The <dfn export for=commands>storage.deleteCookies</dfn> command removes zero or
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
         storage.DeleteCookies = (
           method: "storage.deleteCookies",
           params: storage.DeleteCookiesParameters,
@@ -11501,7 +11501,7 @@ The <dfn export for=commands>storage.deleteCookies</dfn> command removes zero or
    </dd>
    <dt>Result Type</dt>
    <dd>
-     <pre class="cddl local-cddl">
+     <pre class="cddl" data-cddl-module="local-cddl">
         storage.DeleteCookiesResult = {
           partitionKey: storage.PartitionKey
         }
@@ -11589,7 +11589,7 @@ level navigable.
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 LogEvent = (
   log.EntryAdded
 )
@@ -11601,7 +11601,7 @@ LogEvent = (
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 log.Level = "debug" / "info" / "warn" / "error"
 
 log.Entry = (
@@ -11652,7 +11652,7 @@ provide additional fields specific to the entry type.
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
         log.EntryAdded = (
          method: "log.entryAdded",
          params: log.Entry,
@@ -11816,7 +11816,7 @@ simulated user input.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 
 InputCommand = (
   input.PerformActions //
@@ -11827,7 +11827,7 @@ InputCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 
 InputEvent = (
   input.FileDialogOpened
@@ -11841,7 +11841,7 @@ InputEvent = (
 The <code>input.ElementOrigin</code> type represents an {{Element}} that will
 be used as a coordinate origin.
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 input.ElementOrigin = {
   type: "element",
   element: script.SharedReference
@@ -11901,7 +11901,7 @@ Note: for a detailed description of the behavior of this command, see the
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       input.PerformActions = (
         method: "input.performActions",
         params: input.PerformActionsParameters
@@ -12074,7 +12074,7 @@ state associated with the current session.
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       input.ReleaseActions = (
         method: "input.releaseActions",
         params: input.ReleaseActionsParameters
@@ -12131,7 +12131,7 @@ to a set of file paths.
 <dl>
    <dt>Command Type</dt>
    <dd>
-    <pre class="cddl remote-cddl">
+    <pre class="cddl" data-cddl-module="remote-cddl">
       input.SetFiles = (
         method: "input.setFiles",
         params: input.SetFilesParameters
@@ -12218,7 +12218,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl local-cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
          input.FileDialogOpened = (
             method: "input.fileDialogOpened",
             params: input.FileDialogInfo
@@ -12305,7 +12305,7 @@ managing and interacting with web extensions.
 
 [=remote end definition=]
 
-<pre class="cddl remote-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl">
 WebExtensionCommand = (
   webExtension.Install //
   webExtension.Uninstall
@@ -12314,7 +12314,7 @@ WebExtensionCommand = (
 
 [=local end definition=]
 
-<pre class="cddl local-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 WebExtensionResult = (
   webExtension.InstallResult
 )
@@ -12324,7 +12324,7 @@ WebExtensionResult = (
 
 #### The webExtension.Extension Type #### {#type-webExtension-Extension}
 
-<pre class="cddl remote-cddl local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 webExtension.Extension = text
 </pre>
 
@@ -12339,7 +12339,7 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       webExtension.Install = (
          method: "webExtension.install",
          params: webExtension.InstallParameters
@@ -12373,7 +12373,7 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
    </dd>
    <dt>Result Type</dt>
    <dd>
-      <pre class="cddl local-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
       webExtension.InstallResult = {
         extension: webExtension.Extension
       }
@@ -12460,7 +12460,7 @@ The <dfn export for=commands>webExtension.uninstall</dfn> command uninstalls a w
 <dl>
    <dt>Command Type</dt>
    <dd>
-      <pre class="cddl remote-cddl">
+      <pre class="cddl" data-cddl-module="remote-cddl">
       webExtension.Uninstall = (
          method: "webExtension.uninstall",
          params: webExtension.UninstallParameters

--- a/scripts/cddl/utils.js
+++ b/scripts/cddl/utils.js
@@ -16,20 +16,21 @@ function getCDDLNodes(nodes) {
   nodes.forEach((node) => {
     if (node.nodeName === "pre") {
       const nodeClass = node.attrs.find((attr) => attr.name === "class");
+      const nodeModules = node.attrs.find((attr) => attr.name === "data-cddl-module");
       if (nodeClass && nodeClass.value.includes("cddl")) {
         const content = node.childNodes.map((child) => child.value).join("");
 
-        if (nodeClass.value.includes("local-cddl")) {
+        if (nodeModules.value.includes("local-cddl")) {
           entries.local.push(content);
         }
 
-        if (nodeClass.value.includes("remote-cddl")) {
+        if (nodeModules.value.includes("remote-cddl")) {
           entries.remote.push(content);
         }
 
         if (
-          nodeClass.value.includes("local-cddl") ||
-          nodeClass.value.includes("remote-cddl")
+          nodeModules.value.includes("local-cddl") ||
+          nodeModules.value.includes("remote-cddl")
         ) {
           entries.all.push(content);
         }


### PR DESCRIPTION
Some time ago, I mentioned that I had been working on adding support for CDDL highlighting and linking in Bikeshed. That's now done in [version 5.2.0 of Bikeshed](https://github.com/speced/bikeshed/issues/1773#issuecomment-2914475958), released yesterday, see [Bikeshed documentation](https://speced.github.io/bikeshed/#cddl) for details.

This update makes a minimal set of changes to adjust the CDDL declarations to define the CDDL modules and blocks in a way that Bikeshed understands. In particular, Bikeshed needs the blocks to reference the CDDL modules through a `data-cddl-module` attribute (as opposed to them appearing in the `class` attribute).

Bikeshed now also generates a CDDL index at the end of the spec. This CDDL index is divided into a remote end definition part and a local end definition part. Each part contains all definitions defined as applying to the underlying module. Generation of the index can be disabled if needed.

The definitions of the CDDL modules themselves require using a new `cddl-module` definition type. Changing the definition type means that the resulting IDs and the way to reference the definitions from other specs changes. Specs that reference these definitions in WebDriver BiDi need a small update accordingly.

Further updates are doable to start linking the spec prose with the CDDL definition where that makes sense. The auto-linking part already allows to follow CDDL structures that appear in the blocks, which I personally prefer to the raw blocks that the spec had otherwise.

I also updated the script that extracts the CDDL definitions. Now, [CDDL extracts](https://github.com/w3c/webref/tree/main/ed/cddl) are now automatically published in Webref every 6 hours (and validated using the CDDL parser I developed for integration in Bikeshed). I don't know to what extent that script is still used and useful.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/927.html" title="Last updated on Jun 11, 2025, 8:06 AM UTC (c1f3e3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/927/bd16afc...c1f3e3e.html" title="Last updated on Jun 11, 2025, 8:06 AM UTC (c1f3e3e)">Diff</a>