### PR TITLE
Fix breakage caused by external spec changes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -261,6 +261,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: worklet global scopes; url:worklets.html#concept-document-worklet-global-scopes
 spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
   type: dfn
+    text: break; url: iteration-break
     text: convert a JSON-derived JavaScript value to an Infra value; url: convert-a-json-derived-javascript-value-to-an-infra-value
 spec: RESOURCE-TIMING; urlPrefix: https://w3c.github.io/resource-timing/
   type: dfn


### PR DESCRIPTION
As noticed in https://github.com/w3c/webdriver-bidi/pull/1021 we have a breakage due to the external export of `break` from the CSS fragmentation spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/1022.html" title="Last updated on Oct 28, 2025, 9:15 AM UTC (d7f5ed6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1022/a51a94f...whimboo:d7f5ed6.html" title="Last updated on Oct 28, 2025, 9:15 AM UTC (d7f5ed6)">Diff</a>