### PR TITLE
fix: Do not link data collection to network event subscription

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6534,11 +6534,11 @@ To <dfn>match collector for navigable</dfn> given |collector| and |navigable|:
 </div>
 
 <div algorithm>
-To <dfn export>clone network response body</dfn> given |sessions|, |request| and |response body|:
+To <dfn export>clone network response body</dfn> given |request| and |response body|:
 
 Note: This hook is intended to be triggered by the fetch spec when the response is set.
 
-1. For each |session| in |sessions|:
+1. For each |session| in [=active BiDi sessions=]:
 
    1. If |session|'s [=network collectors=] is not [=list/empty=]:
 
@@ -6583,7 +6583,7 @@ To <dfn>maybe abort network response body collection</dfn> given |request|:
 </div>
 
 <div algorithm>
-To <dfn>maybe collect network response body</dfn> given |sessions|, |request| and |response|:
+To <dfn>maybe collect network response body</dfn> given |request| and |response|:
 
 1. If |response|'s [=response/status=] is a [=redirect status=], return.
 
@@ -6614,7 +6614,7 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
 
 1. Let |collectors| be an empty list.
 
-1. For each |session| in |sessions|:
+1. For each |session| in [=active BiDi sessions=]:
 
    1. For each |collector| in |session|'s [=network collectors=]:
 
@@ -9477,10 +9477,10 @@ completed</dfn> steps given |request| and |response|:
    [=request/client=]. Otherwise let |related navigables| be an empty
    set.
 
+1. [=Maybe collect network response body=] with |request| and |response|.
+
 1. Let |sessions| be the [=set of sessions for which an event is enabled=]
    given "<code>network.responseCompleted</code>" and |related navigables|.
-
-1. [=Maybe collect network response body=] with |sessions|, |request| and |response|.
 
 1. For each |session| in |sessions|:
 
@@ -9543,10 +9543,10 @@ started</dfn> steps given |request| and |response|:
 
 1. Let |response status| be "<code>incomplete</code>".
 
+1. [=Clone network response body=] with |request| and |response|.
+
 1. Let |sessions| be the [=set of sessions for which an event is enabled=]
    given "<code>network.responseStarted</code>" and |related navigables|.
-
-1. [=Clone network response body=] with |sessions|, |request| and |response|.
 
 1. For each |session| in |sessions|:
 


### PR DESCRIPTION
With the current spec, you could essentially get deadlock if you subscribe to responseStarted but not to responseCompleted and try to use network.getData.

This is because we only trigger the data collector algorithms for sessions which subscribe to those events. The algorithms should be executed regardless of the state of network event subscription.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/972.html" title="Last updated on Aug 1, 2025, 4:07 PM UTC (68fa7f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/972/5c647ae...juliandescottes:68fa7f3.html" title="Last updated on Aug 1, 2025, 4:07 PM UTC (68fa7f3)">Diff</a>