### PR TITLE
[editorial] fix build warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -762,7 +762,7 @@ A <dfn for=event>subscription</dfn> is a [=/struct=] consisting of a
 <dfn for=subscription>subscription id</dfn> (a string),
 <dfn for=subscription>event names</dfn> (a [=/set=] of event names),
 <dfn for=subscription>top-level traversable ids</dfn> (a [=/set=] of IDs of [=/top-level traversables=])
-and <dfn for=subscription>user context ids</dfn> (a [=/set=] of IDs of [=user contexts=]).
+and <dfn for=subscription>user context ids</dfn> (a [=/set=] of IDs of [=user context|user contexts=]).
 
 A [=subscription=] |subscription| is <dfn for="subscription">global</dfn>
 if |subscription|'s [=subscription/top-level traversable ids=] is an empty set
@@ -1491,7 +1491,7 @@ Issue: Define how this works.
 A <dfn export>user context</dfn> represents a collection of zero or more
 [=/top-level traversables=] within a [=remote end=]. Each [=user context=] has
 an associated [=storage partition=], so that [=remote end=] data is not shared
-between different [=user contexts=].
+between different [=user context|user contexts=].
 
 Issue: Unclear that this is the best way to formally define the concept of a
 user context or the interaction with storage.
@@ -1530,9 +1530,9 @@ The <dfn>default user context</dfn> is a [=user context=] with [=user context
 id=] <code>"default"</code>.
 
 An implementation has a <dfn>set of user contexts</dfn>, which is a [=/set=] of
-[=user contexts=]. Initially this contains the [=default user context=].
+[=user context|user contexts=]. Initially this contains the [=default user context=].
 
-Implementations may [=set/append=] new [=user contexts=] to the [=set of user
+Implementations may [=set/append=] new [=user context|user contexts=] to the [=set of user
 contexts=] at any time, for example in response to user actions.
 
 Note: "At any time" here includes during implementation startup, so a given
@@ -1540,16 +1540,15 @@ implementation might always have multiple entries in the [=set of user contexts=
 
 Implementations may [=set/remove=] any [=empty user context=], with exception of
 the [=default user context=], from the [=set of user contexts=] at any
-time. However they are not required to remove such [=user contexts=]. [=User
-contexts=] that are not [=empty user contexts=] must not be removed from the
+time. However they are not required to remove such [=user context|user contexts=]. [=user context|User contexts=] that are not [=empty user contexts=] must not be removed from the
 [=set of user contexts=].
 
 A [=BiDi session=] has a
 <dfn>user context to accept insecure certificates override map</dfn>, which is a
-[=/map=] between [=user contexts=] and boolean.
+[=/map=] between [=user context|user contexts=] and boolean.
 
 A [=BiDi session=] has a <dfn>user context to proxy configuration map</dfn>, which is
-a [=/map=] between [=user contexts=] and [=proxy configuration=].
+a [=/map=] between [=user context|user contexts=] and [=proxy configuration=].
 
 An <dfn>emulated network conditions struct</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn id="emulated-network-conditions-struct-offline"
@@ -1560,10 +1559,10 @@ a [=struct=] with an [=struct/item=] named <dfn
 for="emulated network conditions">default network conditions</dfn>, which is an
 [=emulated network conditions struct=] or null, an [=struct/item=] named
 <dfn for="emulated network conditions">user context network conditions</dfn>, which
-is a weak map between [=user contexts=] and [=emulated network conditions struct=],
+is a weak map between [=user context|user contexts=] and [=emulated network conditions struct=],
 and a [=struct/item=] named
 <dfn for="emulated network conditions">navigable network conditions</dfn>, which is a
-weak map between [=navigables=] and [=emulated network conditions struct=].
+weak map between [=/navigables=] and [=emulated network conditions struct=].
 
 When a [=user context=] is [=set/remove|removed=] from the
 [=set of user contexts=], [=remove user context subscriptions=].
@@ -2991,7 +2990,7 @@ A [=remote end=] has a <dfn>download behavior</dfn> which is a [=struct=] with a
 named <dfn for="download behavior">default download behavior</dfn>, which is a
 [=download behavior struct=] or null, and an [=struct/item=] named <dfn
 for="download behavior">user context download behavior</dfn>, which is a weak map between
-[=user contexts=] and [=download behavior struct=].
+[=user context|user contexts=] and [=download behavior struct=].
 
 <dl>
    <dt>Command Type</dt>
@@ -3094,7 +3093,7 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 ## The browsingContext Module ## {#module-browsingContext}
 
 The <dfn export for=modules>browsingContext</dfn> module contains commands and
-events relating to [=navigables=].
+events relating to [=/navigables=].
 
 Note: For historic reasons this module is called <code>browsingContext</code>
 rather than <code>navigable</code>, and the protocol uses the term
@@ -3185,7 +3184,7 @@ BrowsingContextEvent = (
 </pre>
 
 A [=remote end=] has a <dfn>device pixel ratio overrides</dfn> which is a weak map
-between [=navigables=] and device pixel ratio overrides. It is initially empty.
+between [=/navigables=] and device pixel ratio overrides. It is initially empty.
 
 Note: this map is not cleared when the final session ends i.e. device pixel
 ratio overrides outlive any WebDriver session.
@@ -3206,10 +3205,10 @@ An <dfn>unhandled prompt behavior struct</dfn> is a [=struct=] with:
 * [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-file">file</dfn> which is a string or null;
 * [=struct/Item=] named <dfn attribute for="unhandled-prompt-behavior-prompt">prompt</dfn> which is a string or null.
 
-A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map between [=user contexts=] and [=viewport configuration=].
+A [=remote end=] has a <dfn>viewport overrides map</dfn> which is a weak map between [=user context|user contexts=] and [=viewport configuration=].
 
 A [=remote end=] has a <dfn>locale overrides map</dfn> which is a weak map between
-[=navigables=] or [=user contexts=] and string.
+[=/navigables=] or [=user context|user contexts=] and string.
 
 A <dfn>screen settings</dfn> is a [=struct=] with an [=struct/item=] named
 <dfn attribute for="screen settings">height</dfn> which is an integer,
@@ -3219,18 +3218,18 @@ an [=struct/item=] named <dfn attribute for="screen settings">y</dfn> which is a
 
 A [=remote end=] has a <dfn>screen settings overrides</dfn> which is a [=struct=] with
 an [=struct/item=] named <dfn for="screen settings overrides">user context screen settings</dfn>,
-which is a weak map between [=user contexts=] and [=screen settings=],
+which is a weak map between [=user context|user contexts=] and [=screen settings=],
 and an [=struct/item=] named <dfn for="screen settings overrides">navigable screen settings</dfn>,
-which is a weak map between [=navigables=] and [=screen settings=].
+which is a weak map between [=/navigables=] and [=screen settings=].
 
 A [=remote end=] has a <dfn>timezone overrides map</dfn> which is a weak map between
-[=navigables=] or [=user contexts=] and string.
+[=/navigables=] or [=user context|user contexts=] and string.
 
 A [=remote end=] has an <dfn>unhandled prompt behavior overrides map</dfn> which is a
-weak map between [=user contexts=] and [=unhandled prompt behavior struct=].
+weak map between [=user context|user contexts=] and [=unhandled prompt behavior struct=].
 
 A [=remote end=] has a <dfn>scripting enabled overrides map</dfn> which is a weak
-map between [=navigables=] or [=user contexts=] and boolean.
+map between [=/navigables=] or [=user context|user contexts=] and boolean.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -3610,7 +3609,7 @@ To <dfn>activate a navigable</dfn> given |navigable|:
 
 1. Run implementation-specific steps so that |navigable|'s [=system visibility state=] becomes [=visible=]. If this is not possible return [=error=] with error code [=unsupported operation=].
 
-    Note: This can have the side effect of making currently [=visible=] [=navigables=] [=hidden=].
+    Note: This can have the side effect of making currently [=visible=] [=/navigables=] [=hidden=].
 
     Note: This can change the underlying OS state by causing the window to become unminimized or by other side effects related to changing the [=system visibility state=].
 
@@ -5990,12 +5989,12 @@ A [=BiDi session=] has an <dfn for=session>emulated user agent</dfn> which is a
 <dfn for="emulated user agent">default user agent</dfn>, which is a string or null,
 an [=struct/item=] named
 <dfn for="emulated user agent">user context user agent</dfn>, which is a weak map
-between [=user contexts=] and string, and an [=struct/item=] named
+between [=user context|user contexts=] and string, and an [=struct/item=] named
 <dfn for="emulated user agent">navigable user agent</dfn>, which is a weak map
-between [=navigables=] and string.
+between [=/navigables=] and string.
 
 A [=remote end=] has a <dfn>forced colors mode theme overrides map</dfn> which is a weak map
-between [=user contexts=] and string or null.
+between [=user context|user contexts=] and string or null.
 
 A <dfn>geolocation override</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn attribute for="geolocation override">latitude</dfn> which is a float;
@@ -6006,7 +6005,7 @@ A <dfn>geolocation override</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn attribute for="geolocation override">heading</dfn> which is a float or null;
 * [=struct/item=] named <dfn attribute for="geolocation override">speed</dfn> which is a float or null.
 
-A [=remote end=] has a <dfn>geolocation overrides map</dfn> which is a weak map between [=user contexts=] and [=geolocation override=].
+A [=remote end=] has a <dfn>geolocation overrides map</dfn> which is a weak map between [=user context|user contexts=] and [=geolocation override=].
 
 A <dfn>screen orientation override</dfn> is a [=struct=] with:
 
@@ -6014,7 +6013,7 @@ A <dfn>screen orientation override</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn attribute for="screen orientation override">type</dfn> which is a string;
 
 A [=remote end=] has a <dfn>screen orientation overrides map</dfn> which is a weak
-map between [=user contexts=] and [=screen orientation override=].
+map between [=user context|user contexts=] and [=screen orientation override=].
 
 ### Commands ### {#module-emulation-commands}
 #### The emulation.setForcedColorsModeThemeOverride Command ####  {#command-emulation-setForcedColorsModeThemeOverride}
@@ -7129,9 +7128,9 @@ A [=BiDi session=] has a <dfn for=session>extra headers</dfn> which is a
 headers</dfn>, which is a [=/header list=] (initially set to an empty
 [=/header list=]), an [=struct/item=] named
 <dfn for="extra headers">user context headers</dfn>, which is a weak map
-between [=user contexts=] and [=/header lists=], and  a [=struct/item=] named
+between [=user context|user contexts=] and [=/header lists=], and  a [=struct/item=] named
 <dfn for="extra headers">navigable headers</dfn>, which is a weak map
-between [=navigables=] and [=/header lists=].
+between [=/navigables=] and [=/header lists=].
 
 ### Network Data Collection ### {#network-data-collection}
 


### PR DESCRIPTION
* Ambiguous references to `user contexts` were resolved by explicitly linking to the single `user context` definition using `[=user context|user contexts=]`
* Ambiguous references to `navigables` were resolved by explicitly linking to the external HTML definition using `[=/navigables=]`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1044.html" title="Last updated on Dec 10, 2025, 1:03 PM UTC (784b8d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1044/b4f7fbe...784b8d9.html" title="Last updated on Dec 10, 2025, 1:03 PM UTC (784b8d9)">Diff</a>