### PR TITLE
editorial: fix typo in browsingContext.downloadWillBegin anchor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5438,7 +5438,7 @@ complete</dfn> steps given |navigable| and |navigation status|:
 
 </div>
 
-#### The browsingContext.downloadWillBegin Event #### {#event-browsingContext-downoadWillBegin}
+#### The browsingContext.downloadWillBegin Event #### {#event-browsingContext-downloadWillBegin}
 
 <dl>
    <dt>Event Type</dt>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/979.html" title="Last updated on Aug 12, 2025, 10:02 AM UTC (0c18939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/979/e373ae7...juliandescottes:0c18939.html" title="Last updated on Aug 12, 2025, 10:02 AM UTC (0c18939)">Diff</a>