### PR TITLE
Resume blocked requests if no active session can resume anymore

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1646,6 +1646,11 @@ To <dfn>cleanup the session</dfn> given |session|:
    1. [=map/Remove=] |session|'s
       [=user context to proxy configuration map=][|user context|].
 
+1. For each |request id| in |session|'s [=blocked request map=]:
+
+   1. [=Resume=] with "<code>continue request</code>", |request id|
+      and (null, "<code>incomplete</code>").
+
 1. For each |collector| in |session|'s [=network collectors=]:
 
    1. Let |collector id| be |collector|'s <code>collector</code>.

--- a/index.bs
+++ b/index.bs
@@ -1646,10 +1646,11 @@ To <dfn>cleanup the session</dfn> given |session|:
    1. [=map/Remove=] |session|'s
       [=user context to proxy configuration map=][|user context|].
 
-1. For each |request id| in |session|'s [=blocked request map=]:
+1. For each |request id| → (<var ignore>request</var>, <var ignore>phase</var>, |response|)
+   in |session|'s [=blocked request map=]:
 
    1. [=Resume=] with "<code>continue request</code>", |request id|
-      and (null, "<code>incomplete</code>").
+      and (|response|, "<code>incomplete</code>").
 
 1. For each |collector| in |session|'s [=network collectors=]:
 


### PR DESCRIPTION
Fixes #936 

On session cleanup (which happens after the session was removed from the active sessions in session end), resume requests which can no longer be resumed by any other active session.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/940.html" title="Last updated on Jun 25, 2025, 1:21 PM UTC (a616e87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/940/6120680...juliandescottes:a616e87.html" title="Last updated on Jun 25, 2025, 1:21 PM UTC (a616e87)">Diff</a>