### PR TITLE
Convert scripts/cddl into an ESM

### DIFF
--- a/scripts/cddl/generate.js
+++ b/scripts/cddl/generate.js
@@ -8,13 +8,15 @@
  * - pathToSpec: a path to the specification to extract CDDL definitions from. Default: _dirname/../../index.bs.
  */
 
-const fs = require('fs')
-const path = require('path')
-const parse5 = require('parse5')
+import fs from 'fs';
+import path from 'path';
+import parse5 from 'parse5';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
-const { getCDDLNodes } = require('./utils')
+import { getCDDLNodes } from './utils.js';
 
-const spec = process.argv[2] || path.resolve(__dirname, '..', '..', 'index.bs')
+const spec = process.argv[2] || path.resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'index.bs')
 const specContent = fs.readFileSync(spec, 'utf-8')
 const specParsed = parse5.parse(specContent)
 

--- a/scripts/cddl/package.json
+++ b/scripts/cddl/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "generate-cddl",
+  "version": "1.0.0",
+  "description": "Generate CDDL files",
+  "main": "utils.jsm",
+  "type": "module",
+  "scripts": {
+    "generate": "node generate.js"
+  },
+  "author": "Browser Testing & Tools WG",
+  "license": "MIT"
+}

--- a/scripts/cddl/utils.js
+++ b/scripts/cddl/utils.js
@@ -10,7 +10,7 @@
  * @param {Array<string>} local Array to fill with local CDDL definitions.
  * @param {Array<string>} remote Array to fill with remote CDDL definitions.
  */
-function getCDDLNodes(nodes) {
+export function getCDDLNodes(nodes) {
   const entries = { local: [], remote: [], all: [] };
 
   nodes.forEach((node) => {
@@ -48,4 +48,3 @@ function getCDDLNodes(nodes) {
   return entries;
 }
 
-module.exports = { getCDDLNodes };

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,8 +14,9 @@ if [[ "$(npm list parse5)" =~ "empty" ]] || [ "$1" = "--upgrade" ]; then
   npm install parse5
 fi
 
-# Extract CDDL content from spec into files
-"$ROOT"/scripts/cddl/generate.js
+cd "$SCRIPT_DIR/cddl/"
+npm run generate
+cd -
 
 cddl compile-cddl --cddl local.cddl
 cddl compile-cddl --cddl remote.cddl


### PR DESCRIPTION
This avoids a CI failure that's started happening with CommonJS imports