### PR TITLE
Directly reference the automation section in External specifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14775,8 +14775,8 @@ Note: the list is not exhaustive and might not be up to date.
 
 The following external specifications define additional WebDriver BiDi modules:
 
-1. <a href="https://www.w3.org/TR/permissions/">Permissions</a>
+1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>
 
-1. <a href="https://wicg.github.io/nav-speculation/prefetch.html">nav-speculation</a>
+1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
 
-1. <a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth</a>
+1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>


### PR DESCRIPTION
As suggested in https://github.com/w3c/webdriver/pull/1940#discussion_r2717274035


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver-bidi/pull/1066.html" title="Last updated on Jan 28, 2026, 2:38 AM UTC (9850841)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1066/572b464...yezhizhen:9850841.html" title="Last updated on Jan 28, 2026, 2:38 AM UTC (9850841)">Diff</a>