### PR TITLE
`emulation.setScrollbarTypeOverride`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -455,10 +455,13 @@ Returns [=WebDriver configuration/unset=] if configuration is not set.
 To <dfn>get WebDriver configuration value</dfn> of [=WebDriver configuration=] |configuration| for
 [=/navigable=] |navigable|:
 
-1. If |configuration|'s [=WebDriver configuration/navigables=] [=map/contains=] |navigable|:
+1. Let |top-level traversable| be |navigable|'s [=navigable/top-level traversable=].
+
+1. If |configuration|'s [=WebDriver configuration/navigables=] [=map/contains=]
+   |top-level traversable|:
 
    1. Let |navigable configuration value| be |configuration|'s
-      [=WebDriver configuration/navigables=][|navigable|].
+      [=WebDriver configuration/navigables=][|top-level traversable|].
 
    1. If |navigable configuration value| is not [=WebDriver configuration/unset=], return
       |navigable configuration value|.


### PR DESCRIPTION
Addressing yet another part of https://github.com/w3c/webdriver-bidi/issues/772.

As discussed in https://github.com/w3c/webdriver-bidi/pull/1050#issuecomment-3756320242, I moved the emulation to a dedicated command.

As discussed ion https://github.com/w3c/webdriver-bidi/issues/772#issuecomment-3756268948, we are going to have quite a lot of emulation commands with the similar syntax and scopes. So I introduced a concept of `WebDriver Configuration` which is supposed to be a placeholders for all the configs. Moving existing configs there is out of scope. It is supposed to reduce both specification and implementation effort.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1064.html" title="Last updated on Feb 19, 2026, 12:38 PM UTC (e556e6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1064/fdf90f8...e556e6b.html" title="Last updated on Feb 19, 2026, 12:38 PM UTC (e556e6b)">Diff</a>