### PR TITLE
browsingContext.locateNodes should use the navigable's active document as default if no start nodes are specified

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4631,8 +4631,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |context nodes| be an empty [=/list=].
 
-1. If |start nodes parameter| is null, [=list/append=] the [=document element=]
-   of |navigable|'s [=active document=] to |context nodes|. Otherwise, for each
+1. If |start nodes parameter| is null, [=list/append=] the |navigable|'s
+   [=active document=] to |context nodes|. Otherwise, for each
    |serialized start node| in |start nodes parameter|:
 
    1. Let |start node| be the result of [=trying=] to [=deserialize shared reference=] given


### PR DESCRIPTION
Compared to WebDriver classic using the "browsingContext.locateNodes" command for BiDi to retrieve the HTML (documentElement) element of a page doesn't return any value. This is because [the WebDriver BiDi spec defaults to the documentElement](https://w3c.github.io/webdriver-bidi/#cddl-value-browsingcontextlocatenodes-method-browsingcontextlocatenodes:~:text=If%20start%20nodes%20parameter%20is%20null%2C%20append%20the%20document%20element) already in case no context node is specified.

To fix that we should default to the navigable's active document instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/1090.html" title="Last updated on Mar 3, 2026, 8:46 AM UTC (ef65889)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1090/e3c596d...whimboo:ef65889.html" title="Last updated on Mar 3, 2026, 8:46 AM UTC (ef65889)">Diff</a>