### PR TITLE
[editorial] rename `SubscriptionParameters` to `SubscribeParameters`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1866,18 +1866,18 @@ session.Subscription = text
 
 The <code>session.Subscription</code> type represents a unique subscription identifier.
 
-#### The session.SubscriptionParameters Type #### {#type-session-SubscriptionParameters}
+#### The session.SubscribeParameters Type #### {#type-session-SubscriptionParameters}
 
 <pre class="cddl" data-cddl-module="remote-cddl">
-session.SubscriptionParameters = {
+session.SubscribeParameters = {
   events: [+text],
   ? contexts: [+browsingContext.BrowsingContext],
   ? userContexts: [+browser.UserContext],
 }
 </pre>
 
-The <code>session.SubscriptionParameters</code> type represents a request to
-subscribe to or unsubscribe from a specific set of events.
+The <code>session.SubscribeParameters</code> type represents a request to
+subscribe to a specific set of events.
 
 #### The session.UnsubscribeByIDRequest Type #### {#type-session-UnsubscribeByIDRequest}
 
@@ -2088,7 +2088,7 @@ Issue: This needs to be generalized to work with realms too.
       <pre class="cddl" data-cddl-module="remote-cddl">
       session.Subscribe = (
         method: "session.subscribe",
-        params: session.SubscriptionParameters
+        params: session.SubscribeParameters
       )
       </pre>
    </dd>


### PR DESCRIPTION
To align with other parameters


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1037.html" title="Last updated on Nov 19, 2025, 12:03 PM UTC (941b826)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1037/6654689...941b826.html" title="Last updated on Nov 19, 2025, 12:03 PM UTC (941b826)">Diff</a>