### PR TITLE
fix: delete collected data if no navigable or collector matches

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6602,6 +6602,8 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
 
 1. If |navigable| is null:
 
+   1. [=list/Remove=] |collected data| from [=collected network data=].
+
    1. [=Resume=] with "<code>network data collected</code>" and (|request|'s [=request id=], "response").
 
    1. Return.
@@ -6623,6 +6625,8 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
          1. [=list/Append=] |collector| to |collectors|.
 
 1. If |collectors| is [=list/empty=]:
+
+   1. [=list/Remove=] |collected data| from [=collected network data=].
 
    1. [=Resume=] with "<code>network data collected</code>" and (|request|'s [=request id=], "response").
 
@@ -6665,6 +6669,8 @@ To <dfn>maybe collect network response body</dfn> given |sessions|, |request| an
       1. Set |collected data|'s <code>bytes</code> to |bytes|.
 
       1. Set |collected data|'s <code>size</code> to |size|.
+
+   1. Otherwise, [=list/remove=] |collected data| from [=collected network data=].
 
 1. [=Resume=] with "<code>network data collected</code>" and (|request|'s [=request id=], "response").
 


### PR DESCRIPTION
If a collected data is not stored at all because it doesn't match any collector (either no navigable is found, no collector matches the navigable or no collector matches the data size), the collected data should be immediately removed from the remote end's collected data map. 

Otherwise this collector-less data will never be cleaned up (because this only happens when cleaning collectors). Calling `getData` for such a data should also throw with `no such network data` and not with `unavailable network data`.