### PR TITLE
Do not allow for forcing classic scrollbars

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,6 @@ spec: RFC4648; urlPrefix: https://datatracker.ietf.org/doc/html/rfc4648
     text: Base64 Encode; url: section-4
 spec: CSS-OVERFLOW-3; urlPrefix: https://drafts.csswg.org/css-overflow-3/
   type: dfn
-    text: classic scrollbars; url: #classic-scrollbars
     text: overlay scrollbars; url: #overlay-scrollbars
 spec: CSS-VALUES-3; urlPrefix: https://drafts.csswg.org/css-values-3/
   type: dfn
@@ -7021,7 +7020,7 @@ scrollbar type on the given top-level traversables, user contexts or globally.
       )
 
       emulation.SetScrollbarTypeOverrideParameters = {
-        scrollbarType: "classic" / "overlay" / null,
+        scrollbarType: "default" / "overlay" / null,
         ? contexts: [+browsingContext.BrowsingContext],
         ? userContexts: [+browser.UserContext],
       }
@@ -7044,18 +7043,13 @@ To <dfn>update scrollbar type override</dfn> for [=/navigable=] |navigable|:
 1. Let |scrollbar type override| be the result of [=get WebDriver configuration value=] of
    [=scrollbar type override configuration=] for |navigable|.
 
-1. Assert: |scrollbar type override| is "<code>classic</code>", "<code>overlay</code>" or
+1. Assert: |scrollbar type override| is "<code>default</code>", "<code>overlay</code>" or
    [=WebDriver configuration/unset=].
-
-1. If |scrollbar type override| is "<code>classic</code>", run [=implementation-defined=] steps to
-   make the |navigable|'s [=active document=] to use <a>classic scrollbars</a> and return.
 
 1. If |scrollbar type override| is "<code>overlay</code>", run [=implementation-defined=]
    steps to make the |navigable|'s [=active document=] to use <a>overlay scrollbars</a> and return.
 
-1. Assert: |scrollbar type override| is [=WebDriver configuration/unset=].
-
-1. Run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
+1. Otherwise, run [=implementation-defined=] steps to make the |navigable|'s [=active document=] to
    use an [=implementation-defined=] default scrollbar type.
 
 </div>


### PR DESCRIPTION
In some cases it is non-trivial and meaningless to try to emulate classic scrollbar. E.g. on mobile device, while forcing overlay scrollbar instead of the classic one is very common use-case. This PR restricts the emulation to only force using overlay scrollbars.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1087.html" title="Last updated on Feb 26, 2026, 2:18 PM UTC (1651933)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1087/4883e50...1651933.html" title="Last updated on Feb 26, 2026, 2:18 PM UTC (1651933)">Diff</a>