### PR TITLE
Allow "sameSite" cookie property to have value "default".

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -325,17 +325,6 @@ spec: STREAMS; urlPrefix: https://streams.spec.whatwg.org/
     text: ReadableStream; url: #readablestream
 </pre>
 
-<pre class="biblio">sa
-{
-    "SAME-SITE-COOKIES": {
-        "authors": ["Steven Bingler", "Mike West", "John Wilander"],
-        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-20",
-        "publisher": "IETF",
-        "title": "Cookies: HTTP State Management Mechanism"
-    }
-}
-</pre>
-
 <style>
 var {
   color: #cd5c5c
@@ -6870,9 +6859,6 @@ The <code>network.Cookie</code> type represents a cookie.
 
 <div algorithm>
 To <dfn>serialize cookie</dfn> given |stored cookie|:
-
-Note: The definitions of |stored cookie|'s fields are from [[COOKIES]], except
-same-site-flag, which is from [[SAME-SITE-COOKIES]].
 
 1. Let |name| be the result of [=UTF-8 decode=] with |stored cookie|'s name field.
 


### PR DESCRIPTION
In case, setting the cookie with `document.cookie` Firefox doesn't set `sameSite` property. At the moment for BiDi `storage.getCookies` API [we fall back to `sameSite` property to `None`](https://bugzilla.mozilla.org/show_bug.cgi?id=1971488) but we would like to have a separate value "default" in this case to better reflect the actual browser behavior. 
This PR allows `sameSite` property to have the value `default` in this case.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/942.html" title="Last updated on Jun 30, 2025, 10:45 AM UTC (df3155c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/942/7831d08...lutien:df3155c.html" title="Last updated on Jun 30, 2025, 10:45 AM UTC (df3155c)">Diff</a>