### PR TITLE
Fix case for command parameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6361,10 +6361,10 @@ context.
     <pre class="cddl" data-cddl-module="remote-cddl">
       emulation.SetNetworkConditions = (
         method: "emulation.setNetworkConditions",
-        params: emulation.setNetworkConditionsParameters
+        params: emulation.SetNetworkConditionsParameters
       )
 
-      emulation.setNetworkConditionsParameters = {
+      emulation.SetNetworkConditionsParameters = {
         networkConditions: emulation.NetworkConditions / null,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
@@ -9424,10 +9424,10 @@ collected network data for a given [=network/collector=].
     <pre class="cddl" data-cddl-module="remote-cddl">
       network.DisownData = (
         method: "network.disownData",
-        params: network.disownDataParameters
+        params: network.DisownDataParameters
       )
 
-      network.disownDataParameters = {
+      network.DisownDataParameters = {
         dataType: network.DataType,
         collector: network.Collector,
         request: network.Request,


### PR DESCRIPTION
All command param names normally start with an uppercase letter except for those two.