### PR TITLE
fix link to get-time-origin-timestamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -268,7 +268,7 @@ spec: RESOURCE-TIMING; urlPrefix: https://w3c.github.io/resource-timing/
     text: convert fetch timestamp; url: convert-fetch-timestamp
 spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
   type: dfn
-    text: get time origin timestamp; url: dfn-get-time-origin-timestamp
+    text: get time origin timestamp; url: get-time-origin-timestamp
 spec: RFC4648; urlPrefix: https://datatracker.ietf.org/doc/html/rfc4648
   type: dfn
     text: Base64 Encode; url: section-4


### PR DESCRIPTION
Fixes #1095


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1098.html" title="Last updated on Mar 9, 2026, 4:33 PM UTC (56ff731)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1098/43236c6...juliandescottes:56ff731.html" title="Last updated on Mar 9, 2026, 4:33 PM UTC (56ff731)">Diff</a>