### PR TITLE
Bump version of node.js from 16 to 22.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - name: Get cddl version
         run: curl -s https://crates.io/api/v1/crates/cddl | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_stable_version'])" | tee cddl.txt
       - name: "Cache rust binaries"


### PR DESCRIPTION
This should unblock https://github.com/w3c/webdriver-bidi/pull/960.