### PR TITLE
`browser.setDownloadBehavior`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5611,7 +5611,7 @@ The [=remote end event trigger=] is the
 The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download
 started</dfn> steps given |navigable| and |navigation status|:
 
-Issue: Removed after HTML spec switched to [=WebDriver BiDi download will begin=]
+Issue: Remove after HTML spec switched to [=WebDriver BiDi download will begin=]
 (https://github.com/whatwg/html/pull/11474).
 
 1. Let |navigation info| be the result of [=get the navigation info=] given |navigable| and


### PR DESCRIPTION
In puppeteer, [there is a way](https://pptr.dev/api/puppeteer.browsercontextoptions) to [deny all the downloads](https://pptr.dev/api/puppeteer.downloadpolicy), or allow for [downloading to a custom folder](https://pptr.dev/api/puppeteer.downloadbehavior#downloadpath). This PR is intended to provide a way to customize the download behavior per user context or globally.

1. Should be followed up with [HTML PR](https://github.com/whatwg/html/pull/11474) invoking new hooks.
1. Add a new hook "WebDriver BiDi download will begin" which is intended to replace "WebDriver BiDi download started".
1. "WebDriver BiDi download will begin" returns "download behavior struct", which instructs the user agent how to handle downloads.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/970.html" title="Last updated on Sep 16, 2025, 5:43 PM UTC (5bad586)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/970/f1d6555...5bad586.html" title="Last updated on Sep 16, 2025, 5:43 PM UTC (5bad586)">Diff</a>