### PR TITLE
feat: restore emulated geolocation data per user context after per context is removed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6551,7 +6551,10 @@ The [=remote end steps=] with |command parameters| are:
 
    1. For each |user context| of |user contexts|:
 
-      1. [=map/Set=] [=screen orientation overrides map=][|user context|] to
+      1. If |emulated screen orientation| is null, [=map/remove=] |user context| from
+         [=screen orientation overrides map=].
+
+      1. Otherwise, [=map/set=] [=screen orientation overrides map=][|user context|] to
          |emulated screen orientation|.
 
       1. [=list/For each=] |top-level traversable| of the list of all
@@ -6562,7 +6565,13 @@ The [=remote end steps=] with |command parameters| are:
 
 1. For each |navigable| of |navigables|:
 
-   1. [=Set emulated screen orientation=] with |navigable| and
+   1. Let |user context| be |navigable|'s [=associated user context=].
+
+   1. If |emulated screen orientation| is null and [=screen orientation overrides map=]
+      [=map/contains=] |user context|, [=set emulated screen orientation=] with |navigable| and
+      [=screen orientation overrides map=][|user context|].
+
+   1. Otherwise, [=set emulated screen orientation=] with |navigable| and
       |emulated screen orientation|.
 
 1. Return [=success=] with data null.


### PR DESCRIPTION
Follow up after https://github.com/w3c/webdriver-bidi/pull/1001

Align geolocation and screen orientation logic with other emulations.

Scenario:
1. Set some emulation per user context.
1. Set another emulation per browsing context.
1. Remove emulation per browsing context.

Current behavior: 
1. All emulations are removed from some emulation per user context

New behavior, aligned with other emulation's methods:
1. Some emulation per user context is still applied.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1026.html" title="Last updated on Nov 4, 2025, 11:08 AM UTC (27bfcc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1026/dbac244...27bfcc8.html" title="Last updated on Nov 4, 2025, 11:08 AM UTC (27bfcc8)">Diff</a>