### PR TITLE
`emulation.setTouchOverride` command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5966,12 +5966,12 @@ EmulationCommand = (
   emulation.SetForcedColorsModeThemeOverride //
   emulation.SetGeolocationOverride //
   emulation.SetLocaleOverride //
-  emulation.SetTouchOverride //
   emulation.SetNetworkConditions //
   emulation.SetScreenOrientationOverride //
   emulation.SetScreenSettingsOverride //
   emulation.SetScriptingEnabled //
   emulation.SetTimezoneOverride //
+  emulation.SetTouchOverride //
   emulation.SetUserAgentOverride
 )
 
@@ -5982,10 +5982,10 @@ EmulationResult = (
   emulation.SetForcedColorsModeThemeOverrideResult /
   emulation.SetGeolocationOverrideResult /
   emulation.SetLocaleOverrideResult /
-  emulation.SetTouchOverrideResult /
   emulation.SetScreenOrientationOverrideResult /
   emulation.SetScriptingEnabledResult /
   emulation.SetTimezoneOverrideResult /
+  emulation.SetTouchOverrideResult /
   emulation.SetUserAgentOverrideResult
 )
 </pre>
@@ -6341,124 +6341,6 @@ The [=remote end steps=] with |command parameters| are:
    1. If |emulated locale| is null, [=map/remove=] |navigable| from [=locale overrides map=].
 
    1. Otherwise, [=map/set=] [=locale overrides map=][|navigable|] to |emulated locale|.
-
-1. Return [=success=] with data null.
-
-</div>
-
-#### The emulation.setTouchOverride Command ####  {#command-emulation-setTouchOverride}
-
-The <dfn export for=commands>emulation.setTouchOverride</dfn> command emulates
-enabled touch input on web pages.
-
-<dl>
-   <dt>Command Type</dt>
-   <dd>
-    <pre class="cddl" data-cddl-module="remote-cddl">
-      emulation.SetTouchOverride = (
-        method: "emulation.setTouchOverride",
-        params: emulation.SetTouchOverrideParameters
-      )
-
-      emulation.SetTouchOverrideParameters = {
-        maxTouchPoints: (js-uint .ge 1) / null,
-        ? contexts: [+browsingContext.BrowsingContext],
-        ? userContexts: [+browser.UserContext],
-      }
-    </pre>
-   </dd>
-   <dt>Return Type</dt>
-   <dd>
-      <pre class="cddl" data-cddl-module="local-cddl">
-      emulation.SetTouchOverrideResult = EmptyResult
-      </pre>
-   </dd>
-</dl>
-
-<div algorithm>
-The <dfn export>WebDriver BiDi emulated max touch points</dfn> steps given
-[=environment settings object=] |environment settings| are:
-
-1. Let |related navigables| be the result of [=get related navigables=] with |environment settings|.
-
-1. For each |navigable| of |related navigables|:
-
-   1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
-
-   1. Let |user context| be |top-level navigable|'s [=associated user context=].
-
-   1. For each |session| in [=active BiDi sessions=]:
-
-      1. If |session|'s [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/navigables=] contains |top-level navigable|, return
-         |session|'s [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/navigables=][|top-level navigable|].
-
-   1. For each |session| in [=active BiDi sessions=]:
-
-      1. If |session|'s [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/user contexts=] contains |user context|, return |session|'s
-         [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/user contexts=][|user context|].
-
-1. For each |session| in [=active BiDi sessions=]:
-
-   1. Let |emulated maxTouchPoints| be |session|'s [=session/emulated maxTouchPoints=]'s
-      [=emulated maxTouchPoints/default=].
-
-   1. If |emulated maxTouchPoints| is not null, return |emulated maxTouchPoints|.
-
-1. Return null.
-
-</div>
-
-<div algorithm="remote end steps for emulation.setTouchOverride">
-
-The [=remote end steps=] with |session| and |command parameters| are:
-
-Note: There is a legacy [=expose legacy touch event APIs=], which can still be used by some existing
-web contents as a signal that the user agent is a touch-enabled "mobile" device. Even though the API
-is legacy, user agent might run [=implementation-defined=] steps to respect the
-[=session/emulated maxTouchPoints=] state in the [=expose legacy touch event APIs=].
-
-1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters|
-   [=map/contains=] "<code>contexts</code>", return [=error=] with [=error code=]
-   [=invalid argument=].
-
-1. Let |maxTouchPoints| be |command parameters|["<code>maxTouchPoints</code>"].
-
-1. If the <code>contexts</code> field of |command parameters| is present:
-
-   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=]
-      with |command parameters|["<code>contexts</code>"].
-
-   1. For each |navigable| of |navigables|:
-
-      1. If |maxTouchPoints| is null, [=map/remove=] |navigable| from |session|'s
-         [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/navigables=].
-
-      1. Otherwise, [=map/set=] |session|'s [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/navigables=][|navigable|] to |maxTouchPoints|.
-
-   1. Return [=success=] with data null.
-
-1. If the <code>userContexts</code> field of |command parameters| is present:
-
-   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with
-      |command parameters|["<code>userContexts</code>"].
-
-   1. For each |user context| of |user contexts|:
-
-      1. If |maxTouchPoints| is null, [=map/remove=] |user context| from |session|'s
-         [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/user contexts=].
-
-      1. Otherwise [=map/set=] |session|'s [=session/emulated maxTouchPoints=]'s
-         [=emulated maxTouchPoints/user contexts=][|user context|] to |maxTouchPoints|.
-
-   1. Return [=success=] with data null.
-
-1. Set |session|'s [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/default=]
-   to |maxTouchPoints|.
 
 1. Return [=success=] with data null.
 
@@ -7177,6 +7059,124 @@ The [=remote end steps=] with |command parameters| are:
    1. If |emulated timezone| is null, [=map/remove=] |navigable| from [=timezone overrides map=].
 
    1. Otherwise, [=map/set=] [=timezone overrides map=][|navigable|] to |emulated timezone|.
+
+1. Return [=success=] with data null.
+
+</div>
+
+#### The emulation.setTouchOverride Command ####  {#command-emulation-setTouchOverride}
+
+The <dfn export for=commands>emulation.setTouchOverride</dfn> command emulates
+enabled touch input on web pages.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      emulation.SetTouchOverride = (
+        method: "emulation.setTouchOverride",
+        params: emulation.SetTouchOverrideParameters
+      )
+
+      emulation.SetTouchOverrideParameters = {
+        maxTouchPoints: (js-uint .ge 1) / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="local-cddl">
+      emulation.SetTouchOverrideResult = EmptyResult
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+The <dfn export>WebDriver BiDi emulated max touch points</dfn> steps given
+[=environment settings object=] |environment settings| are:
+
+1. Let |related navigables| be the result of [=get related navigables=] with |environment settings|.
+
+1. For each |navigable| of |related navigables|:
+
+   1. Let |top-level navigable| be |navigable|'s [=navigable/top-level traversable=].
+
+   1. Let |user context| be |top-level navigable|'s [=associated user context=].
+
+   1. For each |session| in [=active BiDi sessions=]:
+
+      1. If |session|'s [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/navigables=] contains |top-level navigable|, return
+         |session|'s [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/navigables=][|top-level navigable|].
+
+   1. For each |session| in [=active BiDi sessions=]:
+
+      1. If |session|'s [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/user contexts=] contains |user context|, return |session|'s
+         [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/user contexts=][|user context|].
+
+1. For each |session| in [=active BiDi sessions=]:
+
+   1. Let |emulated maxTouchPoints| be |session|'s [=session/emulated maxTouchPoints=]'s
+      [=emulated maxTouchPoints/default=].
+
+   1. If |emulated maxTouchPoints| is not null, return |emulated maxTouchPoints|.
+
+1. Return null.
+
+</div>
+
+<div algorithm="remote end steps for emulation.setTouchOverride">
+
+The [=remote end steps=] with |session| and |command parameters| are:
+
+Note: There is a legacy [=expose legacy touch event APIs=], which can still be used by some existing
+web contents as a signal that the user agent is a touch-enabled "mobile" device. Even though the API
+is legacy, user agent might run [=implementation-defined=] steps to respect the
+[=session/emulated maxTouchPoints=] state in the [=expose legacy touch event APIs=].
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters|
+   [=map/contains=] "<code>contexts</code>", return [=error=] with [=error code=]
+   [=invalid argument=].
+
+1. Let |maxTouchPoints| be |command parameters|["<code>maxTouchPoints</code>"].
+
+1. If the <code>contexts</code> field of |command parameters| is present:
+
+   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=]
+      with |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. If |maxTouchPoints| is null, [=map/remove=] |navigable| from |session|'s
+         [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/navigables=].
+
+      1. Otherwise, [=map/set=] |session|'s [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/navigables=][|navigable|] to |maxTouchPoints|.
+
+   1. Return [=success=] with data null.
+
+1. If the <code>userContexts</code> field of |command parameters| is present:
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with
+      |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. If |maxTouchPoints| is null, [=map/remove=] |user context| from |session|'s
+         [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/user contexts=].
+
+      1. Otherwise [=map/set=] |session|'s [=session/emulated maxTouchPoints=]'s
+         [=emulated maxTouchPoints/user contexts=][|user context|] to |maxTouchPoints|.
+
+   1. Return [=success=] with data null.
+
+1. Set |session|'s [=session/emulated maxTouchPoints=]'s [=emulated maxTouchPoints/default=]
+   to |maxTouchPoints|.
 
 1. Return [=success=] with data null.
 


### PR DESCRIPTION
The hook is supposed to be used in [`navigator.maxTouchPoints`](https://w3c.github.io/pointerevents/#dom-navigator-maxtouchpoints) and in ["expose legacy touch event APIs"](https://w3c.github.io/cg-reports/touchevents/CG-FINAL-touch-events-20240704/#dfn-expose-legacy-touch-event-apis).

Addressing https://github.com/w3c/webdriver-bidi/issues/1028.

* Pointer Events spec PR: https://github.com/w3c/pointerevents/pull/561
* Mention legacy [Touch Events - Level 2](https://github.com/w3c/touch-events) in the note.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1042.html" title="Last updated on Dec 16, 2025, 12:14 PM UTC (968d7f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1042/d7b9635...968d7f6.html" title="Last updated on Dec 16, 2025, 12:14 PM UTC (968d7f6)">Diff</a>