### PR TITLE
Reject with no such user context in setExtraHeaders and addDataCollector

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8759,7 +8759,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
        1. Let |user context| be [=get user context=] with |user context id|.
 
-       1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
+       1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
 1. Let |collector| be a [=network/collector=] with
    [=network-collector/max encoded item size=] field set to |max encoded item size|,
@@ -9695,7 +9695,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
     1. Let |user context| be [=get user context=] with |user context id|.
 
-    1. If |user context| is null, return [=error=] with [=error code=] [=invalid argument=].
+    1. If |user context| is null, return [=error=] with [=error code=] [=no such user context=].
 
     1. [=list/Append=] |user context| to |user contexts|.
 


### PR DESCRIPTION
Update two commands which incorrectly throw invalid argument error when an invalid user context id is provided.
The wdspec tests for both commands already assume that `no such user context` is thrown, so there is no test to update here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1023.html" title="Last updated on Oct 28, 2025, 9:37 AM UTC (4af22c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1023/7fafc35...juliandescottes:4af22c6.html" title="Last updated on Oct 28, 2025, 9:37 AM UTC (4af22c6)">Diff</a>