### PR TITLE
nit: fix alphabetical position for network.DataType

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6777,17 +6777,6 @@ To <dfn>process a network event</dfn> given |session|, |event|, and |request|:
 
 </div>
 
-#### The network.DataType Type #### {#type-network-dataType}
-
-{^Remote end definition^} and {^local end definition^}
-
-<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
-network.DataType = "response"
-</pre>
-
-The <code>network.DataType</code> type represents the different types of network data
-that can be collected.
-
 #### The network.BytesValue Type #### {#type-network-BytesValue}
 
 <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
@@ -6961,6 +6950,17 @@ To <dfn>serialize cookie header</dfn> given |protocol cookie|:
 1. Return |header value|.
 
 </div>
+
+#### The network.DataType Type #### {#type-network-dataType}
+
+{^Remote end definition^} and {^local end definition^}
+
+<pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
+network.DataType = "response"
+</pre>
+
+The <code>network.DataType</code> type represents the different types of network data
+that can be collected.
 
 #### The network.FetchTimingInfo Type #### {#type-network-FetchTimingInfo}
 


### PR DESCRIPTION
DataType definition is not at the expected alphabetical position. This PR only moves the defintion to the correct spot.