### PR TITLE
Revert "Editorial: validate `proxy` in `browser.createUserContext`"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,7 +74,6 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: cookie value; url: dfn-cookie-value
     text: create a cookie; url: dfn-creating-a-cookie
     text: create a session; url: dfn-create-a-session
-    text: deserialize as a proxy; url: dfn-deserialize-as-a-proxy
     text: dispatch actions; url: dfn-dispatch-actions
     text: dispatch tick actions; url: dfn-dispatch-tick-actions
     text: draw a bounding box from the framebuffer; url: dfn-draw-a-bounding-box-from-the-framebuffer
@@ -103,7 +102,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: parse a page range; url: dfn-parse-a-page-range
     text: handler; for: prompt handler configuration; url: dfn-handler
     text: process capabilities; url: dfn-capabilities-processing
-    text: proxy configuration object; url: dfn-proxy-configuration-object
+    text: proxy configuration; url: dfn-proxy-configuration
     text: readiness state; url: dfn-readiness-state
     text: remote end steps; url: dfn-remote-end-steps
     text: remote end; url: dfn-remote-ends
@@ -1540,7 +1539,7 @@ A [=BiDi session=] has a
 [=/map=] between [=user contexts=] and boolean.
 
 A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
-a [=/map=] between [=user contexts=] and [=proxy configuration object=].
+a [=/map=] between [=user contexts=] and [=proxy configuration=].
 
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
@@ -2759,8 +2758,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>proxy</code>":
 
-   1. Let |proxy configuration| be the result of [=trying=] to [=deserialize as a proxy=] with
-      |command parameters|["<code>proxy</code>"].
+   1. Let |proxy configuration| be |command parameters|["<code>proxy</code>"].
 
    1. If the [=remote end=] is unable to configure proxy settings per [=user context=],
        or is unable to configure the proxy with |proxy configuration|, return  [=error=] with


### PR DESCRIPTION
Reverts w3c/webdriver-bidi#988. Reason: https://github.com/w3c/webdriver/issues/1920


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/989.html" title="Last updated on Aug 22, 2025, 1:34 PM UTC (a3bc772)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/989/b7393ef...a3bc772.html" title="Last updated on Aug 22, 2025, 1:34 PM UTC (a3bc772)">Diff</a>