### PR TITLE
Add "emulation.setScreenSettingsOverride" command.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3217,7 +3217,7 @@ an [=struct/item=] named <dfn attribute for="screen settings">width</dfn> which 
 an [=struct/item=] named <dfn attribute for="screen settings">x</dfn> which is an integer,
 an [=struct/item=] named <dfn attribute for="screen settings">y</dfn> which is an integer.
 
-A [=remote end=] has a <dfn>screen settings overrides</dfn> which is [=struct=]
+A [=remote end=] has a <dfn>screen settings overrides</dfn> which is a [=struct=] with
 an [=struct/item=] named <dfn for="screen settings overrides">user context screen settings</dfn>,
 which is a weak map between [=user contexts=] and [=screen settings=],
 and an [=struct/item=] named <dfn for="screen settings overrides">navigable screen settings</dfn>,


### PR DESCRIPTION
Closes #981.

My approach was to more or less to document the current implementation of Responsive Design mode behaviour of browsers. That's why I think for this specific command it makes more sense to override it on the CSS spec level since it touches exactly the data which we currently override. That's also why I think we have to override not just dimensions, but the coordinates as well (they are currently reset when setting the dimensions). It might be useful in the future to allow in the future to set coordinates as well (?). So that's why I came up with the name  `setScreenAreaOverride` rather than `setScreenDimensionsOverride` or something else.

The draft PR in the CSS spec to illustrate how it might look like there: https://github.com/w3c/csswg-drafts/pull/13091.

Let me know what you think.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1030.html" title="Last updated on Nov 20, 2025, 3:44 PM UTC (f77e482)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1030/5ce7a32...lutien:f77e482.html" title="Last updated on Nov 20, 2025, 3:44 PM UTC (f77e482)">Diff</a>