### PR TITLE
[editorial] fix collected data type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6908,7 +6908,7 @@ See step 9 of https://fetch.spec.whatwg.org/#concept-fetch
          [=network-data/pending=] set to true,
          [=network-data/request=] set to |request|'s [=request id=],
          [=network-data/size=] set to null,
-         [=network-data/type=] set to "response".
+         [=network-data/type=] set to "request".
 
       1. [=list/Append=] |collected data| to [=collected network data=].
 


### PR DESCRIPTION
in `clone network request body` collect data of type "request".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1016.html" title="Last updated on Oct 2, 2025, 2:34 PM UTC (bbf01cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1016/092df07...bbf01cf.html" title="Last updated on Oct 2, 2025, 2:34 PM UTC (bbf01cf)">Diff</a>