### PR TITLE
Remove unused return value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10629,7 +10629,7 @@ To <dfn export>run WebDriver BiDi preload scripts</dfn> given |environment setti
 
     1. Let |function declaration| be |preload script|'s <code>function declaration</code>.
 
-    1. Let (<var ignore>script</var>, |function body evaluation status|) be the result of
+    1. Let |function body evaluation status| be the result of
        [=evaluate function body=] with |function declaration|,
        |environment settings|, |base URL|, and |options|.
 
@@ -12735,7 +12735,7 @@ Note: the |function declaration| is parenthesized and evaluated.
 
 1. [=Clean up after running script=] with |environment settings|.
 
-1. Return (|function script|, |function body evaluation status|).
+1. Return |function body evaluation status|.
 
 </div>
 
@@ -12786,7 +12786,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |options| be the [=default script fetch options=].
 
-1. Let (<var ignore>script</var>, |function body evaluation status|) be the
+1. Let |function body evaluation status| be the
    result of [=evaluate function body=] with |function declaration|,
    |environment settings|, |base URL|, and |options|.
 


### PR DESCRIPTION
The script value has not been used outside of the "evaluate function body" algorithm since commit 0575bf7bedc1fb532d7bbdc0fd686780b30d6f29


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver-bidi/pull/1062.html" title="Last updated on Jan 15, 2026, 6:24 PM UTC (67d9c7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1062/9e65594...bocoup:67d9c7c.html" title="Last updated on Jan 15, 2026, 6:24 PM UTC (67d9c7c)">Diff</a>