### PR TITLE
Editorial: validate `proxy` in `browser.createUserContext`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,6 +74,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: cookie value; url: dfn-cookie-value
     text: create a cookie; url: dfn-creating-a-cookie
     text: create a session; url: dfn-create-a-session
+    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: dispatch actions; url: dfn-dispatch-actions
     text: dispatch tick actions; url: dfn-dispatch-tick-actions
     text: draw a bounding box from the framebuffer; url: dfn-draw-a-bounding-box-from-the-framebuffer
@@ -102,7 +103,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
     text: process capabilities; url: dfn-capabilities-processing
-    text: proxy configuration; url: dfn-proxy-configuration
+    text: proxy configuration object; url: dfn-proxy-configuration-object
     text: readiness state; url: dfn-readiness-state
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
@@ -1539,7 +1540,7 @@ A [=BiDi session=] has a
 [=/map=] between [=user contexts=] and boolean.
 
 A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
-a [=/map=] between [=user contexts=] and [=proxy configuration=].
+a [=/map=] between [=user contexts=] and [=proxy configuration object=].
 
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
@@ -2758,7 +2759,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
-   1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
+   1. Let |proxy configuration| be the result of [=trying=] to [=deserialize as a proxy=] with
+      |command parameters|["<code>proxy</code>"].
 
    1. If the [=remote end=] is unable to configure proxy settings per [=user context=],
        or is unable to configure the proxy with |proxy configuration|, return  [=error=] with


### PR DESCRIPTION
Use WebDriver classic's ["deserialize as a proxy"](https://w3c.github.io/webdriver/#dfn-deserialize-as-a-proxy) in `browser.createUserContext` for `proxy` parameter.

We have a bunch of WPT tests checking the validity of `proxy` in `browser.createUserContext`, while the BiDi specification does not have the validation at all.