### PR TITLE
Add hook to emulate navigator.language/s

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6238,7 +6238,7 @@ The <dfn export>WebDriver BiDi emulated language</dfn> steps given an [=environm
 
 </div>
 
-TODO: Remove the following algorithm once the update for navigator.language/s in the html spec is merged.
+TODO: Remove the following algorithm once the update for navigator.language/s in the html spec is merged. https://github.com/whatwg/html/pull/11793
 
 <div algorithm="updated DefaultLocale steps">
 The [=DefaultLocale=] algorithm is implementation defined. A WebDriver-BiDi


### PR DESCRIPTION
Add hook which is going to be used in html spec to set emulation for `navigator.language/s`.

HTML spec draft PR: https://github.com/whatwg/html/pull/11793.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1017.html" title="Last updated on Oct 21, 2025, 12:44 PM UTC (9734716)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1017/18639ef...lutien:9734716.html" title="Last updated on Oct 21, 2025, 12:44 PM UTC (9734716)">Diff</a>