### PR TITLE
`destinationFolder` is required in `allowed` download behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2985,7 +2985,7 @@ for="download behavior">user context download behavior</dfn>, which is a weak ma
 
       browser.DownloadBehaviorAllowed = (
         type: "allowed",
-        ? destinationFolder: text
+        destinationFolder: text
       )
 
       browser.DownloadBehaviorDenied = (


### PR DESCRIPTION
The User agent can have 3 default download behaviors: 
1. Deny.
2. Allow and save to some default download folder.
3. Show file save dialog.

`browser.setDownloadBehavior({type: "allowed"})` without `destinationFolder` does not make sense, as:
* If the user wants to download the file to the default download folder, they should use default download behavior (`downloadBehavior: null`). In this case, if the user agent has a default download folder, it will be used. Otherwise the download will be denied.
* If the user wants to download the file to the specific download folder, they can specify it in `browser.setDownloadBehavior({type: "allowed", destinationFolder: "..."})`.
 
According to the current specification, the user agent should return "unsupported error" if the default download folder is not specified. In case of Chromium, the default download folder is defined only for the default user context of headful or new headless modes. It is not defined for old headless or custom user contexts. Given that, global setting `browser.setDownloadBehavior({type: "allowed"})` in Chromium should always return "unsupported error", as it should be applied for the non-default user contexts as well, even if they are created later on.

My proposal is to make `destinationFolder` required for `allowed` download behavior to make the behavior for each of the 3 default download behaviors mentioned at the beginning clear. This would allow for a clear WebDriver BiDi API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1008.html" title="Last updated on Sep 23, 2025, 8:37 AM UTC (45aab5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1008/32892f3...45aab5a.html" title="Last updated on Sep 23, 2025, 8:37 AM UTC (45aab5a)">Diff</a>