### PR TITLE
Allow for removing emulation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6003,11 +6003,11 @@ The [=remote end steps=] with |command parameters| are:
    |command parameters|["<code>coordinates</code>"].
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
-   and |command parameters| [=map/contains=] "<code>context</code>",
+   and |command parameters| [=map/contains=] "<code>contexts</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
-   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
+   and |command parameters| doesn't [=map/contain=] "<code>contexts</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |navigables| be a [=/set=].
@@ -6101,11 +6101,11 @@ The [=DefaultLocale=] algorithm is implementation defined. A WebDriver-BiDi
 The [=remote end steps=] with |command parameters| are:
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
-   and |command parameters| [=map/contains=] "<code>context</code>",
+   and |command parameters| [=map/contains=] "<code>contexts</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |command parameters| doesn't [=map/contain=] "<code>userContexts</code>"
-   and |command parameters| doesn't [=map/contain=] "<code>context</code>",
+   and |command parameters| doesn't [=map/contain=] "<code>contexts</code>",
    return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |emulated locale| be |command parameters|["<code>locale</code>"].


### PR DESCRIPTION
### Step 1. 

Currently, passing emulation value of `null` behaves differently in different methods. This PR aligns the behavior to the following: passing `null` removes the emulation for the given scope. 

E.g. having pre-condition: NAVIGABLE locale emulation is set to NAVIGABLE_EMULATED_LOCALE and USER_CONTEXT locale emulation is set to USER_CONTEXT_EMULATED_LOCALE.
* The emulated locale of NAVIGABLE is NAVIGABLE_EMULATED_LOCALE.
* Call `emulation.setLocaleOverride(NAVIGABLE, null)`
* The emulated locale of NAVIGABLE is USER_CONTEXT_EMULATED_LOCALE.
* Call `emulation.setLocaleOverride(USER_CONTEXT, null)`.
* The emulated locale of NAVIGABLE is the default one.

Affected method:
* emulation.SetLocaleOverride
* emulation.SetScriptingEnabled
* emulation.SetTimezoneOverride

### Out of scope
The following methods require some extra effort, so it makes sense to get agreement on the approach and to land this PR first:
* emulation.SetForcedColorsModeThemeOverride
* emulation.SetGeolocationOverride
* emulation.SetScreenOrientationOverride


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1001.html" title="Last updated on Sep 12, 2025, 11:34 AM UTC (e6ac810)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1001/ef4a35d...e6ac810.html" title="Last updated on Sep 12, 2025, 11:34 AM UTC (e6ac810)">Diff</a>