### PR TITLE
fix (network.fetchError): define errorText as implementation defined string

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9052,7 +9052,8 @@ error</dfn> steps given |request|:
   1. Let |params| be the result of [=process a network event=] with |session|
      "<code>network.fetchError</code>", and |request|.
 
-  1. TODO: Set the <code>errorText</code> field of |params|.
+  1. Set the <code>errorText</code> field of |params| to an implementation-defined string
+     describing the error which caused the request to be aborted.
 
   1. Assert: |params| matches the <code>network.FetchErrorParameters</code>
      production.


### PR DESCRIPTION
Fixes #631

The fetch spec does not define the error message which leads to abort a request, so the fetchError parameter will most likely be an implementation defined string.

Ideally it should not be used for assertions, but can be still be useful for clients.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/950.html" title="Last updated on Jul 9, 2025, 8:01 PM UTC (186a655)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/950/a8b68a1...juliandescottes:186a655.html" title="Last updated on Jul 9, 2025, 8:01 PM UTC (186a655)">Diff</a>