### PR TITLE
Always restore the client window if it is currently minimized or maximized before setting a different window state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2489,7 +2489,7 @@ To <dfn>set the client window state</dfn> given |window| and |state|:
 
        Note: This is a no-op for documents in window that are not fullscreen.
 
-1. If |current state| is "<code>maximized</code>", or "<code>minimized</code>":
+1. If |current state| is "<code>maximized</code>" or "<code>minimized</code>":
 
   1. [=Restore the client window=] |window|.
 


### PR DESCRIPTION
Fixed #1035.

This was most likely an oversight. We need to restore the window first if it is minimized before actually switching to fullscreen. This is [in-par with WebDriver classic](https://w3c.github.io/webdriver/#fullscreen-window).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/1063.html" title="Last updated on Mar 5, 2026, 7:08 PM UTC (4f8bc14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1063/9e65594...whimboo:4f8bc14.html" title="Last updated on Mar 5, 2026, 7:08 PM UTC (4f8bc14)">Diff</a>