### PR TITLE
[editorial] add a link to "User-Agent Client Hints" external spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14779,6 +14779,6 @@ The following external specifications define additional WebDriver BiDi modules:
 
 1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
 
-1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>
-
 1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
+
+1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1070.html" title="Last updated on Feb 10, 2026, 2:37 PM UTC (840314b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1070/898d896...840314b.html" title="Last updated on Feb 10, 2026, 2:37 PM UTC (840314b)">Diff</a>