### PR TITLE
fix link to convert-fetch-timestamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,7 +265,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     text: convert a JSON-derived JavaScript value to an Infra value; url: convert-a-json-derived-javascript-value-to-an-infra-value
 spec: RESOURCE-TIMING; urlPrefix: https://w3c.github.io/resource-timing/
   type: dfn
-    text: convert fetch timestamp; url: dfn-convert-fetch-timestamp
+    text: convert fetch timestamp; url: convert-fetch-timestamp
 spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
   type: dfn
     text: get time origin timestamp; url: dfn-get-time-origin-timestamp


### PR DESCRIPTION
Fixed #1082


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1083.html" title="Last updated on Feb 23, 2026, 10:49 AM UTC (9eac744)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1083/bf30ceb...juliandescottes:9eac744.html" title="Last updated on Feb 23, 2026, 10:49 AM UTC (9eac744)">Diff</a>