### PR TITLE
[editorial] rename

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6811,16 +6811,16 @@ A <dfn>network data</dfn> is a [=/struct=] with:
 * [=struct/Item=] named <dfn for="network-data">type</dfn>, which is a <code>[=network.DataType=]</code>.
 
 A <dfn for="network">collector</dfn> is a [=/struct=] with:
-* [=struct/Item=] named <dfn for="network-collector">max encoded data size</dfn>, which is a js-uint;
+* [=struct/Item=] named <dfn for="network-collector">max encoded item size</dfn>, which is a js-uint;
 * [=struct/item=] named <dfn for="network-collector">contexts</dfn>, which is a [=/list=] of [=navigable id=];
 * [=struct/item=] named <dfn for="network-collector">data types</dfn>, which is a [=/list=] of  <code>[=network.DataType=]</code>;
 * [=struct/item=] named <dfn for="network-collector">collector</dfn>, which is a <code>[=network.Collector=]</code>;
 * [=struct/item=] named <dfn for="network-collector">collector type</dfn>, which is a <code>[=network.CollectorType=]</code>;
 * [=struct/item=] named <dfn for="network-collector">user contexts</dfn>, which is a [=/list=] of <code>[=browser.UserContext=]</code>.
 
-Note: [=network-collector/Max encoded data size=] defines the limit per item (response or request),
+Note: [=network-collector/max encoded item size=] defines the limit per item (response or request),
 and does not limit the size collected by the specific collector. The total size of all collected resources is
-limited by [=max total data size=].
+limited by [=max total collected size=].
 
 A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
 <code>[=network.Collector=]</code> and a [=network/collector=]. It is initially empty.
@@ -6828,7 +6828,7 @@ A [=BiDi session=] has <dfn>network collectors</dfn> which is a [=/map=] between
 A [=remote end=] has <dfn>collected network data</dfn> which is a list of
 [=network data=]. It is initially empty.
 
-A [=remote end=] has a <dfn>max total data size</dfn> which is a js-uint representing
+A [=remote end=] has a <dfn>max total collected size</dfn> which is a js-uint representing
 the size allocated to collect network data in [=collected network data=]. Its
 value is implementation-defined.
 
@@ -7003,7 +7003,7 @@ To <dfn>maybe collect network response body</dfn> given |request| and |response|
 
    1. For |collector| in |collectors|:
 
-      1. If |size| is less than or equal to |collector|'s [=network-collector/max encoded data size=],
+      1. If |size| is less than or equal to |collector|'s [=network-collector/max encoded item size=],
          [=list/append=] |collector|'s [=network-collector/collector=] to |collected data|'s
          [=network-data/collectors=].
 
@@ -7024,7 +7024,7 @@ To <dfn>maybe collect network response body</dfn> given |request| and |response|
 <div algorithm>
 To <dfn>allocate size to record data</dfn> given |size|:
 
-1. Let |available size| be [=max total data size=].
+1. Let |available size| be [=max total collected size=].
 
 1. Let |already collected data| be an empty list.
 
@@ -8491,16 +8491,16 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |data types| be [=set/create|create a set=] with
    |command parameters|["<code>dataTypes</code>"].
 
-1. Let |max encoded data size| be |command parameters|
+1. Let |max encoded item size| be |command parameters|
    ["<code>maxEncodedDataSize</code>"].
 
    Note: The <code>maxEncodedDataSize</code> parameter represents
-   [=network-collector/max encoded data size=] and limits the size of each request collected by the
+   [=network-collector/max encoded item size=] and limits the size of each request collected by the
    given collector, not the total collector's collected size.
 
    Note: Different implementations might support different encodings, which means the
    encoded size might be different between browsers. Therefore, for the same data collector
-   configuration, some network data might fit the [=network-collector/max encoded data size=] only
+   configuration, some network data might fit the [=network-collector/max encoded item size=] only
    in some implementations.
 
 1. Let |collector type| be |command parameters|
@@ -8515,8 +8515,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |input user context ids| is not empty and |input context ids| is not
    empty, return [=error=] with [=error code=] [=invalid argument=].
 
-1. If |max encoded data size| is 0 or |max encoded data size| is greater than
-   [=max total data size=], return [=error=] with [=error code=] [=invalid argument=].
+1. If |max encoded item size| is 0 or |max encoded item size| is greater than
+   [=max total collected size=], return [=error=] with [=error code=] [=invalid argument=].
 
 1. If |input context ids| is not [=set/empty=]:
 
@@ -8537,7 +8537,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
        1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
 
 1. Let |collector| be a [=network/collector=] with
-   [=network-collector/max encoded data size=] field set to |max encoded data size|,
+   [=network-collector/max encoded item size=] field set to |max encoded item size|,
    [=network-collector/data types=] field set to |data types|,
    [=network-collector/collector=] field set to |collector id|,
    [=network-collector/collector type=] field set to |collector type|,


### PR DESCRIPTION
To avoid confusion, rename some internal struct items and variables. Do not rename command's fields to avoid breaking changes.

* /s/max encoded data size/max encoded item size
* /s/max total data size/max total collected size