### PR TITLE
Update request & response clone steps for fetch integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7359,10 +7359,7 @@ To <dfn>match collector for navigable</dfn> given |collector| and |navigable|:
 </div>
 
 <div algorithm>
-To <dfn export>clone network request body</dfn> given [=/request=] |request|:
-
-Note: This hook is intended to be triggered by the fetch spec when the request body has been safely extracted.
-See step 9 of https://fetch.spec.whatwg.org/#concept-fetch
+The <dfn export>WebDriver BiDi clone network request body</dfn> steps given [=/request=] |request| are:
 
 1. If |request|'s [=request/body=] is null, return.
 
@@ -7386,9 +7383,7 @@ See step 9 of https://fetch.spec.whatwg.org/#concept-fetch
 </div>
 
 <div algorithm>
-To <dfn export>clone network response body</dfn> given |request| and |response body|:
-
-Note: This hook is intended to be triggered by the fetch spec when the response is set.
+The <dfn export>WebDriver BiDi clone network response body</dfn> steps given |request| and |response body| are:
 
 1. If |response body| is null, return.
 
@@ -7444,7 +7439,7 @@ To <dfn>maybe collect network request body</dfn> given |request|:
 1. If |collected data| is null, return.
 
    NOTE: This might happen if there are no collectors setup when the request is created,
-   and [=clone network request body=] does not clone the corresponding body.
+   and [=WebDriver BiDi clone network request body=] does not clone the corresponding body.
    Or if the body was null in the first place.
 
 1. [=Maybe collect network data=] with |request|, |collected data|, null and "request".
@@ -7463,7 +7458,7 @@ To <dfn>maybe collect network response body</dfn> given |request| and |response|
 1. If |collected data| is null, return.
 
    NOTE: This might happen if there are no collectors setup when the response is created,
-   and [=clone network response body=] does not clone the corresponding body.
+   and [=WebDriver BiDi clone network response body=] does not clone the corresponding body.
    Or if the body was null in the first place.
 
 1. Let |size| be |response|'s [=response body info=]'s [=encoded size=].
@@ -10497,8 +10492,6 @@ given [=/request=] |request| and [=/response=] |response|:
    set.
 
 1. Let |response status| be "<code>incomplete</code>".
-
-1. [=Clone network response body=] with |request| and |response|.
 
 1. Let |sessions| be the [=set of sessions for which an event is enabled=]
    given "<code>network.responseStarted</code>" and |related navigables|.


### PR DESCRIPTION
This PR aligns the exported clone algorithms to be compatible with https://github.com/whatwg/fetch/pull/1860

It also removes the explicit call to `Clone network response body` as this is expected to be triggered by fetch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1078.html" title="Last updated on Feb 19, 2026, 6:48 PM UTC (dde3ea7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1078/fdf90f8...juliandescottes:dde3ea7.html" title="Last updated on Feb 19, 2026, 6:48 PM UTC (dde3ea7)">Diff</a>