### PR TITLE
`emulation.setTextLayoutModeOverride`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -430,6 +430,155 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 
 </div>
 
+The <dfn>WebDriver configuration</dfn> is a structure providing a generic way to store
+configurations per user context, per navigable or globally.
+
+The <dfn>WebDriver unset configuration value</dfn> is a specific value indicating the value for the
+specific configuration is unset.
+
+Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">type</dfn>,
+which defines the possible values for the configuration.
+
+Each [=WebDriver configuration=] has a <dfn for="WebDriver configuration">value</dfn>, which is
+either the [=WebDriver unset configuration value=] or a value of the [=WebDriver configuration/type=].
+
+The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
+* [=struct/item=] named <dfn for="WebDriver configuration struct">global</dfn> which is a [=WebDriver configuration/value=], initially [=WebDriver unset configuration value=];
+* [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
+* [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
+
+Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">values</dfn>
+which is a [=WebDriver configuration struct=].
+
+<div algorithm>
+
+Note: this algorithm allows for accessing the [=WebDriver configuration=] for a given navigable by
+checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the navigable,
+then the user context, then the global. Returns null if configuration is not set.
+
+To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configuration=]
+|configuration| for [=/navigables|navigable=] |navigable|:
+
+1. Let |configuration values| be |configuration|'s [=WebDriver configuration/values=].
+
+1. If |configuration values|' [=WebDriver configuration struct/navigables=] [=map/contains=]
+   |navigable|:
+   
+   1. Let |navigable configuration value| be |configuration values|'
+      [=WebDriver configuration struct/navigables=][|navigable|].
+
+   1. If |navigable configuration value| is not [=WebDriver unset configuration value=], return
+      |navigable configuration value|.
+
+1. Let |user context| be |navigable|'s [=associated user context=].
+
+1. If |configuration values|' [=WebDriver configuration struct/user contexts=] [=map/contains=]
+   |user context|:
+   
+   1. Let |user context configuration value| be |configuration values|'
+      [=WebDriver configuration struct/user contexts=][|user context|].
+
+   1. If |user context configuration value| is not [=WebDriver unset configuration value=], return
+      |user context configuration value|.
+
+1. Return |configuration values|' [=WebDriver configuration struct/global=].
+
+</div>
+
+<div algorithm>
+
+Note: this is a generic algorithm for storing [=WebDriver configuration struct/global=]
+[=WebDriver configuration=].
+
+To <dfn>store global WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
+[=WebDriver configuration/value=] |value|:
+
+1. Set |configuration|'s [=WebDriver configuration/values=]'s
+   [=WebDriver configuration struct/global=] to |value|.
+
+</div>
+
+<div algorithm>
+
+Note: this is a generic algorithm for storing [=WebDriver configuration struct/user contexts=]
+[=WebDriver configuration=].
+
+To <dfn>store user context's WebDriver configuration</dfn> [=WebDriver configuration=]
+|configuration|'s [=WebDriver configuration/value=] |value| in [=user context=] |user context|:
+
+1. Set |configuration|'s [=WebDriver configuration/values=]'s
+   [=WebDriver configuration struct/user contexts=][|user context|] to |value|.
+
+</div>
+
+<div algorithm>
+
+Note: this is a generic algorithm for storing [=WebDriver configuration struct/navigables=]
+[=WebDriver configuration=].
+
+To <dfn>store navigable's WebDriver configuration</dfn> [=WebDriver configuration=]
+|configuration|'s [=WebDriver configuration/value=] |value| in [=/navigable=] |navigable|:
+
+1. Set |configuration|'s [=WebDriver configuration/values=]'s
+   [=WebDriver configuration struct/navigables=][|navigable|] to |value|.
+
+</div>
+
+<div algorithm>
+
+Note: this is a generic algorithm for storing [=WebDriver configuration=] in
+[=WebDriver configuration struct/global=], [=WebDriver configuration struct/user contexts=] or
+[=WebDriver configuration struct/navigables=] based on |command parameters|'s
+"<code>userContexts</code>" and "<code>contexts</code>". At most one of the parameters
+"<code>userContexts</code>" and "<code>contexts</code>" is allowed. If none of them are provided,
+the configuration is stored globally.
+
+To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
+[=WebDriver configuration/value=] |value| for given |command parameters|:
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters|
+   [=map/contains=] "<code>contexts</code>", return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |affected navigables| be an empty [=/set=].
+
+1. If |command parameters| [=map/contains=] "<code>contexts</code>":
+
+   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=]
+      with |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. [=set/Append=] |navigable| to |affected navigables|.
+
+      1. [=Store navigable's WebDriver configuration=] |configuration|'s |value| in |navigable|.
+
+1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with
+      |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=] whose
+         [=associated user context=] is |user context|:
+
+         1. [=set/Append=] |top-level traversable| to |affected navigables|.
+
+      1. [=Store user context's WebDriver configuration=] |configuration|'s |value| in
+         |user context|.
+
+1. Otherwise:
+
+   1. [=Store global WebDriver configuration=] |configuration|'s |value|.
+
+   1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:
+
+      1. [=list/Append=] |top-level traversable| to |affected navigables|.
+
+1. Return |affected navigables|.
+
+</div>
+
 # Protocol # {#protocol}
 
 This section defines the basic concepts of the WebDriver BiDi
@@ -6001,174 +6150,6 @@ EmulationResult = (
 )
 </pre>
 
-Note: [=stored remote end configuration=] is an umbrella structure that holds all configurations associated with the
-[=remote end=]. Unlike session configurations, these configurations are not reset after the session is closed, and are
-shared between sessions.
-
-A <dfn export>remote end configuration</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="remote end configuration">scrollbar type</dfn> which is a string or null initially null.
-
-A [=remote end=] has a <dfn for="remote end">stored remote end configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="stored remote end configuration">global</dfn> which is a [=remote end configuration=], initially an empty [=remote end configuration=];
-* [=struct/item=] named <dfn for="stored remote end configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=remote end configuration=], initially empty;
-* [=struct/item=] named <dfn for="stored remote end configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=remote end configuration=], initially empty.
-
-<div algorithm>
-
-Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the remote-end's
-stored configuration for the navigable, then the user context, then the global. Returns null if configuration is not
-set.
-
-To <dfn export>get remote end configuration</dfn> of [=remote end configuration=]'s [=struct/item=] |item|
-for [=/navigables|navigable=] |navigable|:
-
-1. Assert |item| is a [=struct/item=] of [=remote end configuration=].
-
-1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=]
-   [=map/contains=] |navigable|, and [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/navigables=][|navigable|]'s |item| is not null,  return [=remote end=]'s
-   [=stored remote end configuration=]'s [=stored remote end configuration/navigables=][|navigable|]'s |item|.
-
-1. Let |user context| be |navigable|'s [=associated user context=].
-
-1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] [=map/contains=]
-   |user context|, and [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/user contexts=][|user context|]'s |item| is not null, return [=remote end=]'s
-   [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=][|user context|]'s |item|.
-
-1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/global=]
-   |item| is not null, return [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/global=]'s |item|.
-
-1. Return null.
-
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/global=]'s [=remote end configuration=].
-
-To <dfn>store global remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item|:
-
-1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/global=]'s |item| to
-   |config|.
-
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/user contexts=]'s [=remote end configuration=].
-
-To <dfn>store user context's remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=]
-|item| for |user context|:
-
-1. If |config| is null:
-
-   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=]
-      [=map/contains=] |user context|:
-
-      1. Set [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/user contexts=][|user context|]'s |item| to null.
-
-      1. If [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/user contexts=][|user context|] contains only nulls, remove
-         |user context| from [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/user contexts=].
-
-      1. Return.
-
-1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] does not
-   [=map/contain=] |user context|, set [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/user contexts=][|user context|] to an empty [=remote end configuration=].
-
-1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=][|user context|]'s
-   [=struct/item=] |item| to |config|.
-
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/navigables=]'s [=remote end configuration=].
-
-To <dfn>store navigable's remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item| for |navigable|:
-
-1. If |config| is null:
-
-   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=] [=map/contains=]
-      |navigable|:
-
-      1. Set [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/navigables=][|navigable|]'s |item| to null.
-
-      1. If [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/navigables=][|navigable|] contains only nulls, remove
-         |navigable| from [=remote end=]'s [=stored remote end configuration=]'s
-         [=stored remote end configuration/navigables=].
-
-      1. Return.
-
-1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=] does not
-   [=map/contain=] |navigable|, set [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/navigables=][|navigable|] to an empty [=remote end configuration=].
-
-1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=][|navigable|]'s
-   [=struct/item=] |item| to |config|.
-
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]
-[=remote end configuration=] based on the params.
-
-To <dfn>store remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item| for
-|command parameters|:
-
-1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters| [=map/contains=]
-   "<code>contexts</code>", return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |affected navigables| be an empty [=/set=].
-
-1. If |command parameters| [=map/contains=] "<code>contexts</code>":
-
-   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=] with
-      |command parameters|["<code>contexts</code>"].
-
-   1. For each |navigable| of |navigables|:
-
-      1. [=set/Append=] |navigable| to |affected navigables|.
-
-      1. [=Store navigable's remote end config=] |config| in |item| for |navigable|.
-
-1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
-
-   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with
-      |command parameters|["<code>userContexts</code>"].
-
-   1. For each |user context| of |user contexts|:
-
-      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=] whose
-         [=associated user context=] is |user context|:
-
-         1. [=set/Append=] |top-level traversable| to |affected navigables|.
-
-      1. [=Store user context's remote end config=] |config| in |item| for |user context|.
-
-1. Otherwise:
-
-   1. [=Store global remote end config=] |config| in |item|.
-
-   1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:
-
-      1. [=list/Append=] |top-level traversable| to |affected navigables|.
-
-1. Return |affected navigables|.
-
-</div>
-
 A [=BiDi session=] has an <dfn for=session>emulated user agent</dfn> which is a
 [=struct=] with an [=struct/item=] named
 <dfn for="emulated user agent">default user agent</dfn>, which is a string or null,
@@ -7130,19 +7111,23 @@ scrollbar type on the given top-level traversables, user contexts or globally.
    </dd>
 </dl>
 
+The <dfn>scrollbar type override configuration</dfn> is [=WebDriver configuration=] with
+[=WebDriver configuration/type=] string.
+
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
-1. Let |scrollbar type override| be the result of [=get remote end configuration=] of
-   [=remote end configuration/scrollbar type=] for |navigable|.
+1. Let |scrollbar type override| be the result of [=get WebDriver configuration value=] of
+   [=scrollbar type override configuration=] for |navigable|.
 
-1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or null.
+1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
+   [=WebDriver unset configuration value=].
 
-1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to make the
-   |navigable|'s [=active document=] to use <a>classic scrollbars</a>.
+1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to
+   make the |navigable|'s [=active document=] to use <a>classic scrollbars</a>.
 
-1. Otherwise, if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=] steps to
-   make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a>.
+1. Otherwise, if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
+   steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a>.
 
 1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.
@@ -7153,13 +7138,16 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
 The [=remote end steps=] given |command parameters| are:
 
-1. Let |emulated scrollbar type| be |command parameters|["<code>scrollbarType</code>"].
+1. Let |scrollbar type override| be |command parameters|["<code>scrollbarType</code>"].
 
-1. If the implementation does not support setting |emulated scrollbar type|, then return [=error=] with [=error code=]
-   [=unsupported operation=].
+1. If |scrollbar type override| is null, set |scrollbar type override| to
+   [=WebDriver unset configuration value=].
 
-1. Let |affected navigables| be the result of [=store remote end config=] for |emulated scrollbar type|,
-   [=remote end configuration/scrollbar type=] and |command parameters|.
+1. If the implementation does not support setting |scrollbar type override|, then return [=error=]
+   with [=error code=] [=unsupported operation=].
+
+1. Let |affected navigables| be the result of [=store WebDriver configuration=]
+   [=scrollbar type override configuration=] |scrollbar type override| for |command parameters|.
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -465,7 +465,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 
 1. If |configuration values|' [=WebDriver configuration struct/navigables=] [=map/contains=]
    |navigable|:
-   
+
    1. Let |navigable configuration value| be |configuration values|'
       [=WebDriver configuration struct/navigables=][|navigable|].
 
@@ -476,7 +476,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 
 1. If |configuration values|' [=WebDriver configuration struct/user contexts=] [=map/contains=]
    |user context|:
-   
+
    1. Let |user context configuration value| be |configuration values|'
       [=WebDriver configuration struct/user contexts=][|user context|].
 
@@ -7132,7 +7132,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
    steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a> and return.
 
 1. Assert the |scrollbar type override| is [=WebDriver configuration unset value=].
-   
+
 1. Run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.
 

--- a/index.bs
+++ b/index.bs
@@ -6158,7 +6158,7 @@ To <dfn>store remote end config</dfn> |config| in [=remote end configuration=]'s
       1. [=Store user context's remote end config=] |config| in |item| for |user context|.
 
 1. Otherwise:
-  
+
    1. [=Store global remote end config=] |config| in |item|.
 
    1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:

--- a/index.bs
+++ b/index.bs
@@ -5011,6 +5011,8 @@ TODO: Move it as a hook in the html spec instead.
       1. [=Set device pixel ratio override=] with |navigable| and [=viewport overrides map=][|user context|]'s
          [=viewport-configuration/devicePixelRatio=].
 
+1. [=Update scrollbar type override=].
+
 </div>
 
 <div algorithm="remote end steps for browsingContext.setViewport">

--- a/index.bs
+++ b/index.bs
@@ -466,8 +466,8 @@ given [=/navigable=] by checking the [=WebDriver configuration scoped to remote 
 [=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if the
 configuration is not set.
 
-To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configuration=]
-|configuration| for [=/navigable=] |navigable|:
+To <dfn>get WebDriver configuration value</dfn> of [=WebDriver configuration=] |configuration| for
+[=/navigable=] |navigable|:
 
    Issue: extend with "WebDriver configuration scoped to session".
 

--- a/index.bs
+++ b/index.bs
@@ -433,6 +433,11 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 The <dfn>WebDriver configuration</dfn> is a structure providing a generic way to store
 configurations per user context, per navigable or globally.
 
+The <dfn>WebDriver configuration scoped to remote end</dfn> is a [=WebDriver configuration=] which
+is scoped to [=remote end=].
+
+Issue: introduce "WebDriver configuration scoped to session".
+
 <dfn for="WebDriver configuration">Unset</dfn> is a value indicating that a specific configuration
 [=WebDriver configuration/value=] has not be set.
 
@@ -447,21 +452,29 @@ The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
 * [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
 
-Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">values</dfn>
-which is a [=WebDriver configuration struct=].
+For each [=WebDriver configuration scoped to remote end=] |configuration|, [=remote end=] has
+an associated |configuration|'s [=WebDriver configuration struct=]
+<dfn for="WebDriver configuration scoped to remote end">values</dfn>.
 
 <div algorithm>
 
-Note: this algorithm allows accessing the [=WebDriver configuration=] for a given [=/navigable=]
-by checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the
-|navigable|, then for the |navigable|'s [=associated user context=], then
-[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if
+Note: this algorithm allows accessing the [=WebDriver configuration scoped to remote end=] for a
+given [=/navigable=] by checking the [=WebDriver configuration scoped to remote end=]'s
+[=WebDriver configuration scoped to remote end/values=] in
+[=WebDriver configuration struct/navigables=], then in
+[=WebDriver configuration struct/user contexts=] and finally in
+[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if the
 configuration is not set.
 
 To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configuration=]
 |configuration| for [=/navigable=] |navigable|:
 
-1. Let |configuration values| be |configuration|'s [=WebDriver configuration/values=].
+   Issue: extend with "WebDriver configuration scoped to session".
+
+1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
+
+1. Let |configuration values| be [=remote end=]'s |configuration|'s
+   [=WebDriver configuration scoped to remote end/values=].
 
 1. If |configuration values|' [=WebDriver configuration struct/navigables=] [=map/contains=]
    |navigable|:
@@ -494,15 +507,23 @@ either [=/navigable=], [=user context=], or store it globally if the |target| is
 
 To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
 [=WebDriver configuration/value=] |value| in optional |target| which is a [=/navigable=],
-a [=user context=] or null if not provided:
+a [=user context=] or null if not provided, and in optional [=BiDi session=]
+<var ignore>session</var> or null if not provided:
 
-1. If |target| is null, set |configuration|'s [=WebDriver configuration/values=]'s
+   Issue: extend with "WebDriver configuration scoped to session".
+
+1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
+
+1. If |target| is null, set [=remote end=]'s |configuration|'s
+   [=WebDriver configuration scoped to remote end/values=]'s
    [=WebDriver configuration struct/global=] to |value|.
 
-1. If |target| is a [=user context=], set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is a [=user context=], set [=remote end=]'s |configuration|'s
+   [=WebDriver configuration scoped to remote end/values=]'s
    [=WebDriver configuration struct/user contexts=][|target|] to |value|.
 
-1. If |target| is a [=/navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is a [=/navigable=], set [=remote end=]'s |configuration|'s
+   [=WebDriver configuration scoped to remote end/values=]'s
    [=WebDriver configuration struct/navigables=][|target|] to |value|.
 
 </div>
@@ -516,7 +537,12 @@ in [=WebDriver configuration struct/global=], [=WebDriver configuration struct/u
 are mutually exclusive. If neither is provided, the configuration is stored globally.
 
 To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
-[=WebDriver configuration/value=] |value| for given |command parameters|:
+[=WebDriver configuration/value=] |value| for given |command parameters| in optional
+[=BiDi session=] <var ignore>session</var> or null if not provided:
+
+   Issue: extend with "WebDriver configuration scoped to session".
+
+1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters|
    [=map/contains=] "<code>contexts</code>", return [=error=] with [=error code=] [=invalid argument=].
@@ -532,7 +558,7 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
       1. [=set/Append=] |navigable| to |affected navigables|.
 
-      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |navigable|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |navigable| and |session|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -546,14 +572,14 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
-      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |user context|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |user context| and |session|.
 
 1. Otherwise:
 
    1. [=list/For each=] |top-level traversable| of all [=/top-level traversables=], [=list/append=]
       |top-level traversable| to |affected navigables|.
 
-   1. [=WebDriver configuration/Store=] |configuration|'s |value|.
+   1. [=WebDriver configuration/Store=] |configuration|'s |value| in |session|.
 
 1. Return |affected navigables|.
 
@@ -7091,8 +7117,8 @@ scrollbar type on the given top-level traversables, user contexts or globally.
    </dd>
 </dl>
 
-The <dfn>scrollbar type override configuration</dfn> is [=WebDriver configuration=] with
-[=WebDriver configuration/type=] "<code>classic</code>" / "<code>overlay</code>".
+The <dfn>scrollbar type override configuration</dfn> is
+[=WebDriver configuration scoped to remote end=] with [=WebDriver configuration/type=] string.
 
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:

--- a/index.bs
+++ b/index.bs
@@ -6119,6 +6119,56 @@ To <dfn>store navigable's remote end config</dfn> |config| in [=remote end confi
 
 </div>
 
+<div algorithm>
+
+Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]
+[=remote end configuration=] based on the params.
+
+To <dfn>store remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item| for
+|command parameters|:
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters| [=map/contains=]
+   "<code>contexts</code>", return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |affected navigables| be an empty [=/set=].
+
+1. If |command parameters| [=map/contains=] "<code>contexts</code>":
+
+   1. Let |navigables| be the result of [=trying=] to [=get valid top-level traversables by ids=] with
+      |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. [=set/Append=] |navigable| to |affected navigables|.
+
+      1. [=Store navigable's remote end config=] |config| in |item| for |navigable|.
+
+1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=] with
+      |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=] whose
+         [=associated user context=] is |user context|:
+
+         1. [=set/Append=] |top-level traversable| to |affected navigables|.
+
+      1. [=Store user context's remote end config=] |config| in |item| for |user context|.
+
+1. Otherwise:
+  
+   1. [=Store global remote end config=] |config| in |item|.
+
+   1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:
+
+      1. [=list/Append=] |top-level traversable| to |affected navigables|.
+
+1. Return |affected navigables|.
+
+</div>
+
 A [=BiDi session=] has an <dfn for=session>emulated user agent</dfn> which is a
 [=struct=] with an [=struct/item=] named
 <dfn for="emulated user agent">default user agent</dfn>, which is a string or null,
@@ -7108,42 +7158,8 @@ The [=remote end steps=] given |command parameters| are:
 1. If the implementation does not support setting |emulated scrollbar type|, then return [=error=] with [=error code=]
    [=unsupported operation=].
 
-1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
-   and |command parameters| [=map/contains=] "<code>contexts</code>",
-   return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |affected navigables| be an empty [=/set=].
-
-1. If |command parameters| [=map/contains=] "<code>contexts</code>":
-
-   1. Let |navigables| be the result of [=trying=] to
-      [=get valid top-level traversables by ids=] with
-      |command parameters|["<code>contexts</code>"].
-
-   1. For each |navigable| of |navigables|:
-
-      1. [=set/Append=] |navigable| to |affected navigables|.
-
-      1. [=Store navigable's remote end config=] |emulated scrollbar type| in
-         [=remote end configuration/scrollbar type=] for |navigable|.
-
-1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
-
-   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
-      with |command parameters|["<code>userContexts</code>"].
-
-   1. For each |user context| of |user contexts|:
-
-      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
-         whose [=associated user context=] is |user context|:
-
-         1. [=set/Append=] |top-level traversable| to |affected navigables|.
-
-      1. [=Store user context's remote end config=] |emulated scrollbar type| in
-         [=remote end configuration/scrollbar type=] for |user context|.
-
-1. Otherwise, [=store global remote end config=] |emulated scrollbar type| in
-   [=remote end configuration/scrollbar type=] .
+1. Let |affected navigables| be the result of [=store remote end config=] for |emulated scrollbar type|,
+   [=remote end configuration/scrollbar type=] and |command parameters|.
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -7235,45 +7235,8 @@ The [=remote end steps=] given |command parameters| are:
 
 1. Let |emulated text layout mode| be |command parameters|["<code>textLayoutMode</code>"].
 
-1. If |emulated text layout mode| is not null and is not "<code>mobile</code>", then return [=error=] with [=error code=]
-   [=invalid argument=].
-
-1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
-   and |command parameters| [=map/contains=] "<code>contexts</code>",
-   return [=error=] with [=error code=] [=invalid argument=].
-
-1. Let |affected navigables| be an empty [=/set=].
-
-1. If |command parameters| [=map/contains=] "<code>contexts</code>":
-
-   1. Let |navigables| be the result of [=trying=] to
-      [=get valid top-level traversables by ids=] with
-      |command parameters|["<code>contexts</code>"].
-
-   1. For each |navigable| of |navigables|:
-
-      1. [=set/Append=] |navigable| to |affected navigables|.
-
-      1. [=Store navigable's remote end config=] |emulated text layout mode| in
-         [=remote end configuration/text layout mode=] for |navigable|.
-
-1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
-
-   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
-      with |command parameters|["<code>userContexts</code>"].
-
-   1. For each |user context| of |user contexts|:
-
-      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
-         whose [=associated user context=] is |user context|:
-
-         1. [=set/Append=] |top-level traversable| to |affected navigables|.
-
-      1. [=Store user context's remote end config=] |emulated text layout mode| in
-         [=remote end configuration/text layout mode=] for |user context|.
-
-1. Otherwise, [=store global remote end config=] |emulated text layout mode| in
-   [=remote end configuration/text layout mode=] .
+1. Let |affected navigables| be the result of [=store remote end config=] for |emulated text layout mode|,
+   [=remote end configuration/text layout mode=] and |command parameters|.
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -550,11 +550,10 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
 1. Otherwise:
 
+   1. [=list/For each=] |top-level traversable| of all [=/top-level traversables=], [=list/append=]
+      |top-level traversable| to |affected navigables|.
+
    1. [=WebDriver configuration/Store=] |configuration|'s |value|.
-
-   1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:
-
-      1. [=list/Append=] |top-level traversable| to |affected navigables|.
 
 1. Return |affected navigables|.
 

--- a/index.bs
+++ b/index.bs
@@ -492,36 +492,17 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 Note: this is a generic algorithm for storing [=WebDriver configuration struct/global=]
 [=WebDriver configuration=].
 
-To <dfn>store global WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
-[=WebDriver configuration/value=] |value|:
+To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
+[=WebDriver configuration/value=] |value| in optional |target| which is a [=navigable=],
+a [=user context=] or null if not provided:
 
-1. Set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is null, set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/global=] to |value|.
 
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing [=WebDriver configuration struct/user contexts=]
-[=WebDriver configuration=].
-
-To <dfn>store user context's WebDriver configuration</dfn> [=WebDriver configuration=]
-|configuration|'s [=WebDriver configuration/value=] |value| in [=user context=] |user context|:
-
-1. Set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is a [=user context=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/user contexts=][|user context|] to |value|.
 
-</div>
-
-<div algorithm>
-
-Note: this is a generic algorithm for storing [=WebDriver configuration struct/navigables=]
-[=WebDriver configuration=].
-
-To <dfn>store navigable's WebDriver configuration</dfn> [=WebDriver configuration=]
-|configuration|'s [=WebDriver configuration/value=] |value| in [=/navigable=] |navigable|:
-
-1. Set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is a [=navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/navigables=][|navigable|] to |value|.
 
 </div>
@@ -552,7 +533,7 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
       1. [=set/Append=] |navigable| to |affected navigables|.
 
-      1. [=Store navigable's WebDriver configuration=] |configuration|'s |value| in |navigable|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |navigable|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -566,12 +547,11 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
-      1. [=Store user context's WebDriver configuration=] |configuration|'s |value| in
-         |user context|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |user context|.
 
 1. Otherwise:
 
-   1. [=Store global WebDriver configuration=] |configuration|'s |value|.
+   1. [=WebDriver configuration/Store=] |configuration|'s |value|.
 
    1. [=list/For each=] |top-level traversable| of the list of all [=/top-level traversables=]:
 

--- a/index.bs
+++ b/index.bs
@@ -6395,26 +6395,6 @@ The <dfn export>WebDriver BiDi emulated language</dfn> steps given an [=environm
 
 </div>
 
-TODO: Remove the following algorithm once the update for navigator.language/s in the html spec is merged. https://github.com/whatwg/html/pull/11793
-
-<div algorithm="updated DefaultLocale steps">
-The [=DefaultLocale=] algorithm is implementation defined. A WebDriver-BiDi
-[=remote end=] must have an implementation that runs the following steps:
-
-1. Let |realm| be [=current Realm Record=].
-
-1. Let |environment settings| be the [=environment settings object=] whose
-   [=realm execution context=]'s Realm component is |realm|.
-
-1. Let |locale override| be the result of [=WebDriver BiDi emulated language=] with
-   |environment settings|.
-
-1. If |locale override| is not null, return |locale override|.
-   Otherwise, return the result of implementation-defined steps in accordance
-   with the requirements of the [=DefaultLocale=] specification.
-
-</div>
-
 <div algorithm="remote end steps for emulation.setLocaleOverride">
 
 The [=remote end steps=] with |command parameters| are:

--- a/index.bs
+++ b/index.bs
@@ -433,11 +433,6 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 The <dfn>WebDriver configuration</dfn> is a structure providing a generic way to store
 configurations per user context, per navigable or globally.
 
-The <dfn>WebDriver configuration scoped to remote end</dfn> is a [=WebDriver configuration=] which
-is scoped to [=remote end=].
-
-Issue: introduce "WebDriver configuration scoped to session".
-
 <dfn for="WebDriver configuration">Unset</dfn> is a value indicating that a specific configuration
 [=WebDriver configuration/value=] has not be set.
 
@@ -452,29 +447,21 @@ The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
 * [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
 
-For each [=WebDriver configuration scoped to remote end=] |configuration|, [=remote end=] has
-an associated |configuration|'s [=WebDriver configuration struct=]
-<dfn for="WebDriver configuration scoped to remote end">values</dfn>.
+Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">values</dfn>
+which is a [=WebDriver configuration struct=].
 
 <div algorithm>
 
-Note: this algorithm allows accessing the [=WebDriver configuration scoped to remote end=] for a
-given [=/navigable=] by checking the [=WebDriver configuration scoped to remote end=]'s
-[=WebDriver configuration scoped to remote end/values=] in
-[=WebDriver configuration struct/navigables=], then in
-[=WebDriver configuration struct/user contexts=] and finally in
-[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if the
+Note: this algorithm allows accessing the [=WebDriver configuration=] for a given [=/navigable=]
+by checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the
+|navigable|, then for the |navigable|'s [=associated user context=], then
+[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if
 configuration is not set.
 
 To <dfn>get WebDriver configuration value</dfn> of [=WebDriver configuration=] |configuration| for
 [=/navigable=] |navigable|:
 
-   Issue: extend with "WebDriver configuration scoped to session".
-
-1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
-
-1. Let |configuration values| be [=remote end=]'s |configuration|'s
-   [=WebDriver configuration scoped to remote end/values=].
+1. Let |configuration values| be |configuration|'s [=WebDriver configuration/values=].
 
 1. If |configuration values|' [=WebDriver configuration struct/navigables=] [=map/contains=]
    |navigable|:
@@ -507,23 +494,15 @@ either [=/navigable=], [=user context=], or store it globally if the |target| is
 
 To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
 [=WebDriver configuration/value=] |value| in optional |target| which is a [=/navigable=],
-a [=user context=] or null if not provided, and in optional [=BiDi session=]
-<var ignore>session</var> or null if not provided:
+a [=user context=] or null if not provided:
 
-   Issue: extend with "WebDriver configuration scoped to session".
-
-1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
-
-1. If |target| is null, set [=remote end=]'s |configuration|'s
-   [=WebDriver configuration scoped to remote end/values=]'s
+1. If |target| is null, set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/global=] to |value|.
 
-1. If |target| is a [=user context=], set [=remote end=]'s |configuration|'s
-   [=WebDriver configuration scoped to remote end/values=]'s
+1. If |target| is a [=user context=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/user contexts=][|target|] to |value|.
 
-1. If |target| is a [=/navigable=], set [=remote end=]'s |configuration|'s
-   [=WebDriver configuration scoped to remote end/values=]'s
+1. If |target| is a [=/navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/navigables=][|target|] to |value|.
 
 </div>
@@ -537,12 +516,7 @@ in [=WebDriver configuration struct/global=], [=WebDriver configuration struct/u
 are mutually exclusive. If neither is provided, the configuration is stored globally.
 
 To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
-[=WebDriver configuration/value=] |value| for given |command parameters| in optional
-[=BiDi session=] <var ignore>session</var> or null if not provided:
-
-   Issue: extend with "WebDriver configuration scoped to session".
-
-1. Assert: |configuration| is [=WebDriver configuration scoped to remote end=].
+[=WebDriver configuration/value=] |value| for given |command parameters|:
 
 1. If |command parameters| [=map/contains=] "<code>userContexts</code>" and |command parameters|
    [=map/contains=] "<code>contexts</code>", return [=error=] with [=error code=] [=invalid argument=].
@@ -558,7 +532,7 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
       1. [=set/Append=] |navigable| to |affected navigables|.
 
-      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |navigable| and |session|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |navigable|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -572,14 +546,14 @@ To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configu
 
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
-      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |user context| and |session|.
+      1. [=WebDriver configuration/Store=] |configuration|'s |value| in |user context|.
 
 1. Otherwise:
 
    1. [=list/For each=] |top-level traversable| of all [=/top-level traversables=], [=list/append=]
       |top-level traversable| to |affected navigables|.
 
-   1. [=WebDriver configuration/Store=] |configuration|'s |value| in |session|.
+   1. [=WebDriver configuration/Store=] |configuration|'s |value|.
 
 1. Return |affected navigables|.
 
@@ -7117,8 +7091,8 @@ scrollbar type on the given top-level traversables, user contexts or globally.
    </dd>
 </dl>
 
-The <dfn>scrollbar type override configuration</dfn> is
-[=WebDriver configuration scoped to remote end=] with [=WebDriver configuration/type=] string.
+The <dfn>scrollbar type override configuration</dfn> is [=WebDriver configuration=] with
+[=WebDriver configuration/type=] "<code>classic</code>" / "<code>overlay</code>".
 
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:

--- a/index.bs
+++ b/index.bs
@@ -6004,7 +6004,7 @@ EmulationResult = (
 A <dfn export>stored remote end config</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="stored remote end config">scrollbar type</dfn> which is a string or null initially null.
 
-A [=remote end=] has an <dfn for="remote end">remote end stored configuration</dfn> which is a [=struct=] with:
+A [=remote end=] has a <dfn for="remote end">remote end configuration</dfn> which is a [=struct=] with:
 * [=struct/item=] named <dfn for="remote end stored configuration">global</dfn> which is a [=stored remote end config=], initially an empty [=stored remote end config=];
 * [=struct/item=] named <dfn for="remote end stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end config=], initially empty;
 * [=struct/item=] named <dfn for="remote end stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end config=], initially empty.

--- a/index.bs
+++ b/index.bs
@@ -489,8 +489,8 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing [=WebDriver configuration struct/global=]
-[=WebDriver configuration=].
+Note: this is a generic algorithm for storing [=WebDriver configuration=] per |target|, which can be
+either [=navigable=], [=user context=], or store it globally if the |target| is null or emitted.
 
 To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
 [=WebDriver configuration/value=] |value| in optional |target| which is a [=navigable=],

--- a/index.bs
+++ b/index.bs
@@ -6001,16 +6001,17 @@ EmulationResult = (
 )
 </pre>
 
-Note: [=stored remote end configuration=] is an umbrella structure that holds all global configurations. Unlike
-session configurations, these configurations are not reset after the session is closed, and are shared between sessions.
+Note: [=stored remote end configuration=] is an umbrella structure that holds all configurations associated with the
+[=remote end=]. Unlike session configurations, these configurations are not reset after the session is closed, and are
+shared between sessions.
 
-A <dfn export>stored remote end configuration</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="stored remote end configuration">scrollbar type</dfn> which is a string or null initially null.
+A <dfn export>remote end configuration</dfn> is a [=struct=] with:
+* [=struct/item=] named <dfn for="remote end configuration">scrollbar type</dfn> which is a string or null initially null.
 
-A [=remote end=] has a <dfn for="remote end">remote end configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="stored remote end configuration">global</dfn> which is a [=stored remote end configuration=], initially an empty [=stored remote end configuration=];
-* [=struct/item=] named <dfn for="stored remote end configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end configuration=], initially empty;
-* [=struct/item=] named <dfn for="stored remote end configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end configuration=], initially empty.
+A [=remote end=] has a <dfn for="remote end">stored remote end configuration</dfn> which is a [=struct=] with:
+* [=struct/item=] named <dfn for="stored remote end configuration">global</dfn> which is a [=remote end configuration=], initially an empty [=remote end configuration=];
+* [=struct/item=] named <dfn for="stored remote end configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=remote end configuration=], initially empty;
+* [=struct/item=] named <dfn for="stored remote end configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=remote end configuration=], initially empty.
 
 <div algorithm>
 
@@ -6018,10 +6019,10 @@ Note: this algorithm allows for accessing the stored configuration for a given n
 stored configuration for the navigable, then the user context, then the global. Returns null if configuration is not
 set.
 
-To <dfn export>get stored remote end configuration</dfn> of [=stored remote end configuration=]'s [=struct/item=] |item| for
-[=/navigables|navigable=] |navigable|:
+To <dfn export>get remote end configuration</dfn> of [=remote end configuration=]'s [=struct/item=] |item|
+for [=/navigables|navigable=] |navigable|:
 
-1. Assert |item| is a [=struct/item=] of [=stored remote end configuration=].
+1. Assert |item| is a [=struct/item=] of [=remote end configuration=].
 
 1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=]
    [=map/contains=] |navigable|, and [=remote end=]'s [=stored remote end configuration=]'s
@@ -6045,10 +6046,10 @@ To <dfn export>get stored remote end configuration</dfn> of [=stored remote end 
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/global=]'s [=stored remote end configuration=].
+Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
+[=stored remote end configuration/global=]'s [=remote end configuration=].
 
-To <dfn>store global remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item|:
+To <dfn>store global remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item|:
 
 1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/global=]'s |item| to
    |config|.
@@ -6057,16 +6058,16 @@ To <dfn>store global remote end config</dfn> |config| in [=stored remote end con
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/user contexts=]'s [=stored remote end configuration=].
+Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
+[=stored remote end configuration/user contexts=]'s [=remote end configuration=].
 
-To <dfn>store user context's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=]
+To <dfn>store user context's remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=]
 |item| for |user context|:
 
 1. If |config| is null:
 
-   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] [=map/contains=]
-      |user context|:
+   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=]
+      [=map/contains=] |user context|:
 
       1. Set [=remote end=]'s [=stored remote end configuration=]'s
          [=stored remote end configuration/user contexts=][|user context|]'s |item| to null.
@@ -6080,7 +6081,7 @@ To <dfn>store user context's remote end config</dfn> |config| in [=stored remote
 
 1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] does not
    [=map/contain=] |user context|, set [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/user contexts=][|user context|] to an empty [=stored remote end configuration=].
+   [=stored remote end configuration/user contexts=][|user context|] to an empty [=remote end configuration=].
 
 1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=][|user context|]'s
    [=struct/item=] |item| to |config|.
@@ -6089,10 +6090,10 @@ To <dfn>store user context's remote end config</dfn> |config| in [=stored remote
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=stored remote end configuration/navigables=]'s [=stored remote end configuration=].
+Note: this is a generic algorithm for storing configuration [=remote end configuration=] in [=remote end=]'s
+[=stored remote end configuration/navigables=]'s [=remote end configuration=].
 
-To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item| for |navigable|:
+To <dfn>store navigable's remote end config</dfn> |config| in [=remote end configuration=]'s [=struct/item=] |item| for |navigable|:
 
 1. If |config| is null:
 
@@ -6111,7 +6112,7 @@ To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote en
 
 1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=] does not
    [=map/contain=] |navigable|, set [=remote end=]'s [=stored remote end configuration=]'s
-   [=stored remote end configuration/navigables=][|navigable|] to an empty [=stored remote end configuration=].
+   [=stored remote end configuration/navigables=][|navigable|] to an empty [=remote end configuration=].
 
 1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=][|navigable|]'s
    [=struct/item=] |item| to |config|.
@@ -7082,8 +7083,8 @@ scrollbar type on the given top-level traversables, user contexts or globally.
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
-1. Let |scrollbar type override| be the result of [=get stored remote end configuration=] of
-   [=stored remote end configuration/scrollbar type=] for |navigable|.
+1. Let |scrollbar type override| be the result of [=get remote end configuration=] of
+   [=remote end configuration/scrollbar type=] for |navigable|.
 
 1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or null.
 
@@ -7124,7 +7125,7 @@ The [=remote end steps=] given |command parameters| are:
       1. [=set/Append=] |navigable| to |affected navigables|.
 
       1. [=Store navigable's remote end config=] |emulated scrollbar type| in
-         [=stored remote end configuration/scrollbar type=] for |navigable|.
+         [=remote end configuration/scrollbar type=] for |navigable|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -7139,10 +7140,10 @@ The [=remote end steps=] given |command parameters| are:
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
       1. [=Store user context's remote end config=] |emulated scrollbar type| in
-         [=stored remote end configuration/scrollbar type=] for |user context|.
+         [=remote end configuration/scrollbar type=] for |user context|.
 
 1. Otherwise, [=store global remote end config=] |emulated scrollbar type| in
-   [=stored remote end configuration/scrollbar type=] .
+   [=remote end configuration/scrollbar type=] .
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -5993,6 +5993,118 @@ EmulationResult = (
 )
 </pre>
 
+A <dfn export>stored config</dfn> is a [=struct=] with:
+* [=struct/item=] named <dfn for="stored config">scrollbar type</dfn> which is a string or null initially null.
+
+A [=BiDi session=] has an <dfn for=session>session stored configuration</dfn> which is a [=struct=] with:
+* [=struct/item=] named <dfn for="session stored configuration">default</dfn> which is a [=stored config=], initially an empty [=stored config=];
+* [=struct/item=] named <dfn for="session stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored config=], initially empty;
+* [=struct/item=] named <dfn for="session stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored config=], initially empty.
+
+<div algorithm>
+
+Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the stored
+configuration for the navigable, then the user context, then the default for all the active sessions.
+
+To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |config item| for
+[=/navigables|navigable=] |navigable|:
+
+1. Assert |config item| is a [=struct/item=] of [=stored config=].
+
+1. For each |session| in [=active BiDi sessions=]:
+
+   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
+      |navigable|, and |session|'s [=session stored configuration=]'s
+      [=session stored configuration/navigables=][|navigable|]'s |config item| is not null,  return |session|'s
+      [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s |config item|.
+
+1. Let |user context| be |navigable|'s [=associated user context=].
+
+1. For each |session| in [=active BiDi sessions=]:
+
+   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
+      |user context|, and |session|'s [=session stored configuration=]'s
+      [=session stored configuration/user contexts=][|user context|]'s |config item| is not null, return |session|'s
+      [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s |config item|.
+
+1. For each |session| in [=active BiDi sessions=]:
+
+   1. If |session|'s |session|'s [=session stored configuration=]'s [=session stored configuration/default=]
+      |config item| is not null, return |session|'s [=session stored configuration=]'s
+      [=session stored configuration/default=]'s |config item|.
+
+1. Return null.
+
+</div>
+
+<div algorithm>
+
+To <dfn export>store global config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| in [=BiDi session=]
+|session|:
+
+1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/default=]'s |config item| to
+   |config|.
+
+</div>
+
+<div algorithm>
+
+To <dfn export>store user context config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+|user context| in [=BiDi session=] |session|:
+
+1. If |config| is null:
+
+   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
+      |user context|:
+      
+      1. Set |session|'s [=session stored configuration=]'s
+         [=session stored configuration/user contexts=][|user context|]'s |config item| to null.
+   
+      1. If |session|'s [=session stored configuration=]'s
+         [=session stored configuration/user contexts=][|user context|] contains only nulls, remove
+         |user context| from |session|'s [=session stored configuration=]'s
+         [=session stored configuration/user contexts=].
+      
+      1. Return.
+
+1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] does not
+   [=map/contain=] |user context|, set |session|'s [=session stored configuration=]'s
+   [=session stored configuration/user contexts=][|user context|] to an empty [=stored config=].
+
+1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s
+   [=struct/item=] |config item| to |config|.
+
+</div>
+
+<div algorithm>
+
+To <dfn export>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+|navigable| in [=BiDi session=] |session|:
+
+1. If |config| is null:
+
+   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
+      |navigable|:
+      
+      1. Set |session|'s [=session stored configuration=]'s
+         [=session stored configuration/navigables=][|navigable|]'s |config item| to null.
+   
+      1. If |session|'s [=session stored configuration=]'s
+         [=session stored configuration/navigables=][|navigable|] contains only nulls, remove
+         |navigable| from |session|'s [=session stored configuration=]'s
+         [=session stored configuration/navigables=].
+      
+      1. Return.
+
+1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] does not
+   [=map/contain=] |navigable|, set |session|'s [=session stored configuration=]'s
+   [=session stored configuration/navigables=][|navigable|] to an empty [=stored config=].
+
+1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s
+   [=struct/item=] |config item| to |config|.
+
+</div>
+
 A [=BiDi session=] has an <dfn for=session>emulated user agent</dfn> which is a
 [=struct=] with an [=struct/item=] named
 <dfn for="emulated user agent">default user agent</dfn>, which is a string or null,

--- a/index.bs
+++ b/index.bs
@@ -6008,9 +6008,9 @@ A <dfn export>stored remote end configuration</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="stored remote end configuration">scrollbar type</dfn> which is a string or null initially null.
 
 A [=remote end=] has a <dfn for="remote end">remote end configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="remote end stored configuration">global</dfn> which is a [=stored remote end configuration=], initially an empty [=stored remote end configuration=];
-* [=struct/item=] named <dfn for="remote end stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end configuration=], initially empty;
-* [=struct/item=] named <dfn for="remote end stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end configuration=], initially empty.
+* [=struct/item=] named <dfn for="stored remote end configuration">global</dfn> which is a [=stored remote end configuration=], initially an empty [=stored remote end configuration=];
+* [=struct/item=] named <dfn for="stored remote end configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end configuration=], initially empty;
+* [=struct/item=] named <dfn for="stored remote end configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end configuration=], initially empty.
 
 <div algorithm>
 
@@ -6023,21 +6023,21 @@ To <dfn export>get stored remote end configuration</dfn> of [=stored remote end 
 
 1. Assert |item| is a [=struct/item=] of [=stored remote end configuration=].
 
-1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=]
-   [=map/contains=] |navigable|, and [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/navigables=][|navigable|]'s |item| is not null,  return [=remote end=]'s
-   [=remote end stored configuration=]'s [=remote end stored configuration/navigables=][|navigable|]'s |item|.
+1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=]
+   [=map/contains=] |navigable|, and [=remote end=]'s [=stored remote end configuration=]'s
+   [=stored remote end configuration/navigables=][|navigable|]'s |item| is not null,  return [=remote end=]'s
+   [=stored remote end configuration=]'s [=stored remote end configuration/navigables=][|navigable|]'s |item|.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] [=map/contains=]
-   |user context|, and [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/user contexts=][|user context|]'s |item| is not null, return [=remote end=]'s
-   [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=][|user context|]'s |item|.
+1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] [=map/contains=]
+   |user context|, and [=remote end=]'s [=stored remote end configuration=]'s
+   [=stored remote end configuration/user contexts=][|user context|]'s |item| is not null, return [=remote end=]'s
+   [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=][|user context|]'s |item|.
 
-1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/global=]
-   |item| is not null, return [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/global=]'s |item|.
+1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/global=]
+   |item| is not null, return [=remote end=]'s [=stored remote end configuration=]'s
+   [=stored remote end configuration/global=]'s |item|.
 
 1. Return null.
 
@@ -6046,11 +6046,11 @@ To <dfn export>get stored remote end configuration</dfn> of [=stored remote end 
 <div algorithm>
 
 Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=remote end stored configuration/global=]'s [=remote end stored configuration=].
+[=stored remote end configuration/global=]'s [=stored remote end configuration=].
 
 To <dfn>store global remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item|:
 
-1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/global=]'s |item| to
+1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/global=]'s |item| to
    |config|.
 
 </div>
@@ -6058,31 +6058,31 @@ To <dfn>store global remote end config</dfn> |config| in [=stored remote end con
 <div algorithm>
 
 Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=remote end stored configuration/user contexts=]'s [=remote end stored configuration=].
+[=stored remote end configuration/user contexts=]'s [=stored remote end configuration=].
 
 To <dfn>store user context's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=]
 |item| for |user context|:
 
 1. If |config| is null:
 
-   1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] [=map/contains=]
+   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] [=map/contains=]
       |user context|:
 
-      1. Set [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/user contexts=][|user context|]'s |item| to null.
+      1. Set [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/user contexts=][|user context|]'s |item| to null.
 
-      1. If [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/user contexts=][|user context|] contains only nulls, remove
-         |user context| from [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/user contexts=].
+      1. If [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/user contexts=][|user context|] contains only nulls, remove
+         |user context| from [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/user contexts=].
 
       1. Return.
 
-1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] does not
-   [=map/contain=] |user context|, set [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/user contexts=][|user context|] to an empty [=stored remote end configuration=].
+1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=] does not
+   [=map/contain=] |user context|, set [=remote end=]'s [=stored remote end configuration=]'s
+   [=stored remote end configuration/user contexts=][|user context|] to an empty [=stored remote end configuration=].
 
-1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=][|user context|]'s
+1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/user contexts=][|user context|]'s
    [=struct/item=] |item| to |config|.
 
 </div>
@@ -6090,30 +6090,30 @@ To <dfn>store user context's remote end config</dfn> |config| in [=stored remote
 <div algorithm>
 
 Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
-[=remote end stored configuration/navigables=]'s [=remote end stored configuration=].
+[=stored remote end configuration/navigables=]'s [=stored remote end configuration=].
 
 To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item| for |navigable|:
 
 1. If |config| is null:
 
-   1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=] [=map/contains=]
+   1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=] [=map/contains=]
       |navigable|:
 
-      1. Set [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/navigables=][|navigable|]'s |item| to null.
+      1. Set [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/navigables=][|navigable|]'s |item| to null.
 
-      1. If [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/navigables=][|navigable|] contains only nulls, remove
-         |navigable| from [=remote end=]'s [=remote end stored configuration=]'s
-         [=remote end stored configuration/navigables=].
+      1. If [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/navigables=][|navigable|] contains only nulls, remove
+         |navigable| from [=remote end=]'s [=stored remote end configuration=]'s
+         [=stored remote end configuration/navigables=].
 
       1. Return.
 
-1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=] does not
-   [=map/contain=] |navigable|, set [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/navigables=][|navigable|] to an empty [=stored remote end configuration=].
+1. If [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=] does not
+   [=map/contain=] |navigable|, set [=remote end=]'s [=stored remote end configuration=]'s
+   [=stored remote end configuration/navigables=][|navigable|] to an empty [=stored remote end configuration=].
 
-1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=][|navigable|]'s
+1. Set [=remote end=]'s [=stored remote end configuration=]'s [=stored remote end configuration/navigables=][|navigable|]'s
    [=struct/item=] |item| to |config|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -7175,6 +7175,9 @@ the text layout mode on the given top-level traversables or user contexts.
    </dd>
 </dl>
 
+The <dfn>text layout mode override configuration</dfn> is [=WebDriver configuration=] with
+[=WebDriver configuration/type=] "<code>mobile</code>".
+
 <div algorithm>
 To <dfn>update text layout mode override</dfn> for [=/navigable=] |navigable|:
 
@@ -7185,13 +7188,14 @@ that content remains readable without requiring the user to zoom in. This
 behavior is often controlled via the 'text-size-adjust' CSS property.
 See [[!CSS-SIZE-ADJUST-1]].
 
-1. Let |text layout mode override| be the result of [=get remote end configuration=] of
-   [=remote end configuration/text layout mode=] for |navigable|.
+1. Let |text layout mode override| be the result of [=get WebDriver configuration value=] of
+   [=text layout mode override configuration=] for |navigable|.
 
-1. Assert that |text layout mode override| is "<code>mobile</code>" or null.
+1. Assert that |text layout mode override| is "<code>mobile</code>" or
+   [=WebDriver configuration/unset=].
 
-1. If |text layout mode override| is "<code>mobile</code>", run [=implementation-defined=] steps to make the
-   |navigable|'s [=active document=] to use the "<code>mobile</code>" text layout mode.
+1. If |text layout mode override| is "<code>mobile</code>", run [=implementation-defined=] steps to
+   make the |navigable|'s [=active document=] to use the "<code>mobile</code>" text layout mode.
 
 1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default text layout mode.
@@ -7202,10 +7206,13 @@ See [[!CSS-SIZE-ADJUST-1]].
 
 The [=remote end steps=] given |command parameters| are:
 
-1. Let |emulated text layout mode| be |command parameters|["<code>textLayoutMode</code>"].
+1. Let |text layout mode override| be |command parameters|["<code>textLayoutMode</code>"].
 
-1. Let |affected navigables| be the result of [=store remote end config=] for |emulated text layout mode|,
-   [=remote end configuration/text layout mode=] and |command parameters|.
+1. If |text layout mode override| is null, set |text layout mode override| to
+   [=WebDriver configuration/unset=].
+
+1. Let |affected navigables| be the result of [=store WebDriver configuration=]
+   [=text layout mode override configuration=] |text layout mode override| for |command parameters|.
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -433,17 +433,17 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 The <dfn>WebDriver configuration</dfn> is a structure providing a generic way to store
 configurations per user context, per navigable or globally.
 
-The <dfn>WebDriver configuration unset value</dfn> is a specific value indicating the value for the
-specific configuration is unset.
+<dfn for="WebDriver configuration">Unset</dfn> is a value indicating that a specific configuration
+[=WebDriver configuration/value=] has not be set.
 
 Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">type</dfn>,
 which defines the possible values for the configuration.
 
 Each [=WebDriver configuration=] has a <dfn for="WebDriver configuration">value</dfn>, which is
-either the [=WebDriver configuration unset value=] or a value of the [=WebDriver configuration/type=].
+either [=WebDriver configuration/unset=] or a value of the [=WebDriver configuration/type=].
 
 The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="WebDriver configuration struct">global</dfn> which is a [=WebDriver configuration/value=], initially [=WebDriver configuration unset value=];
+* [=struct/item=] named <dfn for="WebDriver configuration struct">global</dfn> which is a [=WebDriver configuration/value=], initially [=WebDriver configuration/unset=];
 * [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
 * [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
 
@@ -455,7 +455,7 @@ which is a [=WebDriver configuration struct=].
 Note: this algorithm allows accessing the [=WebDriver configuration=] for a given [=/navigable=]
 by checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the
 |navigable|, then for the |navigable|'s [=associated user context=], then
-[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration unset value=] if
+[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration/unset=] if
 configuration is not set.
 
 To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configuration=]
@@ -469,7 +469,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
    1. Let |navigable configuration value| be |configuration values|'
       [=WebDriver configuration struct/navigables=][|navigable|].
 
-   1. If |navigable configuration value| is not [=WebDriver configuration unset value=], return
+   1. If |navigable configuration value| is not [=WebDriver configuration/unset=], return
       |navigable configuration value|.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
@@ -480,7 +480,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
    1. Let |user context configuration value| be |configuration values|'
       [=WebDriver configuration struct/user contexts=][|user context|].
 
-   1. If |user context configuration value| is not [=WebDriver configuration unset value=], return
+   1. If |user context configuration value| is not [=WebDriver configuration/unset=], return
       |user context configuration value|.
 
 1. Return |configuration values|' [=WebDriver configuration struct/global=].
@@ -7123,7 +7123,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
    [=scrollbar type override configuration=] for |navigable|.
 
 1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
-   [=WebDriver configuration unset value=].
+   [=WebDriver configuration/unset=].
 
 1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to
    make the |navigable|'s [=active document=] to use <a>classic scrollbars</a> and return.
@@ -7131,7 +7131,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 1. if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
    steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a> and return.
 
-1. Assert the |scrollbar type override| is [=WebDriver configuration unset value=].
+1. Assert the |scrollbar type override| is [=WebDriver configuration/unset=].
 
 1. Run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.
@@ -7145,7 +7145,7 @@ The [=remote end steps=] given |command parameters| are:
 1. Let |scrollbar type override| be |command parameters|["<code>scrollbarType</code>"].
 
 1. If |scrollbar type override| is null, set |scrollbar type override| to
-   [=WebDriver configuration unset value=].
+   [=WebDriver configuration/unset=].
 
 1. If the implementation does not support setting |scrollbar type override|, then return [=error=]
    with [=error code=] [=unsupported operation=].

--- a/index.bs
+++ b/index.bs
@@ -6001,6 +6001,9 @@ EmulationResult = (
 )
 </pre>
 
+Note: [=stored remote end configuration=] is an umbrella structure that holds all global configurations. Unlike
+session configurations, these configurations are not reset after the session is closed, and are shared between sessions.
+
 A <dfn export>stored remote end configuration</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="stored remote end configuration">scrollbar type</dfn> which is a string or null initially null.
 

--- a/index.bs
+++ b/index.bs
@@ -5011,7 +5011,7 @@ TODO: Move it as a hook in the html spec instead.
       1. [=Set device pixel ratio override=] with |navigable| and [=viewport overrides map=][|user context|]'s
          [=viewport-configuration/devicePixelRatio=].
 
-1. [=Update scrollbar type override=].
+1. [=Update scrollbar type override=] for |navigable|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -490,7 +490,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 <div algorithm>
 
 Note: this is a generic algorithm for storing [=WebDriver configuration=] per |target|, which can be
-either [=/navigable=], [=user context=], or store it globally if the |target| is null or emitted.
+either [=/navigable=], [=user context=], or store it globally if the |target| is null or omitted.
 
 To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
 [=WebDriver configuration/value=] |value| in optional |target| which is a [=/navigable=],

--- a/index.bs
+++ b/index.bs
@@ -6001,13 +6001,13 @@ EmulationResult = (
 )
 </pre>
 
-A <dfn export>stored remote end config</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="stored remote end config">scrollbar type</dfn> which is a string or null initially null.
+A <dfn export>stored remote end configuration</dfn> is a [=struct=] with:
+* [=struct/item=] named <dfn for="stored remote end configuration">scrollbar type</dfn> which is a string or null initially null.
 
 A [=remote end=] has a <dfn for="remote end">remote end configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="remote end stored configuration">global</dfn> which is a [=stored remote end config=], initially an empty [=stored remote end config=];
-* [=struct/item=] named <dfn for="remote end stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end config=], initially empty;
-* [=struct/item=] named <dfn for="remote end stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end config=], initially empty.
+* [=struct/item=] named <dfn for="remote end stored configuration">global</dfn> which is a [=stored remote end configuration=], initially an empty [=stored remote end configuration=];
+* [=struct/item=] named <dfn for="remote end stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end configuration=], initially empty;
+* [=struct/item=] named <dfn for="remote end stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end configuration=], initially empty.
 
 <div algorithm>
 
@@ -6015,10 +6015,10 @@ Note: this algorithm allows for accessing the stored configuration for a given n
 stored configuration for the navigable, then the user context, then the global. Returns null if configuration is not
 set.
 
-To <dfn export>get stored remote end config</dfn> of [=stored remote end config=]'s [=struct/item=] |item| for
+To <dfn export>get stored remote end configuration</dfn> of [=stored remote end configuration=]'s [=struct/item=] |item| for
 [=/navigables|navigable=] |navigable|:
 
-1. Assert |item| is a [=struct/item=] of [=stored remote end config=].
+1. Assert |item| is a [=struct/item=] of [=stored remote end configuration=].
 
 1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=]
    [=map/contains=] |navigable|, and [=remote end=]'s [=remote end stored configuration=]'s
@@ -6042,10 +6042,10 @@ To <dfn export>get stored remote end config</dfn> of [=stored remote end config=
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
 [=remote end stored configuration/global=]'s [=remote end stored configuration=].
 
-To <dfn>store global remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item|:
+To <dfn>store global remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item|:
 
 1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/global=]'s |item| to
    |config|.
@@ -6054,11 +6054,11 @@ To <dfn>store global remote end config</dfn> |config| in [=stored remote end con
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
 [=remote end stored configuration/user contexts=]'s [=remote end stored configuration=].
 
-To <dfn>store user context's remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item|
-for |user context|:
+To <dfn>store user context's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=]
+|item| for |user context|:
 
 1. If |config| is null:
 
@@ -6077,7 +6077,7 @@ for |user context|:
 
 1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] does not
    [=map/contain=] |user context|, set [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/user contexts=][|user context|] to an empty [=stored remote end config=].
+   [=remote end stored configuration/user contexts=][|user context|] to an empty [=stored remote end configuration=].
 
 1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=][|user context|]'s
    [=struct/item=] |item| to |config|.
@@ -6086,10 +6086,10 @@ for |user context|:
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+Note: this is a generic algorithm for storing configuration [=stored remote end configuration=] in [=remote end=]'s
 [=remote end stored configuration/navigables=]'s [=remote end stored configuration=].
 
-To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item| for |navigable|:
+To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote end configuration=]'s [=struct/item=] |item| for |navigable|:
 
 1. If |config| is null:
 
@@ -6108,7 +6108,7 @@ To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote en
 
 1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=] does not
    [=map/contain=] |navigable|, set [=remote end=]'s [=remote end stored configuration=]'s
-   [=remote end stored configuration/navigables=][|navigable|] to an empty [=stored remote end config=].
+   [=remote end stored configuration/navigables=][|navigable|] to an empty [=stored remote end configuration=].
 
 1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=][|navigable|]'s
    [=struct/item=] |item| to |config|.
@@ -7079,8 +7079,8 @@ scrollbar type on the given top-level traversables, user contexts or globally.
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
-1. Let |scrollbar type override| be the result of [=get stored remote end config=] of
-   [=stored remote end config/scrollbar type=] for |navigable|.
+1. Let |scrollbar type override| be the result of [=get stored remote end configuration=] of
+   [=stored remote end configuration/scrollbar type=] for |navigable|.
 
 1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or null.
 
@@ -7121,7 +7121,7 @@ The [=remote end steps=] given |command parameters| are:
       1. [=set/Append=] |navigable| to |affected navigables|.
 
       1. [=Store navigable's remote end config=] |emulated scrollbar type| in
-         [=stored remote end config/scrollbar type=] for |navigable|.
+         [=stored remote end configuration/scrollbar type=] for |navigable|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -7136,10 +7136,10 @@ The [=remote end steps=] given |command parameters| are:
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
       1. [=Store user context's remote end config=] |emulated scrollbar type| in
-         [=stored remote end config/scrollbar type=] for |user context|.
+         [=stored remote end configuration/scrollbar type=] for |user context|.
 
 1. Otherwise, [=store global remote end config=] |emulated scrollbar type| in
-   [=stored remote end config/scrollbar type=] .
+   [=stored remote end configuration/scrollbar type=] .
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -7184,8 +7184,8 @@ the text layout mode on the given top-level traversables or user contexts.
    </dd>
 </dl>
 
-The <dfn>text layout mode override configuration</dfn> is [=WebDriver configuration=] with
-[=WebDriver configuration/type=] "<code>mobile</code>".
+A [=remote end=] has a <dfn>text layout mode override configuration</dfn>, which is
+[=WebDriver configuration=] with [=WebDriver configuration/associated type=] string.
 
 <div algorithm>
 To <dfn>update text layout mode override</dfn> for [=/navigable=] |navigable|:

--- a/index.bs
+++ b/index.bs
@@ -509,12 +509,11 @@ a [=user context=] or null if not provided:
 
 <div algorithm>
 
-Note: this is a generic algorithm for storing [=WebDriver configuration=] in
-[=WebDriver configuration struct/global=], [=WebDriver configuration struct/user contexts=] or
-[=WebDriver configuration struct/navigables=] based on |command parameters|'s
-"<code>userContexts</code>" and "<code>contexts</code>". At most one of the parameters
-"<code>userContexts</code>" and "<code>contexts</code>" is allowed. If none of them are provided,
-the configuration is stored globally.
+Note: This generic algorithm stores [=WebDriver configuration=]'s [=WebDriver configuration/value=]
+in [=WebDriver configuration struct/global=], [=WebDriver configuration struct/user contexts=], or
+[=WebDriver configuration struct/navigables=], depending on the presence of
+"<code>userContexts</code>" and "<code>contexts</code>" in |command parameters|. These parameters
+are mutually exclusive. If neither is provided, the configuration is stored globally.
 
 To <dfn>store WebDriver configuration</dfn> [=WebDriver configuration=] |configuration|'s
 [=WebDriver configuration/value=] |value| for given |command parameters|:

--- a/index.bs
+++ b/index.bs
@@ -5013,6 +5013,8 @@ TODO: Move it as a hook in the html spec instead.
 
 1. [=Update scrollbar type override=].
 
+1. [=Update text layout mode override=] for |navigable|.
+
 </div>
 
 <div algorithm="remote end steps for browsingContext.setViewport">
@@ -5980,6 +5982,7 @@ EmulationCommand = (
   emulation.SetScreenSettingsOverride //
   emulation.SetScriptingEnabled //
   emulation.SetScrollbarTypeOverride //
+  emulation.SetTextLayoutModeOverride //
   emulation.SetTimezoneOverride //
   emulation.SetTouchOverride //
   emulation.SetUserAgentOverride
@@ -5995,6 +5998,7 @@ EmulationResult = (
   emulation.SetScreenOrientationOverrideResult /
   emulation.SetScriptingEnabledResult /
   emulation.SetScrollbarTypeOverrideResult /
+  emulation.SetTextLayoutModeOverrideResult /
   emulation.SetTimezoneOverrideResult /
   emulation.SetTouchOverrideResult /
   emulation.SetUserAgentOverrideResult
@@ -6006,7 +6010,8 @@ Note: [=stored remote end configuration=] is an umbrella structure that holds al
 shared between sessions.
 
 A <dfn export>remote end configuration</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="remote end configuration">scrollbar type</dfn> which is a string or null initially null.
+* [=struct/item=] named <dfn for="remote end configuration">scrollbar type</dfn> which is a string or null initially null;
+* [=struct/item=] named <dfn for="remote end configuration">text layout mode</dfn> which is a string or null initially null.
 
 A [=remote end=] has a <dfn for="remote end">stored remote end configuration</dfn> which is a [=struct=] with:
 * [=struct/item=] named <dfn for="stored remote end configuration">global</dfn> which is a [=remote end configuration=], initially an empty [=remote end configuration=];
@@ -7148,6 +7153,115 @@ The [=remote end steps=] given |command parameters| are:
 1. For each |navigable| of |affected navigables|:
 
    1. [=Update scrollbar type override=] for |navigable|.
+
+1. Return [=success=] with data null.
+
+</div>
+
+
+#### The emulation.setTextLayoutModeOverride Command #### {#command-emulation-setTextLayoutModeOverride}
+
+The <dfn export for=commands>emulation.setTextLayoutModeOverride</dfn> command modifies
+the text layout mode on the given top-level traversables or user contexts.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      emulation.SetTextLayoutModeOverride = (
+        method: "emulation.setTextLayoutModeOverride",
+        params: emulation.SetTextLayoutModeOverrideParameters
+      )
+
+      emulation.SetTextLayoutModeOverrideParameters = {
+        textLayoutMode: emulation.TextLayoutMode / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+
+      emulation.TextLayoutMode = "mobile"
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="local-cddl">
+      emulation.SetTextLayoutModeOverrideResult = EmptyResult
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+To <dfn>update text layout mode override</dfn> for [=/navigable=] |navigable|:
+
+Note: Text layout mode "<code>mobile</code>" enables text autosizing (font
+inflation), which is an algorithm used primarily on mobile devices to boost the
+legibility of text blocks when fitting them into a small viewport. This ensures
+that content remains readable without requiring the user to zoom in. This
+behavior is often controlled via the 'text-size-adjust' CSS property.
+See [[!CSS-SIZE-ADJUST-1]].
+
+1. Let |text layout mode override| be the result of [=get remote end configuration=] of
+   [=remote end configuration/text layout mode=] for |navigable|.
+
+1. Assert that |text layout mode override| is "<code>mobile</code>" or null.
+
+1. If |text layout mode override| is "<code>mobile</code>", run [=implementation-defined=] steps to make the
+   |navigable|'s [=active document=] to use the "<code>mobile</code>" text layout mode.
+
+1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
+   use an [=implementation-defined=] default text layout mode.
+
+</div>
+
+<div algorithm="remote end steps for emulation.setTextLayoutModeOverride">
+
+The [=remote end steps=] given |command parameters| are:
+
+1. Let |emulated text layout mode| be |command parameters|["<code>textLayoutMode</code>"].
+
+1. If |emulated text layout mode| is not null and is not "<code>mobile</code>", then return [=error=] with [=error code=]
+   [=invalid argument=].
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>contexts</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |affected navigables| be an empty [=/set=].
+
+1. If |command parameters| [=map/contains=] "<code>contexts</code>":
+
+   1. Let |navigables| be the result of [=trying=] to
+      [=get valid top-level traversables by ids=] with
+      |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. [=set/Append=] |navigable| to |affected navigables|.
+
+      1. [=Store navigable's remote end config=] |emulated text layout mode| in
+         [=remote end configuration/text layout mode=] for |navigable|.
+
+1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
+      with |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+         whose [=associated user context=] is |user context|:
+
+         1. [=set/Append=] |top-level traversable| to |affected navigables|.
+
+      1. [=Store user context's remote end config=] |emulated text layout mode| in
+         [=remote end configuration/text layout mode=] for |user context|.
+
+1. Otherwise, [=store global remote end config=] |emulated text layout mode| in
+   [=remote end configuration/text layout mode=] .
+
+1. For each |navigable| of |affected navigables|:
+
+   1. [=Update text layout mode override=] for |navigable|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -452,7 +452,7 @@ which is a [=WebDriver configuration struct=].
 
 <div algorithm>
 
-Note: this algorithm allows for accessing the [=WebDriver configuration=] for a given [=/navigable=]
+Note: this algorithm allows accessing the [=WebDriver configuration=] for a given [=/navigable=]
 by checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the
 |navigable|, then for the |navigable|'s [=associated user context=], then
 [=WebDriver configuration struct/global=]. Returns [=WebDriver configuration unset value=] if

--- a/index.bs
+++ b/index.bs
@@ -433,17 +433,17 @@ To <dfn export>resume</dfn> given |name|, |id| and |parameters|:
 The <dfn>WebDriver configuration</dfn> is a structure providing a generic way to store
 configurations per user context, per navigable or globally.
 
-The <dfn>WebDriver unset configuration value</dfn> is a specific value indicating the value for the
+The <dfn>WebDriver configuration unset value</dfn> is a specific value indicating the value for the
 specific configuration is unset.
 
 Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">type</dfn>,
 which defines the possible values for the configuration.
 
 Each [=WebDriver configuration=] has a <dfn for="WebDriver configuration">value</dfn>, which is
-either the [=WebDriver unset configuration value=] or a value of the [=WebDriver configuration/type=].
+either the [=WebDriver configuration unset value=] or a value of the [=WebDriver configuration/type=].
 
 The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="WebDriver configuration struct">global</dfn> which is a [=WebDriver configuration/value=], initially [=WebDriver unset configuration value=];
+* [=struct/item=] named <dfn for="WebDriver configuration struct">global</dfn> which is a [=WebDriver configuration/value=], initially [=WebDriver configuration unset value=];
 * [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
 * [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
 
@@ -452,12 +452,14 @@ which is a [=WebDriver configuration struct=].
 
 <div algorithm>
 
-Note: this algorithm allows for accessing the [=WebDriver configuration=] for a given navigable by
-checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the navigable,
-then the user context, then the global. Returns null if configuration is not set.
+Note: this algorithm allows for accessing the [=WebDriver configuration=] for a given [=/navigable=]
+by checking the [=WebDriver configuration=]'s [=WebDriver configuration/values=] for the
+|navigable|, then for the |navigable|'s [=associated user context=], then
+[=WebDriver configuration struct/global=]. Returns [=WebDriver configuration unset value=] if
+configuration is not set.
 
 To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configuration=]
-|configuration| for [=/navigables|navigable=] |navigable|:
+|configuration| for [=/navigable=] |navigable|:
 
 1. Let |configuration values| be |configuration|'s [=WebDriver configuration/values=].
 
@@ -467,7 +469,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
    1. Let |navigable configuration value| be |configuration values|'
       [=WebDriver configuration struct/navigables=][|navigable|].
 
-   1. If |navigable configuration value| is not [=WebDriver unset configuration value=], return
+   1. If |navigable configuration value| is not [=WebDriver configuration unset value=], return
       |navigable configuration value|.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
@@ -478,7 +480,7 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
    1. Let |user context configuration value| be |configuration values|'
       [=WebDriver configuration struct/user contexts=][|user context|].
 
-   1. If |user context configuration value| is not [=WebDriver unset configuration value=], return
+   1. If |user context configuration value| is not [=WebDriver configuration unset value=], return
       |user context configuration value|.
 
 1. Return |configuration values|' [=WebDriver configuration struct/global=].
@@ -7121,15 +7123,17 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
    [=scrollbar type override configuration=] for |navigable|.
 
 1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
-   [=WebDriver unset configuration value=].
+   [=WebDriver configuration unset value=].
 
 1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to
-   make the |navigable|'s [=active document=] to use <a>classic scrollbars</a>.
+   make the |navigable|'s [=active document=] to use <a>classic scrollbars</a> and return.
 
-1. Otherwise, if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
-   steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a>.
+1. if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
+   steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a> and return.
 
-1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
+1. Assert the |scrollbar type override| is [=WebDriver configuration unset value=].
+   
+1. Run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.
 
 </div>
@@ -7141,7 +7145,7 @@ The [=remote end steps=] given |command parameters| are:
 1. Let |scrollbar type override| be |command parameters|["<code>scrollbarType</code>"].
 
 1. If |scrollbar type override| is null, set |scrollbar type override| to
-   [=WebDriver unset configuration value=].
+   [=WebDriver configuration unset value=].
 
 1. If the implementation does not support setting |scrollbar type override|, then return [=error=]
    with [=error code=] [=unsupported operation=].

--- a/index.bs
+++ b/index.bs
@@ -7109,7 +7109,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 1. if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
    steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a> and return.
 
-1. Assert the |scrollbar type override| is [=WebDriver configuration/unset=].
+1. Assert: |scrollbar type override| is [=WebDriver configuration/unset=].
 
 1. Run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.

--- a/index.bs
+++ b/index.bs
@@ -490,10 +490,10 @@ To <dfn export>get WebDriver configuration value</dfn> of [=WebDriver configurat
 <div algorithm>
 
 Note: this is a generic algorithm for storing [=WebDriver configuration=] per |target|, which can be
-either [=navigable=], [=user context=], or store it globally if the |target| is null or emitted.
+either [=/navigable=], [=user context=], or store it globally if the |target| is null or emitted.
 
 To <dfn for="WebDriver configuration">store</dfn> [=WebDriver configuration=] |configuration|'s
-[=WebDriver configuration/value=] |value| in optional |target| which is a [=navigable=],
+[=WebDriver configuration/value=] |value| in optional |target| which is a [=/navigable=],
 a [=user context=] or null if not provided:
 
 1. If |target| is null, set |configuration|'s [=WebDriver configuration/values=]'s
@@ -502,7 +502,7 @@ a [=user context=] or null if not provided:
 1. If |target| is a [=user context=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/user contexts=][|user context|] to |value|.
 
-1. If |target| is a [=navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
+1. If |target| is a [=/navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
    [=WebDriver configuration struct/navigables=][|navigable|] to |value|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -7102,7 +7102,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 1. Let |scrollbar type override| be the result of [=get WebDriver configuration value=] of
    [=scrollbar type override configuration=] for |navigable|.
 
-1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
+1. Assert: |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
    [=WebDriver configuration/unset=].
 
 1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to

--- a/index.bs
+++ b/index.bs
@@ -500,10 +500,10 @@ a [=user context=] or null if not provided:
    [=WebDriver configuration struct/global=] to |value|.
 
 1. If |target| is a [=user context=], set |configuration|'s [=WebDriver configuration/values=]'s
-   [=WebDriver configuration struct/user contexts=][|user context|] to |value|.
+   [=WebDriver configuration struct/user contexts=][|target|] to |value|.
 
 1. If |target| is a [=/navigable=], set |configuration|'s [=WebDriver configuration/values=]'s
-   [=WebDriver configuration struct/navigables=][|navigable|] to |value|.
+   [=WebDriver configuration struct/navigables=][|target|] to |value|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -447,8 +447,8 @@ The <dfn>WebDriver configuration struct</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="WebDriver configuration struct">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=WebDriver configuration/value=], initially empty;
 * [=struct/item=] named <dfn for="WebDriver configuration struct">navigables</dfn> which is a weak map between [=/navigables=] and [=WebDriver configuration/value=], initially empty.
 
-Each [=WebDriver configuration=] has an associated <dfn for="WebDriver configuration">values</dfn>
-which is a [=WebDriver configuration struct=].
+For each [=WebDriver configuration=], [=remote end=] has an associated
+<dfn for="WebDriver configuration">values</dfn> which is a [=WebDriver configuration struct=].
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -7092,7 +7092,7 @@ scrollbar type on the given top-level traversables, user contexts or globally.
 </dl>
 
 The <dfn>scrollbar type override configuration</dfn> is [=WebDriver configuration=] with
-[=WebDriver configuration/type=] string.
+[=WebDriver configuration/type=] "<code>classic</code>" / "<code>overlay</code>".
 
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:

--- a/index.bs
+++ b/index.bs
@@ -6012,17 +6012,17 @@ A [=BiDi session=] has an <dfn for=session>session stored configuration</dfn> wh
 Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the stored
 configuration for the navigable, then the user context, then the global for all the active sessions.
 
-To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |config item| for
+To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |item| for
 [=/navigables|navigable=] |navigable|:
 
-1. Assert |config item| is a [=struct/item=] of [=stored config=].
+1. Assert |item| is a [=struct/item=] of [=stored config=].
 
 1. For each |session| in [=active BiDi sessions=]:
 
    1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
       |navigable|, and |session|'s [=session stored configuration=]'s
-      [=session stored configuration/navigables=][|navigable|]'s |config item| is not null,  return |session|'s
-      [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s |config item|.
+      [=session stored configuration/navigables=][|navigable|]'s |item| is not null,  return |session|'s
+      [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s |item|.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
@@ -6030,14 +6030,14 @@ To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |c
 
    1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
       |user context|, and |session|'s [=session stored configuration=]'s
-      [=session stored configuration/user contexts=][|user context|]'s |config item| is not null, return |session|'s
-      [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s |config item|.
+      [=session stored configuration/user contexts=][|user context|]'s |item| is not null, return |session|'s
+      [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s |item|.
 
 1. For each |session| in [=active BiDi sessions=]:
 
    1. If |session|'s |session|'s [=session stored configuration=]'s [=session stored configuration/global=]
-      |config item| is not null, return |session|'s [=session stored configuration=]'s
-      [=session stored configuration/global=]'s |config item|.
+      |item| is not null, return |session|'s [=session stored configuration=]'s
+      [=session stored configuration/global=]'s |item|.
 
 1. Return null.
 
@@ -6045,17 +6045,17 @@ To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |c
 
 <div algorithm>
 
-To <dfn>store global config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| in [=BiDi session=]
+To <dfn>store global config</dfn> [=stored config=]'s [=struct/item=] |item| |config| in [=BiDi session=]
 |session|:
 
-1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/global=]'s |config item| to
+1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/global=]'s |item| to
    |config|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |item| |config| for
 |user context| in [=BiDi session=] |session|:
 
 1. If |config| is null:
@@ -6064,7 +6064,7 @@ To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |con
       |user context|:
 
       1. Set |session|'s [=session stored configuration=]'s
-         [=session stored configuration/user contexts=][|user context|]'s |config item| to null.
+         [=session stored configuration/user contexts=][|user context|]'s |item| to null.
 
       1. If |session|'s [=session stored configuration=]'s
          [=session stored configuration/user contexts=][|user context|] contains only nulls, remove
@@ -6078,13 +6078,13 @@ To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |con
    [=session stored configuration/user contexts=][|user context|] to an empty [=stored config=].
 
 1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s
-   [=struct/item=] |config item| to |config|.
+   [=struct/item=] |item| to |config|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |item| |config| for
 |navigable| in [=BiDi session=] |session|:
 
 1. If |config| is null:
@@ -6093,7 +6093,7 @@ To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config
       |navigable|:
 
       1. Set |session|'s [=session stored configuration=]'s
-         [=session stored configuration/navigables=][|navigable|]'s |config item| to null.
+         [=session stored configuration/navigables=][|navigable|]'s |item| to null.
 
       1. If |session|'s [=session stored configuration=]'s
          [=session stored configuration/navigables=][|navigable|] contains only nulls, remove
@@ -6107,7 +6107,7 @@ To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config
    [=session stored configuration/navigables=][|navigable|] to an empty [=stored config=].
 
 1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s
-   [=struct/item=] |config item| to |config|.
+   [=struct/item=] |item| to |config|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5999,45 +5999,40 @@ EmulationResult = (
 )
 </pre>
 
-A <dfn export>stored config</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="stored config">scrollbar type</dfn> which is a string or null initially null.
+A <dfn export>stored remote end config</dfn> is a [=struct=] with:
+* [=struct/item=] named <dfn for="stored remote end config">scrollbar type</dfn> which is a string or null initially null.
 
-A [=BiDi session=] has an <dfn for=session>session stored configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="session stored configuration">global</dfn> which is a [=stored config=], initially an empty [=stored config=];
-* [=struct/item=] named <dfn for="session stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored config=], initially empty;
-* [=struct/item=] named <dfn for="session stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored config=], initially empty.
+A [=remote end=] has an <dfn for="remote end">remote end stored configuration</dfn> which is a [=struct=] with:
+* [=struct/item=] named <dfn for="remote end stored configuration">global</dfn> which is a [=stored remote end config=], initially an empty [=stored remote end config=];
+* [=struct/item=] named <dfn for="remote end stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored remote end config=], initially empty;
+* [=struct/item=] named <dfn for="remote end stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored remote end config=], initially empty.
 
 <div algorithm>
 
-Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the stored
-configuration for the navigable, then the user context, then the global for all the active sessions.
+Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the remote-end's
+stored configuration for the navigable, then the user context, then the global. Returns null if configuration is not
+set.
 
-To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |item| for
+To <dfn export>get stored remote end config</dfn> of [=stored remote end config=]'s [=struct/item=] |item| for
 [=/navigables|navigable=] |navigable|:
 
-1. Assert |item| is a [=struct/item=] of [=stored config=].
+1. Assert |item| is a [=struct/item=] of [=stored remote end config=].
 
-1. For each |session| in [=active BiDi sessions=]:
-
-   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
-      |navigable|, and |session|'s [=session stored configuration=]'s
-      [=session stored configuration/navigables=][|navigable|]'s |item| is not null,  return |session|'s
-      [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s |item|.
+1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=]
+   [=map/contains=] |navigable|, and [=remote end=]'s [=remote end stored configuration=]'s
+   [=remote end stored configuration/navigables=][|navigable|]'s |item| is not null,  return [=remote end=]'s
+   [=remote end stored configuration=]'s [=remote end stored configuration/navigables=][|navigable|]'s |item|.
 
 1. Let |user context| be |navigable|'s [=associated user context=].
 
-1. For each |session| in [=active BiDi sessions=]:
+1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] [=map/contains=]
+   |user context|, and [=remote end=]'s [=remote end stored configuration=]'s
+   [=remote end stored configuration/user contexts=][|user context|]'s |item| is not null, return [=remote end=]'s
+   [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=][|user context|]'s |item|.
 
-   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
-      |user context|, and |session|'s [=session stored configuration=]'s
-      [=session stored configuration/user contexts=][|user context|]'s |item| is not null, return |session|'s
-      [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s |item|.
-
-1. For each |session| in [=active BiDi sessions=]:
-
-   1. If |session|'s |session|'s [=session stored configuration=]'s [=session stored configuration/global=]
-      |item| is not null, return |session|'s [=session stored configuration=]'s
-      [=session stored configuration/global=]'s |item|.
+1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/global=]
+   |item| is not null, return [=remote end=]'s [=remote end stored configuration=]'s
+   [=remote end stored configuration/global=]'s |item|.
 
 1. Return null.
 
@@ -6045,68 +6040,75 @@ To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |i
 
 <div algorithm>
 
-To <dfn>store global config</dfn> [=stored config=]'s [=struct/item=] |item| |config| in [=BiDi session=]
-|session|:
+Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+[=remote end stored configuration/global=]'s [=remote end stored configuration=].
 
-1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/global=]'s |item| to
+To <dfn>store global remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item|:
+
+1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/global=]'s |item| to
    |config|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |item| |config| for
-|user context| in [=BiDi session=] |session|:
+Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+[=remote end stored configuration/user contexts=]'s [=remote end stored configuration=].
+
+To <dfn>store user context's remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item|
+for |user context|:
 
 1. If |config| is null:
 
-   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
+   1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] [=map/contains=]
       |user context|:
 
-      1. Set |session|'s [=session stored configuration=]'s
-         [=session stored configuration/user contexts=][|user context|]'s |item| to null.
+      1. Set [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/user contexts=][|user context|]'s |item| to null.
 
-      1. If |session|'s [=session stored configuration=]'s
-         [=session stored configuration/user contexts=][|user context|] contains only nulls, remove
-         |user context| from |session|'s [=session stored configuration=]'s
-         [=session stored configuration/user contexts=].
+      1. If [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/user contexts=][|user context|] contains only nulls, remove
+         |user context| from [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/user contexts=].
 
       1. Return.
 
-1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] does not
-   [=map/contain=] |user context|, set |session|'s [=session stored configuration=]'s
-   [=session stored configuration/user contexts=][|user context|] to an empty [=stored config=].
+1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=] does not
+   [=map/contain=] |user context|, set [=remote end=]'s [=remote end stored configuration=]'s
+   [=remote end stored configuration/user contexts=][|user context|] to an empty [=stored remote end config=].
 
-1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=][|user context|]'s
+1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/user contexts=][|user context|]'s
    [=struct/item=] |item| to |config|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |item| |config| for
-|navigable| in [=BiDi session=] |session|:
+Note: this is a generic algorithm for storing configuration [=stored remote end config=] in [=remote end=]'s
+[=remote end stored configuration/navigables=]'s [=remote end stored configuration=].
+
+To <dfn>store navigable's remote end config</dfn> |config| in [=stored remote end config=]'s [=struct/item=] |item| for |navigable|:
 
 1. If |config| is null:
 
-   1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
+   1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=] [=map/contains=]
       |navigable|:
 
-      1. Set |session|'s [=session stored configuration=]'s
-         [=session stored configuration/navigables=][|navigable|]'s |item| to null.
+      1. Set [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/navigables=][|navigable|]'s |item| to null.
 
-      1. If |session|'s [=session stored configuration=]'s
-         [=session stored configuration/navigables=][|navigable|] contains only nulls, remove
-         |navigable| from |session|'s [=session stored configuration=]'s
-         [=session stored configuration/navigables=].
+      1. If [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/navigables=][|navigable|] contains only nulls, remove
+         |navigable| from [=remote end=]'s [=remote end stored configuration=]'s
+         [=remote end stored configuration/navigables=].
 
       1. Return.
 
-1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] does not
-   [=map/contain=] |navigable|, set |session|'s [=session stored configuration=]'s
-   [=session stored configuration/navigables=][|navigable|] to an empty [=stored config=].
+1. If [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=] does not
+   [=map/contain=] |navigable|, set [=remote end=]'s [=remote end stored configuration=]'s
+   [=remote end stored configuration/navigables=][|navigable|] to an empty [=stored remote end config=].
 
-1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=][|navigable|]'s
+1. Set [=remote end=]'s [=remote end stored configuration=]'s [=remote end stored configuration/navigables=][|navigable|]'s
    [=struct/item=] |item| to |config|.
 
 </div>
@@ -7095,8 +7097,8 @@ scrollbar type on the given top-level traversables, user contexts or globally.
 <div algorithm>
 To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
-1. Let |scrollbar type override| be the result of [=get stored config=] of [=stored config/scrollbar type=] for
-   |navigable|.
+1. Let |scrollbar type override| be the result of [=get stored remote end config=] of
+   [=stored remote end config/scrollbar type=] for |navigable|.
 
 1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or null.
 
@@ -7113,7 +7115,7 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 
 <div algorithm="remote end steps for emulation.setScrollbarTypeOverride">
 
-The [=remote end steps=] given |session| and |command parameters| are:
+The [=remote end steps=] given |command parameters| are:
 
 1. Let |emulated scrollbar type| be |command parameters|["<code>scrollbarType</code>"].
 
@@ -7136,7 +7138,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
       1. [=set/Append=] |navigable| to |affected navigables|.
 
-      1. [=Store navigable config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |navigable|.
+      1. [=Store navigable's remote end config=] |emulated scrollbar type| in
+         [=stored remote end config/scrollbar type=] for |navigable|.
 
 1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
 
@@ -7150,9 +7153,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
          1. [=set/Append=] |top-level traversable| to |affected navigables|.
 
-      1. [=Store user context config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |user context|.
+      1. [=Store user context's remote end config=] |emulated scrollbar type| in
+         [=stored remote end config/scrollbar type=] for |user context|.
 
-1. Otherwise, [=store global config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |session|.
+1. Otherwise, [=store global remote end config=] |emulated scrollbar type| in
+   [=stored remote end config/scrollbar type=] .
 
 1. For each |navigable| of |affected navigables|:
 

--- a/index.bs
+++ b/index.bs
@@ -272,6 +272,10 @@ spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
 spec: RFC4648; urlPrefix: https://datatracker.ietf.org/doc/html/rfc4648
   type: dfn
     text: Base64 Encode; url: section-4
+spec: CSS-OVERFLOW-3; urlPrefix: https://drafts.csswg.org/css-overflow-3/
+  type: dfn
+    text: classic scrollbars; url: #classic-scrollbars
+    text: overlay scrollbars; url: #overlay-scrollbars
 spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
   type: dfn
     text: absolute lengths; url: #absolute-lengths
@@ -5973,6 +5977,7 @@ EmulationCommand = (
   emulation.SetScreenOrientationOverride //
   emulation.SetScreenSettingsOverride //
   emulation.SetScriptingEnabled //
+  emulation.SetScrollbarTypeOverride //
   emulation.SetTimezoneOverride //
   emulation.SetTouchOverride //
   emulation.SetUserAgentOverride
@@ -5987,6 +5992,7 @@ EmulationResult = (
   emulation.SetLocaleOverrideResult /
   emulation.SetScreenOrientationOverrideResult /
   emulation.SetScriptingEnabledResult /
+  emulation.SetScrollbarTypeOverrideResult /
   emulation.SetTimezoneOverrideResult /
   emulation.SetTouchOverrideResult /
   emulation.SetUserAgentOverrideResult
@@ -5997,14 +6003,14 @@ A <dfn export>stored config</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="stored config">scrollbar type</dfn> which is a string or null initially null.
 
 A [=BiDi session=] has an <dfn for=session>session stored configuration</dfn> which is a [=struct=] with:
-* [=struct/item=] named <dfn for="session stored configuration">default</dfn> which is a [=stored config=], initially an empty [=stored config=];
+* [=struct/item=] named <dfn for="session stored configuration">global</dfn> which is a [=stored config=], initially an empty [=stored config=];
 * [=struct/item=] named <dfn for="session stored configuration">user contexts</dfn> which is a weak map between [=user context|user contexts=] and [=stored config=], initially empty;
 * [=struct/item=] named <dfn for="session stored configuration">navigables</dfn> which is a weak map between [=/navigables=] and [=stored config=], initially empty.
 
 <div algorithm>
 
 Note: this algorithm allows for accessing the stored configuration for a given navigable by checking the stored
-configuration for the navigable, then the user context, then the default for all the active sessions.
+configuration for the navigable, then the user context, then the global for all the active sessions.
 
 To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |config item| for
 [=/navigables|navigable=] |navigable|:
@@ -6029,9 +6035,9 @@ To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |c
 
 1. For each |session| in [=active BiDi sessions=]:
 
-   1. If |session|'s |session|'s [=session stored configuration=]'s [=session stored configuration/default=]
+   1. If |session|'s |session|'s [=session stored configuration=]'s [=session stored configuration/global=]
       |config item| is not null, return |session|'s [=session stored configuration=]'s
-      [=session stored configuration/default=]'s |config item|.
+      [=session stored configuration/global=]'s |config item|.
 
 1. Return null.
 
@@ -6039,32 +6045,32 @@ To <dfn export>get stored config</dfn> of [=stored config=]'s [=struct/item=] |c
 
 <div algorithm>
 
-To <dfn export>store global config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| in [=BiDi session=]
+To <dfn>store global config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| in [=BiDi session=]
 |session|:
 
-1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/default=]'s |config item| to
+1. Set |session|'s [=session stored configuration=]'s [=session stored configuration/global=]'s |config item| to
    |config|.
 
 </div>
 
 <div algorithm>
 
-To <dfn export>store user context config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+To <dfn>store user context config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
 |user context| in [=BiDi session=] |session|:
 
 1. If |config| is null:
 
    1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] [=map/contains=]
       |user context|:
-      
+
       1. Set |session|'s [=session stored configuration=]'s
          [=session stored configuration/user contexts=][|user context|]'s |config item| to null.
-   
+
       1. If |session|'s [=session stored configuration=]'s
          [=session stored configuration/user contexts=][|user context|] contains only nulls, remove
          |user context| from |session|'s [=session stored configuration=]'s
          [=session stored configuration/user contexts=].
-      
+
       1. Return.
 
 1. If |session|'s [=session stored configuration=]'s [=session stored configuration/user contexts=] does not
@@ -6078,22 +6084,22 @@ To <dfn export>store user context config</dfn> [=stored config=]'s [=struct/item
 
 <div algorithm>
 
-To <dfn export>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
+To <dfn>store navigable config</dfn> [=stored config=]'s [=struct/item=] |config item| |config| for
 |navigable| in [=BiDi session=] |session|:
 
 1. If |config| is null:
 
    1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] [=map/contains=]
       |navigable|:
-      
+
       1. Set |session|'s [=session stored configuration=]'s
          [=session stored configuration/navigables=][|navigable|]'s |config item| to null.
-   
+
       1. If |session|'s [=session stored configuration=]'s
          [=session stored configuration/navigables=][|navigable|] contains only nulls, remove
          |navigable| from |session|'s [=session stored configuration=]'s
          [=session stored configuration/navigables=].
-      
+
       1. Return.
 
 1. If |session|'s [=session stored configuration=]'s [=session stored configuration/navigables=] does not
@@ -7056,6 +7062,106 @@ The [=remote end steps=] with |command parameters| are:
 1. Return [=success=] with data null.
 
 </div>
+
+#### The emulation.SetScrollbarTypeOverride Command #### {#command-emulation-setScrollbarTypeOverride}
+
+The <dfn export for=commands>emulation.setScrollbarTypeOverride</dfn> command modifies
+scrollbar type on the given top-level traversables, user contexts or globally.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      emulation.SetScrollbarTypeOverride = (
+        method: "emulation.setScrollbarTypeOverride",
+        params: emulation.SetScrollbarTypeOverrideParameters
+      )
+
+      emulation.SetScrollbarTypeOverrideParameters = {
+        scrollbarType: "classic" / "overlay" / null,
+        ? contexts: [+browsingContext.BrowsingContext],
+        ? userContexts: [+browser.UserContext],
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="local-cddl">
+      emulation.SetScrollbarTypeOverrideResult = EmptyResult
+      </pre>
+   </dd>
+</dl>
+
+<div algorithm>
+To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
+
+1. Let |scrollbar type override| be the result of [=get stored config=] of [=stored config/scrollbar type=] for
+   |navigable|.
+
+1. Assert that |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or null.
+
+1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to make the
+   |navigable|'s [=active document=] to use <a>classic scrollbars</a>.
+
+1. Otherwise, if |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=] steps to
+   make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a>.
+
+1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
+   use an [=implementation-defined=] default scrollbar type.
+
+</div>
+
+<div algorithm="remote end steps for emulation.setScrollbarTypeOverride">
+
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |emulated scrollbar type| be |command parameters|["<code>scrollbarType</code>"].
+
+1. If the implementation does not support setting |emulated scrollbar type|, then return [=error=] with [=error code=]
+   [=unsupported operation=].
+
+1. If |command parameters| [=map/contains=] "<code>userContexts</code>"
+   and |command parameters| [=map/contains=] "<code>contexts</code>",
+   return [=error=] with [=error code=] [=invalid argument=].
+
+1. Let |affected navigables| be an empty [=/set=].
+
+1. If |command parameters| [=map/contains=] "<code>contexts</code>":
+
+   1. Let |navigables| be the result of [=trying=] to
+      [=get valid top-level traversables by ids=] with
+      |command parameters|["<code>contexts</code>"].
+
+   1. For each |navigable| of |navigables|:
+
+      1. [=set/Append=] |navigable| to |affected navigables|.
+
+      1. [=Store navigable config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |navigable|.
+
+1. Otherwise, if |command parameters| [=map/contains=] "<code>userContexts</code>":
+
+   1. Let |user contexts| be the result of [=trying=] to [=get valid user contexts=]
+      with |command parameters|["<code>userContexts</code>"].
+
+   1. For each |user context| of |user contexts|:
+
+      1. [=list/For each=] |top-level traversable| in the list of all [=/top-level traversables=]
+         whose [=associated user context=] is |user context|:
+
+         1. [=set/Append=] |top-level traversable| to |affected navigables|.
+
+      1. [=Store user context config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |user context|.
+
+1. Otherwise, [=store global config=] [=stored config/scrollbar type=] |emulated scrollbar type| for |session|.
+
+1. For each |navigable| of |affected navigables|:
+
+   1. [=Update scrollbar type override=] for |navigable|.
+
+1. Return [=success=] with data null.
+
+</div>
+
 
 #### The emulation.setTimezoneOverride Command ####  {#command-emulation-setTimezoneOverride}
 


### PR DESCRIPTION
Addressing https://github.com/w3c/webdriver-bidi/issues/1051 by introducing a new command `emulation.setTextLayoutModeOverride`. As [discussed](https://github.com/w3c/webdriver-bidi/issues/1051#issuecomment-3756361016), the command's effect is "implementation defined".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1072.html" title="Last updated on Feb 23, 2026, 12:34 PM UTC (4ff0fec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1072/a9b2e5b...4ff0fec.html" title="Last updated on Feb 23, 2026, 12:34 PM UTC (4ff0fec)">Diff</a>