### PR TITLE
[editorial] rename `SubscriptionRequest` to `SubscriptionParameters`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1866,17 +1866,17 @@ session.Subscription = text
 
 The <code>session.Subscription</code> type represents a unique subscription identifier.
 
-#### The session.SubscriptionRequest Type #### {#type-session-SubscriptionRequest}
+#### The session.SubscriptionParameters Type #### {#type-session-SubscriptionParameters}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
-session.SubscriptionRequest = {
+session.SubscriptionParameters = {
   events: [+text],
   ? contexts: [+browsingContext.BrowsingContext],
   ? userContexts: [+browser.UserContext],
 }
 </pre>
 
-The <code>session.SubscriptionRequest</code> type represents a request to
+The <code>session.SubscriptionParameters</code> type represents a request to
 subscribe to or unsubscribe from a specific set of events.
 
 #### The session.UnsubscribeByIDRequest Type #### {#type-session-UnsubscribeByIDRequest}
@@ -2088,7 +2088,7 @@ Issue: This needs to be generalized to work with realms too.
       <pre class="cddl" data-cddl-module="remote-cddl">
       session.Subscribe = (
         method: "session.subscribe",
-        params: session.SubscriptionRequest
+        params: session.SubscriptionParameters
       )
       </pre>
    </dd>


### PR DESCRIPTION
To align with the pattern used in all other commands


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1036.html" title="Last updated on Nov 19, 2025, 11:43 AM UTC (8f87111)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1036/5ce7a32...8f87111.html" title="Last updated on Nov 19, 2025, 11:43 AM UTC (8f87111)">Diff</a>