### PR TITLE
Allow for empty `headers` in `network.setExtraHeaders`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9039,7 +9039,7 @@ specifying headers that will extend, or overwrite, existing request headers.
       )
 
       network.SetExtraHeadersParameters = {
-        headers: [+network.Header]
+        headers: [*network.Header]
         ? contexts: [+browsingContext.BrowsingContext]
         ? userContexts: [+browser.UserContext]
       }


### PR DESCRIPTION
Addressing https://github.com/w3c/webdriver-bidi/issues/977


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/978.html" title="Last updated on Aug 8, 2025, 10:34 AM UTC (c69e259)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/978/8c95812...c69e259.html" title="Last updated on Aug 8, 2025, 10:34 AM UTC (c69e259)">Diff</a>