### PR TITLE
Add support for request dataType to network data collection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6877,7 +6877,7 @@ To <dfn>match collector for navigable</dfn> given |collector| and |navigable|:
 </div>
 
 <div algorithm>
-To <dfn export>clone network request body</dfn> given |request|:
+To <dfn export>clone network request body</dfn> given [=/request=] |request|:
 
 Note: This hook is intended to be triggered by the fetch spec when the request body has been safely extracted.
 See step 9 of https://fetch.spec.whatwg.org/#concept-fetch
@@ -6998,7 +6998,8 @@ To <dfn>maybe collect network response body</dfn> given |request| and |response|
 </div>
 
 <div algorithm>
-To <dfn>maybe collect network data</dfn> given |request|, |collected data|, |size| and |data type|:
+To <dfn>maybe collect network data</dfn> given [=/request=] |request|,
+[=network data=] |collected data|, js-uint |size| and [=network.DataType=] |data type|:
 
 1. Set |collected data|'s <code>pending</code> to false.
 


### PR DESCRIPTION
Fixes #748 

- Adds another entry point expected to be called from the fetch spec `clone network request body` (alternatively could be called explicitly from beforeRequestSent for now)
- Extracts a generic algorithm `maybe collect network data` from `maybe collect network response body`
- Update `maybe collect network response body` to call `maybe collect network data`
- Adds a new algorithm `maybe collect network request body` called from the beforeRequestSent steps

Otherwise this mostly reuses the logic added for response body collection. Commands do not need to be udpated AFAICT


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1011.html" title="Last updated on Sep 29, 2025, 9:30 AM UTC (2eca438)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1011/bf20c0b...juliandescottes:2eca438.html" title="Last updated on Sep 29, 2025, 9:30 AM UTC (2eca438)">Diff</a>