### PR TITLE
`emulation.setScriptingEnabled`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -243,7 +243,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: report an error; url: webappapis.html#report-the-error
     text: run the animation frame callbacks; url: imagebitmap-and-animations.html#run-the-animation-frame-callbacks
     text: same origin domain; url: browsers.html#same-origin-domain
-    text: scripting is disabled; url: webappapis.html#concept-environment-noscript
     text: select an image source from a source set; url: images.html#select-an-image-source-from-a-source-set
     text: selected files; url: input.html#concept-input-type-file-selected
     text: session history entry; url: browsing-the-web.html#session-history-entry
@@ -6068,67 +6067,37 @@ disabling JavaScript on web pages.
 Note: only emulation of disabled Javascript is supported.
 
 <div algorithm>
+The <dfn export>WebDriver BiDi scripting is enabled</dfn> steps given
+[=environment settings object=] |settings| are:
 
-To <dfn>emulate javascript enabled status</dfn> given |environment settings| and
-|emulated javascript enabled status|:
+1. Let |navigable| be |settings|'s [=relevant global object=]'s
+   <a>associated <code>Document</code></a>'s [=/node navigable=].
 
-1. Assert |emulated javascript enabled status| is null of false.
+1. Let |top-level traversable| be |navigable|’s [=navigable/top-level traversable=].
 
-1. If |emulated javascript enabled status| is false, perform implementation defined
-   steps to emulate the user disabled scripting for |environment settings|, so that
-   |environment settings|'s [=scripting is disabled=].
+1. If [=javascript enabled overrides map=] contains |top-level traversable|:
 
-1. Otherwise if |emulated javascript enabled status| is null, perform implementation
-   defined steps to restore the default scripting enabled status for
-   |environment settings|.
+   1. If [=javascript enabled overrides map=][|top-level traversable|] is false,
+      return false.
 
-</div>
+   1. Return true.
 
-<div algorithm>
+1. Let |user context| be  |top-level traversable|'s [=associated user context=].
 
-To <dfn>get emulated javascript enabled status</dfn> given |navigables|:
+1. If [=javascript enabled overrides map=] contains |user context|, return
+   [=javascript enabled overrides map=][|user context|].
 
-1. For each |navigable| or |navigables|:
+   1. If [=javascript enabled overrides map=][|user context|] is false, return false.
 
-   1. Let |top-level traversable| be |navigable|’s
-      [=navigable/top-level traversable=].
+   1. Return true.
 
-   1. If [=javascript enabled overrides map=] contains |top-level traversable|,
-      return [=javascript enabled overrides map=][|top-level traversable|].
-
-   1. Let |user context| be  |top-level traversable|'s [=associated user context=].
-
-   1. If [=javascript enabled overrides map=] contains |user context|, return
-      [=javascript enabled overrides map=][|user context|].
-
-   1. Return null.
+1. Return true.
 
 </div>
 
-<div algorithm>
-
-To <dfn>update javascript enabled status</dfn>:
-
-1. For each |environment settings| of [=environment settings objects=]:
-
-   1. Let |related navigables| be the result of [=get related navigables=] given
-      |environment settings|.
-
-   1. Let |emulated javascript enabled status| be the result of
-      [=get emulated javascript enabled status=] given |related navigables|.
-
-   1. [=Emulate javascript enabled status=] given |environment settings| and
-      |emulated javascript enabled status|.
-
-</div>
-
-<div algorithm="remote end steps for emulation.setEnableScriptingOverride">
+<div algorithm="remote end steps for emulation.setJavascriptEnabled">
 
 The [=remote end steps=] with |command parameters| are:
-
-1. If the implementation is unable to adjust the [=scripting is disabled=]
-   state for any reason, return [=error=] with [=error code=]
-   [=unsupported operation=].
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
    and |command parameters| [=map/contains=] "<code>context</code>",
@@ -6140,12 +6109,10 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |emulated javascript enabled status| be null.
 
-1. If |command parameters| [=map/contains=] "<code>enable</code>":
+1. If |command parameters| [=map/contains=] "<code>enabled</code>":
 
    1. Set |emulated javascript enabled status| to
-      |command parameters|["<code>enable</code>"].
-
-1. Let |navigables| be a [=/set=].
+      |command parameters|["<code>enabled</code>"].
 
 1. If the <code>contexts</code> field of |command parameters| is present:
 
@@ -6153,9 +6120,12 @@ The [=remote end steps=] with |command parameters| are:
       [=get valid top-level traversables by ids=] with
       |command parameters|["<code>contexts</code>"].
 
-1. Otherwise:
+   1. For each |navigable| of |navigables|:
 
-   1. Assert the <code>userContexts</code> field of |command parameters| is present.
+      1. [=map/Set=] [=javascript enabled overrides map=][|navigable|] to
+         |emulated javascript enabled status|.
+
+1. If the <code>userContexts</code> field of |command parameters| is present:
 
    1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
       with |command parameters|["<code>userContexts</code>"].
@@ -6164,19 +6134,6 @@ The [=remote end steps=] with |command parameters| are:
 
       1. [=map/Set=] [=javascript enabled overrides map=][|user context|] to
          |emulated javascript enabled status|.
-
-      1. [=list/For each=] |top-level traversable| of the list of all
-         [=/top-level traversables=] whose [=associated user context=] is
-         |user context|:
-
-         1. [=list/Append=] |top-level traversable| to |navigables|.
-
-1. For each |navigable| of |navigables|:
-
-   1. [=map/Set=] [=javascript enabled overrides map=][|navigable|] to
-      |emulated javascript enabled status|.
-
-1. [=Update javascript enabled status=].
 
 1. Return [=success=] with data null.
 
@@ -12396,12 +12353,6 @@ object:
 1. If |realm info| is null, return.
 
 1. Let |related navigables| be the result of [=get related navigables=] given |environment settings|.
-
-1. Let |emulated javascript enabled status| be the result of
-   [=get emulated javascript enabled status=] given |related navigables|.
-
-1. [=Emulate javascript enabled status=] given |environment settings| and
-   |emulated javascript enabled status|.
 
 1. Let |body| be a [=/map=] matching the <code>script.RealmCreated</code>
    production, with the <code>params</code> field set to |realm info|.

--- a/index.bs
+++ b/index.bs
@@ -5824,9 +5824,9 @@ relating to emulation of browser APIs.
 EmulationCommand = (
   emulation.SetForcedColorsModeThemeOverride //
   emulation.SetGeolocationOverride //
-  emulation.SetScriptingEnabled //
   emulation.SetLocaleOverride //
   emulation.SetScreenOrientationOverride //
+  emulation.SetScriptingEnabled //
   emulation.SetTimezoneOverride
 )
 </pre>
@@ -6030,110 +6030,6 @@ The [=remote end steps=] with |command parameters| are:
 1. For each |navigable| of |navigables|:
 
    1. [=Set emulated position data=] with |navigable| and |emulated position data|.
-
-1. Return [=success=] with data null.
-
-</div>
-
-#### The emulation.setScriptingEnabled Command ####  {#command-emulation-setScriptingEnabled}
-
-The <dfn export for=commands>emulation.setScriptingEnabled</dfn> command emulates
-disabling JavaScript on web pages.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl" data-cddl-module="remote-cddl">
-      emulation.SetScriptingEnabled = (
-        method: "emulation.setScriptingEnabled",
-        params: emulation.SetScriptingEnabledParameters
-      )
-
-      emulation.SetScriptingEnabledParameters = {
-        enabled: false / null,
-        ? contexts: [+browsingContext.BrowsingContext],
-        ? userContexts: [+browser.UserContext],
-      }
-    </pre>
-   </dd>
-   <dt>Result Type</dt>
-   <dd>
-    <code>
-     EmptyResult
-    </code>
-   </dd>
-</dl>
-
-Note: only emulation of disabled Javascript is supported.
-
-<div algorithm>
-The <dfn export>WebDriver BiDi scripting is enabled</dfn> steps given
-[=environment settings object=] |settings| are:
-
-1. Let |navigable| be |settings|'s [=relevant global object=]'s
-   <a>associated <code>Document</code></a>'s [=/node navigable=].
-
-1. Let |top-level traversable| be |navigable|’s [=navigable/top-level traversable=].
-
-1. If [=scripting enabled overrides map=] contains |top-level traversable|:
-
-   1. If [=scripting enabled overrides map=][|top-level traversable|] is false,
-      return false.
-
-   1. Return true.
-
-1. Let |user context| be  |top-level traversable|'s [=associated user context=].
-
-1. If [=scripting enabled overrides map=] contains |user context|, return
-   [=scripting enabled overrides map=][|user context|].
-
-   1. If [=scripting enabled overrides map=][|user context|] is false, return false.
-
-   1. Return true.
-
-1. Return true.
-
-</div>
-
-<div algorithm="remote end steps for emulation.setScriptingEnabled">
-
-The [=remote end steps=] with |command parameters| are:
-
-1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
-   and |command parameters| [=map/contains=] "<code>context</code>",
-   return [=error=] with [=error code=] [=invalid argument=].
-
-1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
-   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
-   return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |emulated scripting enabled status| be null.
-
-1. If |command parameters| [=map/contains=] "<code>enabled</code>":
-
-   1. Set |emulated scripting enabled status| to
-      |command parameters|["<code>enabled</code>"].
-
-1. If the <code>contexts</code> field of |command parameters| is present:
-
-   1. Let |navigables| be the result of [=trying=] to
-      [=get valid top-level traversables by ids=] with
-      |command parameters|["<code>contexts</code>"].
-
-   1. For each |navigable| of |navigables|:
-
-      1. [=map/Set=] [=scripting enabled overrides map=][|navigable|] to
-         |emulated scripting enabled status|.
-
-1. If the <code>userContexts</code> field of |command parameters| is present:
-
-   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
-      with |command parameters|["<code>userContexts</code>"].
-
-   1. For each |user context| of |user contexts|:
-
-      1. [=map/Set=] [=scripting enabled overrides map=][|user context|] to
-         |emulated scripting enabled status|.
 
 1. Return [=success=] with data null.
 
@@ -6376,6 +6272,110 @@ The [=remote end steps=] with |command parameters| are:
 
    1. [=Set emulated screen orientation=] with |navigable| and
       |emulated screen orientation|.
+
+1. Return [=success=] with data null.
+
+</div>
+
+#### The emulation.setScriptingEnabled Command ####  {#command-emulation-setScriptingEnabled}
+
+The <dfn export for=commands>emulation.setScriptingEnabled</dfn> command emulates
+disabling JavaScript on web pages.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      emulation.SetScriptingEnabled = (
+        method: "emulation.setScriptingEnabled",
+        params: emulation.SetScriptingEnabledParameters
+      )
+
+      emulation.SetScriptingEnabledParameters = {
+        enabled: false / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+    </pre>
+   </dd>
+   <dt>Result Type</dt>
+   <dd>
+    <code>
+     EmptyResult
+    </code>
+   </dd>
+</dl>
+
+Note: only emulation of disabled Javascript is supported.
+
+<div algorithm>
+The <dfn export>WebDriver BiDi scripting is enabled</dfn> steps given
+[=environment settings object=] |settings| are:
+
+1. Let |navigable| be |settings|'s [=relevant global object=]'s
+   <a>associated <code>Document</code></a>'s [=/node navigable=].
+
+1. Let |top-level traversable| be |navigable|’s [=navigable/top-level traversable=].
+
+1. If [=scripting enabled overrides map=] contains |top-level traversable|:
+
+   1. If [=scripting enabled overrides map=][|top-level traversable|] is false,
+      return false.
+
+   1. Return true.
+
+1. Let |user context| be  |top-level traversable|'s [=associated user context=].
+
+1. If [=scripting enabled overrides map=] contains |user context|, return
+   [=scripting enabled overrides map=][|user context|].
+
+   1. If [=scripting enabled overrides map=][|user context|] is false, return false.
+
+   1. Return true.
+
+1. Return true.
+
+</div>
+
+<div algorithm="remote end steps for emulation.setScriptingEnabled">
+
+The [=remote end steps=] with |command parameters| are:
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
+   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |emulated scripting enabled status| be null.
+
+1. If |command parameters| [=map/contains=] "<code>enabled</code>":
+
+   1. Set |emulated scripting enabled status| to
+      |command parameters|["<code>enabled</code>"].
+
+1. If the <code>contexts</code> field of |command parameters| is present:
+
+   1. Let |navigables| be the result of [=trying=] to
+      [=get valid top-level traversables by ids=] with
+      |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. [=map/Set=] [=scripting enabled overrides map=][|navigable|] to
+         |emulated scripting enabled status|.
+
+1. If the <code>userContexts</code> field of |command parameters| is present:
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
+      with |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=map/Set=] [=scripting enabled overrides map=][|user context|] to
+         |emulated scripting enabled status|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -5824,7 +5824,7 @@ relating to emulation of browser APIs.
 EmulationCommand = (
   emulation.SetForcedColorsModeThemeOverride //
   emulation.SetGeolocationOverride //
-  emulation.SetJavascriptEnabled //
+  emulation.SetScriptingEnabled //
   emulation.SetLocaleOverride //
   emulation.SetScreenOrientationOverride //
   emulation.SetTimezoneOverride
@@ -6035,21 +6035,21 @@ The [=remote end steps=] with |command parameters| are:
 
 </div>
 
-#### The emulation.setJavascriptEnabled Command ####  {#command-emulation-setJavascriptEnabled}
+#### The emulation.setScriptingEnabled Command ####  {#command-emulation-setScriptingEnabled}
 
-The <dfn export for=commands>emulation.setJavascriptEnabled</dfn> command emulates
+The <dfn export for=commands>emulation.setScriptingEnabled</dfn> command emulates
 disabling JavaScript on web pages.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl" data-cddl-module="remote-cddl">
-      emulation.SetJavascriptEnabled = (
-        method: "emulation.setJavascriptEnabled",
-        params: emulation.SetJavascriptEnabledParameters
+      emulation.SetScriptingEnabled = (
+        method: "emulation.setScriptingEnabled",
+        params: emulation.SetScriptingEnabledParameters
       )
 
-      emulation.SetJavascriptEnabledParameters = {
+      emulation.SetScriptingEnabledParameters = {
         enabled: false / null,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
@@ -6095,7 +6095,7 @@ The <dfn export>WebDriver BiDi scripting is enabled</dfn> steps given
 
 </div>
 
-<div algorithm="remote end steps for emulation.setJavascriptEnabled">
+<div algorithm="remote end steps for emulation.setScriptingEnabled">
 
 The [=remote end steps=] with |command parameters| are:
 

--- a/index.bs
+++ b/index.bs
@@ -243,6 +243,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: report an error; url: webappapis.html#report-the-error
     text: run the animation frame callbacks; url: imagebitmap-and-animations.html#run-the-animation-frame-callbacks
     text: same origin domain; url: browsers.html#same-origin-domain
+    text: scripting is disabled; url: webappapis.html#concept-environment-noscript
     text: select an image source from a source set; url: images.html#select-an-image-source-from-a-source-set
     text: selected files; url: input.html#concept-input-type-file-selected
     text: session history entry; url: browsing-the-web.html#session-history-entry
@@ -3143,6 +3144,9 @@ A [=remote end=] has a <dfn>timezone overrides map</dfn> which is a weak map bet
 A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn> which is a
 weak map between [=user contexts=] and [=unhandled prompt behavior struct=].
 
+A [=remote end=] has a <dfn>javascript enabled overrides map</dfn> which is a weak
+map between [=navigables=] or [=user contexts=] and boolean or null.
+
 ### Types ### {#module-browsingcontext-types}
 
 #### The browsingContext.BrowsingContext Type #### {#type-browsingContext-Browsingcontext}
@@ -5821,6 +5825,7 @@ relating to emulation of browser APIs.
 EmulationCommand = (
   emulation.SetForcedColorsModeThemeOverride //
   emulation.SetGeolocationOverride //
+  emulation.SetJavascriptEnabled //
   emulation.SetLocaleOverride //
   emulation.SetScreenOrientationOverride //
   emulation.SetTimezoneOverride
@@ -6026,6 +6031,152 @@ The [=remote end steps=] with |command parameters| are:
 1. For each |navigable| of |navigables|:
 
    1. [=Set emulated position data=] with |navigable| and |emulated position data|.
+
+1. Return [=success=] with data null.
+
+</div>
+
+#### The emulation.setJavascriptEnabled Command ####  {#command-emulation-setJavascriptEnabled}
+
+The <dfn export for=commands>emulation.setJavascriptEnabled</dfn> command emulates
+disabling JavaScript on web pages.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      emulation.SetJavascriptEnabled = (
+        method: "emulation.setJavascriptEnabled",
+        params: emulation.SetJavascriptEnabledParameters
+      )
+
+      emulation.SetJavascriptEnabledParameters = {
+        enabled: false / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+    </pre>
+   </dd>
+   <dt>Result Type</dt>
+   <dd>
+    <code>
+     EmptyResult
+    </code>
+   </dd>
+</dl>
+
+Note: only emulation of disabled Javascript is supported.
+
+<div algorithm>
+
+To <dfn>emulate javascript enabled status</dfn> given |environment settings| and
+|emulated javascript enabled status|:
+
+1. Assert |emulated javascript enabled status| is null of false.
+
+1. If |emulated javascript enabled status| is false, perform implementation defined
+   steps to emulate the user disabled scripting for |environment settings|, so that
+   |environment settings|'s [=scripting is disabled=].
+
+1. Otherwise if |emulated javascript enabled status| is null, perform implementation
+   defined steps to restore the default scripting enabled status for
+   |environment settings|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>get emulated javascript enabled status</dfn> given |navigables|:
+
+1. For each |navigable| or |navigables|:
+
+   1. Let |top-level traversable| be |navigable|’s
+      [=navigable/top-level traversable=].
+
+   1. If [=javascript enabled overrides map=] contains |top-level traversable|,
+      return [=javascript enabled overrides map=][|top-level traversable|].
+
+   1. Let |user context| be  |top-level traversable|'s [=associated user context=].
+
+   1. If [=javascript enabled overrides map=] contains |user context|, return
+      [=javascript enabled overrides map=][|user context|].
+
+   1. Return null.
+
+</div>
+
+<div algorithm>
+
+To <dfn>update javascript enabled status</dfn>:
+
+1. For each |environment settings| of [=environment settings objects=]:
+
+   1. Let |related navigables| be the result of [=get related navigables=] given
+      |environment settings|.
+
+   1. Let |emulated javascript enabled status| be the result of
+      [=get emulated javascript enabled status=] given |related navigables|.
+
+   1. [=Emulate javascript enabled status=] given |environment settings| and
+      |emulated javascript enabled status|.
+
+</div>
+
+<div algorithm="remote end steps for emulation.setEnableScriptingOverride">
+
+The [=remote end steps=] with |command parameters| are:
+
+1. If the implementation is unable to adjust the [=scripting is disabled=]
+   state for any reason, return [=error=] with [=error code=]
+   [=unsupported operation=].
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
+   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |emulated javascript enabled status| be null.
+
+1. If |command parameters| [=map/contains=] "<code>enable</code>":
+
+   1. Set |emulated javascript enabled status| to
+      |command parameters|["<code>enable</code>"].
+
+1. Let |navigables| be a [=/set=].
+
+1. If the <code>contexts</code> field of |command parameters| is present:
+
+   1. Let |navigables| be the result of [=trying=] to
+      [=get valid top-level traversables by ids=] with
+      |command parameters|["<code>contexts</code>"].
+
+1. Otherwise:
+
+   1. Assert the <code>userContexts</code> field of |command parameters| is present.
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
+      with |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=map/Set=] [=javascript enabled overrides map=][|user context|] to
+         |emulated javascript enabled status|.
+
+      1. [=list/For each=] |top-level traversable| of the list of all
+         [=/top-level traversables=] whose [=associated user context=] is
+         |user context|:
+
+         1. [=list/Append=] |top-level traversable| to |navigables|.
+
+1. For each |navigable| of |navigables|:
+
+   1. [=map/Set=] [=javascript enabled overrides map=][|navigable|] to
+      |emulated javascript enabled status|.
+
+1. [=Update javascript enabled status=].
 
 1. Return [=success=] with data null.
 
@@ -11795,7 +11946,8 @@ Note: the |function declaration| is parenthesized and evaluated.
    «"<code>(</code>", |function declaration|, "<code>)</code>"»
 
 1. Let |function script| be the result of [=create a classic script=] with
-   |parenthesized function declaration|, |environment settings|, |base URL|, and |options|.
+   |parenthesized function declaration|, |environment settings|, |base URL|,
+   |options| and <code>bypass disabled scripting</code> of true.
 
 1. [=Prepare to run script=] with |environment settings|.
 
@@ -11982,7 +12134,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
 1. Let |script| be the result of [=create a classic script=] with |source|,
-   |environment settings|, |base URL|, and |options|.
+   |environment settings|, |base URL|, |options| and
+   <code>bypass disabled scripting</code> of true.
 
 1. If |command parameters|["<code>userActivation</code>"] is true, run [=activation notification=] steps.
 
@@ -12243,6 +12396,12 @@ object:
 1. If |realm info| is null, return.
 
 1. Let |related navigables| be the result of [=get related navigables=] given |environment settings|.
+
+1. Let |emulated javascript enabled status| be the result of
+   [=get emulated javascript enabled status=] given |related navigables|.
+
+1. [=Emulate javascript enabled status=] given |environment settings| and
+   |emulated javascript enabled status|.
 
 1. Let |body| be a [=/map=] matching the <code>script.RealmCreated</code>
    production, with the <code>params</code> field set to |realm info|.

--- a/index.bs
+++ b/index.bs
@@ -3143,7 +3143,7 @@ A [=remote end=] has a <dfn>timezone overrides map</dfn> which is a weak map bet
 A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn> which is a
 weak map between [=user contexts=] and [=unhandled prompt behavior struct=].
 
-A [=remote end=] has a <dfn>javascript enabled overrides map</dfn> which is a weak
+A [=remote end=] has a <dfn>scripting enabled overrides map</dfn> which is a weak
 map between [=navigables=] or [=user contexts=] and boolean or null.
 
 ### Types ### {#module-browsingcontext-types}
@@ -6075,19 +6075,19 @@ The <dfn export>WebDriver BiDi scripting is enabled</dfn> steps given
 
 1. Let |top-level traversable| be |navigable|’s [=navigable/top-level traversable=].
 
-1. If [=javascript enabled overrides map=] contains |top-level traversable|:
+1. If [=scripting enabled overrides map=] contains |top-level traversable|:
 
-   1. If [=javascript enabled overrides map=][|top-level traversable|] is false,
+   1. If [=scripting enabled overrides map=][|top-level traversable|] is false,
       return false.
 
    1. Return true.
 
 1. Let |user context| be  |top-level traversable|'s [=associated user context=].
 
-1. If [=javascript enabled overrides map=] contains |user context|, return
-   [=javascript enabled overrides map=][|user context|].
+1. If [=scripting enabled overrides map=] contains |user context|, return
+   [=scripting enabled overrides map=][|user context|].
 
-   1. If [=javascript enabled overrides map=][|user context|] is false, return false.
+   1. If [=scripting enabled overrides map=][|user context|] is false, return false.
 
    1. Return true.
 
@@ -6107,11 +6107,11 @@ The [=remote end steps=] with |command parameters| are:
    and |command parameters| doesn't [=map/contain=] "<code>context</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
-1. Let |emulated javascript enabled status| be null.
+1. Let |emulated scripting enabled status| be null.
 
 1. If |command parameters| [=map/contains=] "<code>enabled</code>":
 
-   1. Set |emulated javascript enabled status| to
+   1. Set |emulated scripting enabled status| to
       |command parameters|["<code>enabled</code>"].
 
 1. If the <code>contexts</code> field of |command parameters| is present:
@@ -6122,8 +6122,8 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |navigable| of |navigables|:
 
-      1. [=map/Set=] [=javascript enabled overrides map=][|navigable|] to
-         |emulated javascript enabled status|.
+      1. [=map/Set=] [=scripting enabled overrides map=][|navigable|] to
+         |emulated scripting enabled status|.
 
 1. If the <code>userContexts</code> field of |command parameters| is present:
 
@@ -6132,8 +6132,8 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |user context| of |user contexts|:
 
-      1. [=map/Set=] [=javascript enabled overrides map=][|user context|] to
-         |emulated javascript enabled status|.
+      1. [=map/Set=] [=scripting enabled overrides map=][|user context|] to
+         |emulated scripting enabled status|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -11899,12 +11899,14 @@ To <dfn>evaluate function body</dfn> given |function declaration|,
 
 Note: the |function declaration| is parenthesized and evaluated.
 
+1. Let |bypassDisabledScripting| be true.
+
 1. Let |parenthesized function declaration| be [=concatenate=]
    «"<code>(</code>", |function declaration|, "<code>)</code>"»
 
 1. Let |function script| be the result of [=create a classic script=] with
    |parenthesized function declaration|, |environment settings|, |base URL|,
-   |options| and <code>bypass disabled scripting</code> of true.
+   |options| and |bypassDisabledScripting|.
 
 1. [=Prepare to run script=] with |environment settings|.
 
@@ -12090,9 +12092,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |base URL| be the [=API base URL=] of |environment settings|.
 
+1. Let |bypassDisabledScripting| be true.
+
 1. Let |script| be the result of [=create a classic script=] with |source|,
-   |environment settings|, |base URL|, |options| and
-   <code>bypass disabled scripting</code> of true.
+   |environment settings|, |base URL|, |options| and |bypassDisabledScripting|.
 
 1. If |command parameters|["<code>userActivation</code>"] is true, run [=activation notification=] steps.
 


### PR DESCRIPTION
`emulation. setScriptingEnabled` command. Related [HTML PR](https://github.com/whatwg/html/pull/11441) should be landed after this one.

* Store the state in `scripting enabled overrides map`.
* Provide a hook "WebDriver BiDi scripting is enabled" to be called by HTML's ["Scripting is enabled"](https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-script) method.
* Force scripting enabled for scripts initiated by BiDi protocol user via "bypassDisabledScripting" argument.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/946.html" title="Last updated on Aug 11, 2025, 9:42 PM UTC (a651416)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/946/0a6dc6c...a651416.html" title="Last updated on Aug 11, 2025, 9:42 PM UTC (a651416)">Diff</a>