### PR TITLE
Added note about possibility of capping the cookie expiry value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -49,6 +49,7 @@ spec: RFC6265
     text: Cookie store; url: https://httpwg.org/specs/rfc6265.html#storage-model
 spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-20.html
   type: dfn
+    text: Cookie Lifetime Limits; url: #cookie-lifetime-limits
     text: Lax; url: section-4.1.2.7
     text: Strict; url: section-4.1.2.7
     text: Default; url: section-5.6.7.2
@@ -12333,6 +12334,8 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
    <dt>[=Cookie expiry time=]
    <dd><p>|cookie spec|["<code>expiry</code>"] if it exists, otherwise leave unset to
     indicate that this is a session cookie.
+
+    Note: The cookie's expiry value might be limited by the remote end in accordance with the [=Cookie Lifetime Limits=].
 
    <dt>[=Cookie same site=]
    <dd><p>|cookie spec|["<code>sameSite</code>"] if it exists, otherwise leave unset to


### PR DESCRIPTION
Equivalent to https://github.com/w3c/webdriver/pull/1907 which was for WebDriver classic.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/944.html" title="Last updated on Jul 1, 2025, 2:13 PM UTC (02f49cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/944/0b2239c...whimboo:02f49cc.html" title="Last updated on Jul 1, 2025, 2:13 PM UTC (02f49cc)">Diff</a>