### PR TITLE
Fix references to CDDL module definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -413,8 +413,8 @@ protocol. These terms are distinct from their representation at the
 
 The protocol is defined using a [[!RFC8610|CDDL]] definition. For the
 convenience of implementers two separate CDDL definitions are defined; the
-<dfn cddl-module export lt="remote end definition|remote-cddl">remote end definition</dfn> which defines the format of messages produced
-on the [=local end=] and consumed on the [=remote end=], and the <dfn cddl-module export lt="local end definition|local-cddl">local end
+<dfn cddl-module export lt="Remote end definition|remote end definition|remote-cddl">remote end definition</dfn> which defines the format of messages produced
+on the [=local end=] and consumed on the [=remote end=], and the <dfn cddl-module export lt="Local end definition|local end definition|local-cddl">local end
 definition</dfn> which defines the format of messages produced on the [=remote end=]
 and consumed on the [=local end=]
 
@@ -422,11 +422,11 @@ and consumed on the [=local end=]
 
 Issue: Should this be an appendix?
 
-This section gives the initial contents of the [=remote end definition=] and
-[=local end definition=]. These are augmented by the definition fragments defined in
+This section gives the initial contents of the {^remote end definition^} and
+{^local end definition^}. These are augmented by the definition fragments defined in
 the remainder of the specification.
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 Command = {
@@ -452,7 +452,7 @@ EmptyParams = {
 }
 </pre>
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 Message = (
@@ -506,7 +506,7 @@ EventData = (
 )
 </pre>
 
-[=Remote end definition=] and [=Local end definition=]
+{^Remote end definition^} and {^Local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 Extensible = (*text => any)
@@ -551,13 +551,13 @@ Each module has a <dfn for=module export>module name</dfn> which is a string. Th
 [=command name=] and [=event name=] for commands and events defined in the
 module start with the [=module name=] followed by a period "<code>.</code>".
 
-Modules which contain [=commands=] define [=remote end definition=]
+Modules which contain [=commands=] define {^remote end definition^}
 fragments. These provide choices in the <code>CommandData</code> group for the
 module's [=commands=], and can also define additional definition properties. They
-can also define [=local end definition=] fragments that provide additional choices
+can also define {^local end definition^} fragments that provide additional choices
 in the <code>ResultData</code> group for the results of commands in the module.
 
-Modules which contain events define [=local end definition=] fragments that are
+Modules which contain events define {^local end definition^} fragments that are
 choices in the <code>Event</code> group for the module's [=events=].
 
 An implementation may define <dfn export>extension modules</dfn>. These must have a
@@ -584,7 +584,7 @@ long-running. As a consequence, commands can finish out-of-order.
 
 Each [=command=] is defined by:
 
-- A <dfn export for=command>command type</dfn> which is defined by a [=remote end definition=]
+- A <dfn export for=command>command type</dfn> which is defined by a {^remote end definition^}
    fragment containing a group. Each such group has two fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[method name]</code>. This is the <dfn export for=command>command
@@ -592,8 +592,8 @@ Each [=command=] is defined by:
     - <code>params</code> which defines a mapping containing data that to be passed into
       the command. The populated value of this map is the
       <dfn export for=command>command parameters</dfn>.
-- A <dfn export for=command>result type</dfn>, which is defined by a [=local
-  end definition=] fragment.
+- A <dfn export for=command>result type</dfn>, which is defined by a {^local
+  end definition^} fragment.
 - A set of [=remote end steps=] which define the actions to take for a command
   given a [=BiDi session=] and [=command parameters=] and return an
   instance of the command [=result type=].
@@ -702,8 +702,8 @@ An <dfn export>event</dfn> is a notification, sent by the [=remote end=]
 to the [=local end=], signaling that something of interest has
 occurred on the [=remote end=].
 
- - An <dfn export for=event>event type</dfn> is defined by a [=local
-   end definition=] fragment containing a group. Each such group has two fields:
+ - An <dfn export for=event>event type</dfn> is defined by a {^local
+   end definition^} fragment containing a group. Each such group has two fields:
     - <code>method</code> which is a string literal of the form <code>[module
       name].[event name]</code>. This is the <dfn export for=event>event
       name</dfn>.
@@ -1056,7 +1056,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
 
 1. If |session| is not null and not in [=active sessions=] then return.
 
-1. Match |parsed| against the [=remote end definition=]. If this results in a
+1. Match |parsed| against the {^remote end definition^}. If this results in a
    match:
 
    1. Let |matched| be the [=/map=] representing the matched data.
@@ -1097,7 +1097,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=]
        a session=].
 
     1. Let |response| be a new [=/map=] matching the <code>CommandResponse</code>
-       production in the [=local end definition=] with the <code>id</code>
+       production in the {^local end definition^} with the <code>id</code>
        field set to |command id| and the <code>value</code> field set to
        |value|.
 
@@ -1239,7 +1239,7 @@ To <dfn>send an error response</dfn> given a [=WebSocket connection=]
 |connection|, |command id|, and |error code|:
 
 1. Let |error data| be a new [=/map=] matching the <code>ErrorResponse</code>
-   production in the [=local end definition=], with the <code>id</code> field
+   production in the {^local end definition^}, with the <code>id</code> field
    set to |command id|, the <code>error</code> field set to |error code|, the
    <code>message</code> field set to an implementation-defined string
    containing a human-readable definition of the error that occurred and the
@@ -1583,7 +1583,7 @@ events for monitoring the status of the remote end.
 
 ### Definition ### {#module-session-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 SessionCommand = (
@@ -1595,7 +1595,7 @@ SessionCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 SessionResult = (
@@ -1666,7 +1666,7 @@ for a session.
 
 #### The session.CapabilityRequest Type #### {#type-session-CapabilityRequest}
 
-[=remote end definition=] and [=local end definition=]
+{^remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.CapabilityRequest = {
@@ -1717,7 +1717,7 @@ with parameter |value| is:
 
 #### The session.ProxyConfiguration Type #### {#type-session-ProxyConfiguration}
 
-[=remote end definition=] and [=local end definition=]
+{^remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.ProxyConfiguration = {
@@ -1767,7 +1767,7 @@ session.SystemProxyConfiguration = (
 
 #### The session.UserPromptHandler Type #### {#type-session-UserPromptHandler}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.UserPromptHandler = {
@@ -1788,7 +1788,7 @@ the picker. "ignore" keeps the picker open.
 
 #### The session.UserPromptHandlerType Type #### {#type-session-UserPromptHandlerType}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 session.UserPromptHandlerType = "accept" / "dismiss" / "ignore";
@@ -2321,7 +2321,7 @@ managing the remote end browser process.
 
 ### Definition ### {#module-browser-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 BrowserCommand = (
@@ -2334,7 +2334,7 @@ BrowserCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <!-- Nothing yet -->
 <pre class="cddl" data-cddl-module="local-cddl">
@@ -3019,7 +3019,7 @@ The progress of navigation is communicated using an immutable
 
 ### Definition ### {#module-browsingContext-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 BrowsingContextCommand = (
@@ -3038,7 +3038,7 @@ BrowsingContextCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 BrowsingContextResult = (
@@ -3089,7 +3089,7 @@ A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map bet
 
 #### The browsingContext.BrowsingContext Type #### {#type-browsingContext-Browsingcontext}
 
-[=remote end definition=] and [=local end definition=]
+{^remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.BrowsingContext = text;
@@ -3124,7 +3124,7 @@ To <dfn export>get a navigable</dfn> given |navigable id|:
 
 #### The browsingContext.Info Type #### {#type-browsingContext-Info}
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 browsingContext.InfoList = [*browsingContext.Info]
@@ -3295,7 +3295,7 @@ To <dfn>await a navigation</dfn> given |navigable|, |request|, |wait condition|,
 
 #### The browsingContext.Locator Type #### {#type-browsingContext-Locator}
 
-[=remote end definition=] and [=local end definition=]
+{^remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.Locator = (
@@ -3345,7 +3345,7 @@ for locating a node in a document.
 
 #### The browsingContext.Navigation Type #### {#type-browsingContext-Navigation}
 
-[=remote end definition=] and [=local end definition=]
+{^remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.Navigation = text;
@@ -3359,7 +3359,7 @@ TODO: Link to the definition in the HTML spec.
 
 #### The browsingContext.NavigationInfo Type #### {#type-browsingContext-NavigationInfo}
 
-[=local end definition=]:
+{^local end definition^}:
 
 <pre class="cddl" data-cddl-module="local-cddl">
 browsingContext.BaseNavigationInfo = (
@@ -3406,7 +3406,7 @@ document loading at which a navigation command will return.
 
 #### The browsingContext.UserPromptType Type #### {#type-browsingContext-UserPromptType}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 browsingContext.UserPromptType = "alert" / "beforeunload" / "confirm" / "prompt";
@@ -5728,7 +5728,7 @@ relating to emulation of browser APIs.
 
 ### Definition ### {#module-emulation-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 EmulationCommand = (
@@ -5862,7 +5862,7 @@ relating to network requests.
 
 ### Definition ### {#module-network-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 
@@ -5879,7 +5879,7 @@ NetworkCommand = (
 
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 
@@ -6260,7 +6260,7 @@ Note: this takes a [=byte sequence=] and returns a <code>network.BytesValue</cod
 
 #### The network.Cookie Type #### {#type-network-Cookie}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 
@@ -6329,7 +6329,7 @@ samesite-flag, which is from [[SAME-SITE-COOKIES]].
 
 #### The network.CookieHeader Type #### {#type-network-CookieHeader}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 network.CookieHeader = {
@@ -6358,7 +6358,7 @@ To <dfn>serialize cookie header</dfn> given |protocol cookie|:
 
 #### The network.FetchTimingInfo Type #### {#type-network-FetchTimingInfo}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 network.FetchTimingInfo = {
@@ -6454,7 +6454,7 @@ TODO: Add service worker fields
 
 #### The network.Header Type #### {#type-network-Header}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Header = {
@@ -6494,7 +6494,7 @@ To <dfn>deserialize header</dfn> given |protocol header|:
 
 #### The network.Initiator Type #### {#type-network-Initiator}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 network.Initiator = {
@@ -6551,7 +6551,7 @@ To <dfn>get the initiator</dfn> given |request|:
 
 #### The network.Intercept Type #### {#type-network-Intercept}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Intercept = text
@@ -6561,7 +6561,7 @@ The <code>network.Intercept</code> type represents the id of a [=network interce
 
 #### The network.Request Type #### {#type-network-Request}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 network.Request = text;
@@ -6573,7 +6573,7 @@ redirect matches that of the request that initiated it.
 
 #### The network.RequestData Type #### {#type-network-RequestData}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 network.RequestData = {
@@ -6655,7 +6655,7 @@ To <dfn>get the request data</dfn> given |request|:
 
 #### The network.ResponseContent Type #### {#type-network-ResponseContent}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 network.ResponseContent = {
@@ -6680,7 +6680,7 @@ To <dfn>get the response content info</dfn> given |response|.
 
 #### The network.ResponseData Type #### {#type-network-ResponseData}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 network.ResponseData = {
@@ -6794,7 +6794,7 @@ To <dfn>get the response data</dfn> given |response|:
 
 #### The network.SetCookieHeader Type #### {#type-network-SetCookieHeader}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 <!--
@@ -6926,7 +6926,7 @@ To <dfn>serialize set-cookie header</dfn> given |protocol cookie|:
 
 #### The network.UrlPattern Type #### {#type-network-UrlPattern}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 network.UrlPattern = (
@@ -8309,7 +8309,7 @@ relating to script realms and execution.
 
 ### Definition ### {#module-script-definition}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 ScriptCommand = (
@@ -8322,7 +8322,7 @@ ScriptCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 ScriptResult = (
@@ -8444,7 +8444,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
 #### The script.Channel Type #### {#type-script-Channel}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Channel = text;
@@ -8455,7 +8455,7 @@ used to send custom messages from the [=remote end=] to the [=local end=].
 
 #### The script.ChannelValue Type #### {#type-script-ChannelValue}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.ChannelValue = {
@@ -8492,7 +8492,7 @@ To <dfn>create a channel</dfn> given |session|, |realm| and |protocol value|:
 
 #### The script.EvaluateResult Type #### {#type-script-EvaluateResult}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.EvaluateResult = (
@@ -8521,7 +8521,7 @@ completes with a thrown exception.
 
 #### The script.ExceptionDetails Type #### {#type-script-ExceptionDetails}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.ExceptionDetails = {
@@ -8576,7 +8576,7 @@ To <dfn>get exception details</dfn> given a |realm|, a [=completion record=]
 
 #### The script.Handle Type #### {#type-script-Handle}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Handle = text;
@@ -8590,7 +8590,7 @@ strong [=/map=] from handle ids to their corresponding objects.
 
 #### The script.InternalId Type #### {#type-script-InternalId}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.InternalId = text;
@@ -8603,7 +8603,7 @@ a previously serialized <code>script.RemoteValue</code> during
 
 #### The script.LocalValue Type #### {#type-script-LocalValue}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.LocalValue = (
@@ -8804,7 +8804,7 @@ To <dfn>deserialize local value</dfn> given |local protocol value|, |realm| and
 
 #### The script.PreloadScript Type #### {#type-script-PreloadScript}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.PreloadScript = text;
@@ -8815,7 +8815,7 @@ on realm creation.
 
 #### The script.Realm Type #### {#type-script-Realm}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.Realm = text;
@@ -8849,7 +8849,7 @@ Issue: This has the wrong error code
 
 #### The script.PrimitiveProtocolValue Type #### {#type-script-PrimitiveProtocolValue}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.PrimitiveProtocolValue = (
@@ -8907,15 +8907,15 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
   <dl>
     <dt>[=Type=](|value|) is undefined
     <dd>Let |remote value| be a [=/map=] matching the <code>script.UndefinedValue</code>
-    production in the [=local end definition=].
+    production in the {^local end definition^}.
 
     <dt>[=Type=](|value|) is Null
     <dd>Let |remote value| be a [=/map=] matching the <code>script.NullValue</code>
-    production in the [=local end definition=].
+    production in the {^local end definition^}.
 
     <dt>[=Type=](|value|) is String
     <dd>Let |remote value| be a [=/map=] matching the <code>script.StringValue</code>
-    production in the [=local end definition=], with the <code>value</code>
+    production in the {^local end definition^}, with the <code>value</code>
     property set to |value|.
 
     Issue: This doesn't handle lone surrogates
@@ -8937,17 +8937,17 @@ To <dfn>serialize primitive protocol value</dfn> given a |value|:
       </dl>
 
     1. Let |remote value| be a [=/map=] matching the <code>script.NumberValue</code>
-       production in the [=local end definition=], with the <code>value</code>
+       production in the {^local end definition^}, with the <code>value</code>
        property set to |serialized|.
 
     <dt>[=Type=](|value|) is Boolean
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BooleanValue</code>
-        production in the [=local end definition=], with the <code>value</code>
+        production in the {^local end definition^}, with the <code>value</code>
         property set to |value|.
 
     <dt>[=Type=](|value|) is BigInt
     <dd>Let |remote value| be a [=/map=] matching the <code>script.BigIntValue</code>
-        production in the [=local end definition=], with the <code>value</code>
+        production in the {^local end definition^}, with the <code>value</code>
         property set to the result of running the [=ToString=] operation on
         |value|.
 
@@ -9017,7 +9017,7 @@ To <dfn>deserialize primitive protocol value</dfn> given a |primitive protocol v
 
 #### The script.RealmInfo Type ####  {#type-script-RealmInfo}
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 script.RealmInfo = (
@@ -9225,7 +9225,7 @@ Note: Future variations of this specification will retain the invariant that
 
 #### The script.RealmType Type ####  {#type-script-RealmType}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.RealmType = "window" / "dedicated-worker" / "shared-worker" / "service-worker" /
@@ -9236,7 +9236,7 @@ The <code>script.RealmType</code> type represents the different types of Realm.
 
 #### The script.RemoteReference Type #### {#type-script-RemoteReference}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 <!-- This is specifically ordered in the order in which matches need to be -->
@@ -9346,7 +9346,7 @@ To <dfn>deserialize shared reference</dfn> given |shared reference|, |realm| and
 
 #### The script.RemoteValue Type #### {#type-script-RemoteValue}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.RemoteValue = (
@@ -9646,7 +9646,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
   <dl>
     <dt>[=Type=](|value|) is Symbol
     <dd>Let |remote value| be a [=/map=] matching the <code>script.SymbolRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsArray=](|value|)
@@ -9662,11 +9662,11 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     1. Let |flags| be [=ToString=]([=Get=](|value|, "flags")).
 
     1. Let |serialized| be a [=/map=] matching the <code>script.RegExpValue</code> production in the
-       [=local end definition=], with the <code>pattern</code> property set to the
+       {^local end definition^}, with the <code>pattern</code> property set to the
        |pattern| and the the <code>flags</code> property set to the |flags|.
 
     1. Let |remote value| be a [=/map=] matching the <code>script.RegExpRemoteValue</code>
-       production in the [=local end definition=], with the <code>handle</code>
+       production in the {^local end definition^}, with the <code>handle</code>
        property set to |handle id| if it's not null, or omitted otherwise, and
        the <code>value</code> property set to |serialized|.
 
@@ -9677,7 +9677,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     1. Assert: |serialized| is not a [=throw completion=].
 
     1. Let |remote value| be a [=/map=] matching the <code>script.DateRemoteValue</code>
-       production in the [=local end definition=], with the <code>handle</code>
+       production in the {^local end definition^}, with the <code>handle</code>
        property set to |handle id| if it's not null, or omitted otherwise, and the
        value set to |serialized|.
 
@@ -9685,7 +9685,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     <dd>
 
     1. Let |remote value| be a [=/map=] matching the <code>script.MapRemoteValue</code>
-       production in the [=local end definition=], with the
+       production in the {^local end definition^}, with the
        <code>handle</code> property set to |handle id| if it's not null, or omitted
        otherwise.
 
@@ -9708,7 +9708,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     <dt>|value| has a \[[SetData]] [=internal slot=]
     <dd>
     1. Let |remote value| be a [=/map=] matching the <code>script.SetRemoteValue</code>
-       production in the [=local end definition=], with the
+       production in the {^local end definition^}, with the
        <code>handle</code> property set to |handle id| if it's not null, or omitted
        otherwise.
 
@@ -9731,42 +9731,42 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| has a \[[WeakMapData]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.WeakMapRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[WeakSetData]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.WeakSetRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[GeneratorState]] [=internal slot=] or \[[AsyncGeneratorState]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.GeneratorRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ErrorData]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.ErrorRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[ProxyHandler]] [=internal slot=] and a \[[ProxyTarget]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.ProxyRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsPromise=](|value|)
     <dd>Let |remote value| be a [=/map=] matching the <code>script.PromiseRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has a \[[TypedArrayName]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.TypedArrayRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| has an \[[ArrayBufferData]] [=internal slot=]
     <dd>Let |remote value| be a [=/map=] matching the <code>script.ArrayBufferRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=] that implements {{NodeList}}
@@ -9786,7 +9786,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
       1. Let |shared id| be [=get shared id for a node=] with |value| and |session|.
 
       1. Let |remote value| be a [=/map=] matching the <code>script.NodeRemoteValue</code>
-         production in the [=local end definition=], with the <code>sharedId</code>
+         production in the {^local end definition^}, with the <code>sharedId</code>
          property set to |shared id| if it's not null, or omitted otherwise, and the
          <code>handle</code> property set to |handle id| if it's not null, or omitted
          otherwise.
@@ -9886,22 +9886,22 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     1. Let |navigable id| be the [=navigable id=] for |navigable|.
 
     1. Let |serialized| be a [=/map=] matching the
-       <code>script.WindowProxyProperties</code> production in the [=local end
-       definition=] with the <code>context</code> property set to |navigable id|.
+       <code>script.WindowProxyProperties</code> production in the {^local end
+       definition^} with the <code>context</code> property set to |navigable id|.
 
     1. Let |remote value| be a [=/map=] matching the <code>script.WindowProxyRemoteValue</code>
-       production in the [=local end definition=], with the <code>handle</code>
+       production in the {^local end definition^}, with the <code>handle</code>
        property set to |handle id| if it's not null, or omitted otherwise, and
        the <code>value</code> property set to |serialized|.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a [=/map=] matching the <code>script.ObjectRemoteValue</code>
-           production in the [=local end definition=], with the <code>handle</code>
+           production in the {^local end definition^}, with the <code>handle</code>
            property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>[=IsCallable=](|value|)
     <dd>Let |remote value| be a [=/map=] matching the <code>script.FunctionRemoteValue</code>
-        production in the [=local end definition=], with the <code>handle</code>
+        production in the {^local end definition^}, with the <code>handle</code>
         property set to |handle id| if it's not null, or omitted otherwise.
 
     <dt>Otherwise:
@@ -9909,7 +9909,7 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     1. [=Assert=]: [=type=](|value|) is Object
 
     1. Let |remote value| be a [=/map=] matching the <code>script.ObjectRemoteValue</code> production
-       in the [=local end definition=], with the <code>handle</code> property set
+       in the {^local end definition^}, with the <code>handle</code> property set
        to |handle id| if it's not null, or omitted otherwise.
 
     1. [=Set internal ids if needed=] with |serialization internal map|,
@@ -10051,7 +10051,7 @@ ownership will be treated.
 
 #### The script.SerializationOptions Type #### {#type-script-SerializationOptions}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.SerializationOptions = {
@@ -10066,7 +10066,7 @@ objects will be serialized.
 
 #### The script.SharedId Type #### {#type-script-SharedId}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.SharedId = text;
@@ -10077,7 +10077,7 @@ is usable in any realm (including <a href=#sandbox-realm>Sandbox Realms</a>).
 
 #### The script.StackFrame Type #### {#type-script-StackFrame}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.StackFrame = {
@@ -10096,7 +10096,7 @@ properties, which represent the line and column number of the executed code.
 
 #### The script.StackTrace Type #### {#type-script-StackTrace}
 
-[=Remote end definition=] and [=local end definition=]
+{^Remote end definition^} and {^local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.StackTrace = {
@@ -10180,7 +10180,7 @@ Record=] of type <code>throw</code>, |exception|, is given by:
 
 #### The script.Source Type #### {#type-script-Source}
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 script.Source = {
@@ -10222,7 +10222,7 @@ To <dfn>get the source</dfn> given |source realm|:
 
 #### The script.Target Type #### {#type-script-Target}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 script.RealmTarget = {
@@ -11108,7 +11108,7 @@ A <dfn>storage partition key</dfn> is a [=/map=] which uniquely identifies a [=s
 
 ### Definition ### {#module-storage-definition}
 
-[=Remote end definition=]
+{^Remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 StorageCommand = (
@@ -11118,7 +11118,7 @@ StorageCommand = (
 )
 </pre>
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 StorageResult = (
@@ -11132,7 +11132,7 @@ StorageResult = (
 
 #### The storage.PartitionKey Type #### {#type-storage-PartitionKey}
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
 storage.PartitionKey = {
@@ -11586,7 +11586,7 @@ level navigable.
 
 ### Definition ### {#module-log-definition}
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 LogEvent = (
@@ -11598,7 +11598,7 @@ LogEvent = (
 
 #### log.LogEntry #### {#types-log-logentry}
 
-[=Local end definition=]
+{^Local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 log.Level = "debug" / "info" / "warn" / "error"
@@ -11813,7 +11813,7 @@ simulated user input.
 
 ### Definition ### {#module-input-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 
@@ -11824,7 +11824,7 @@ InputCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 
@@ -12302,7 +12302,7 @@ managing and interacting with web extensions.
 
 ### Definition ### {#module-webExtension-definition}
 
-[=remote end definition=]
+{^remote end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
 WebExtensionCommand = (
@@ -12311,7 +12311,7 @@ WebExtensionCommand = (
 )
 </pre>
 
-[=local end definition=]
+{^local end definition^}
 
 <pre class="cddl" data-cddl-module="local-cddl">
 WebExtensionResult = (


### PR DESCRIPTION
The CDDL modules are now defined using the "cddl-module" dfn type. This means they can no longer be referenced using the `[= =]` shorthand but now need the `{^ ^}` shorthand.

Internal references were missed in previous update (and did not trigger any error during the build because the xref database still contained the previous definition of type `dfn`).

Via
https://github.com/w3c/webdriver-bidi/pull/937#issuecomment-2987413818


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/939.html" title="Last updated on Jun 19, 2025, 10:32 AM UTC (2fcce96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/939/7b70258...2fcce96.html" title="Last updated on Jun 19, 2025, 10:32 AM UTC (2fcce96)">Diff</a>