### PR TITLE
[Editorial] Add CallFunctionResult alias

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12061,7 +12061,7 @@ Note: In case of an arrow function in <code>functionDeclaration</code>, the
    </dd>
    <dt>Result Type</dt>
    <dd>
-   <pre class="cddl" data-cddl-module="local-cddl">
+    <pre class="cddl" data-cddl-module="local-cddl">
       script.CallFunctionResult = script.EvaluateResult
     </pre>
    </dd>


### PR DESCRIPTION
This change is a subset of https://github.com/w3c/webdriver-bidi/pull/1002
Unlike the other case where we can do things like
Deduce or falling back to Extensiable/EmptyResult 
Use the method name and transform it via (exp `script.evaluate` -> `Script.EvaluateResult`)

This one can't be inferred by name alone. 
With this change  we unlock correct types in https://github.com/GoogleChromeLabs/webdriver-bidi-protocol
and other type provides may look at the implementation there.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1009.html" title="Last updated on Sep 24, 2025, 11:54 AM UTC (0e81c8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1009/dd4d017...0e81c8d.html" title="Last updated on Sep 24, 2025, 11:54 AM UTC (0e81c8d)">Diff</a>