### PR TITLE
editorial: remove legacy "WebDriver BiDi download started"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5731,42 +5731,6 @@ The [=remote end event trigger=] is the
 
 </div>
 
-<div algorithm>
-The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download started</dfn> steps
-given [=/navigable=] |navigable| and [=WebDriver BiDi navigation status|navigation status=]
-|navigation status|:
-
-Issue: Remove after HTML spec switched to [=WebDriver BiDi download will begin=]
-(https://github.com/whatwg/html/pull/11474).
-
-1. Let |navigation info| be the result of [=get the navigation info=] given |navigable| and
-    |navigation status|.
-
-1. Let |params| be a [=/map=] matching the <code>browsingContext.DownloadWillBeginParams</code>
-   production, with the <code>context</code> field set to |navigation info|["<code>context</code>"],
-   the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"], the
-   <code>timestamp</code> field set to |navigation info|["<code>timestamp</code>"], the
-   <code>url</code> field set to |navigation info|["<code>url</code>"] and
-   <code>suggestedFilename</code> field set to |navigation status|'s
-   [=WebDriver BiDi navigation status/suggestedFilename=].
-
-1. Let |body| be a [=/map=] matching the
-   <code>browsingContext.DownloadWillBegin</code> production, with the
-   <code>params</code> field set to |params|.
-
-1. Let |navigation id| be |navigation status|'s [=WebDriver BiDi navigation status/id=].
-
-1. Let |related navigables| be a [=/set=] containing |navigable|.
-
-1. [=Resume=] with "<code>download started</code>", |navigation id|, and |navigation status|.
-
-1. For each |session| in the [=set of sessions for which an event is enabled=]
-   given "<code>browsingContext.downloadWillBegin</code>" and |related navigables|:
-
-  1. [=Emit an event=] with |session| and |body|.
-
-</div>
-
 #### The browsingContext.downloadEnd Event #### {#event-browsingContext-downloadEnd}
 
 <dl>


### PR DESCRIPTION
No need in it after the HTML spec PR https://github.com/whatwg/html/pull/11474 is landed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1084.html" title="Last updated on Feb 24, 2026, 10:03 AM UTC (e304b76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1084/a9b2e5b...e304b76.html" title="Last updated on Feb 24, 2026, 10:03 AM UTC (e304b76)">Diff</a>