### PR TITLE
Extend `browsingContext.setViewport` with `scrollbarType`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4975,7 +4975,7 @@ To <dfn>set scrollbar type</dfn> given [=/navigable=] |navigable| and scrollbar 
    make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a>.
 
 1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
-   use a UA defined default scrollbar type.
+   use an [=implementation-defined=] default scrollbar type.
 
 </div>
 


### PR DESCRIPTION
# Closed in favor of https://github.com/w3c/webdriver-bidi/pull/1064

Addressing yet another part of https://github.com/w3c/webdriver-bidi/issues/772.

Related CSS PR: https://github.com/w3c/csswg-drafts/pull/13240


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1050.html" title="Last updated on Feb 19, 2026, 2:46 PM UTC (e081a30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1050/d5ddb9e...e081a30.html" title="Last updated on Feb 19, 2026, 2:46 PM UTC (e081a30)">Diff</a>