### PR TITLE
Fix CDDL definition for input.PointerCommonProperties

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14464,15 +14464,15 @@ Note: for a detailed description of the behavior of this command, see the
       }
 
       input.PointerCommonProperties = (
-        ? width: js-uint .default 1,
-        ? height: js-uint .default 1,
-        ? pressure: float .default 0.0,
-        ? tangentialPressure: float .default 0.0,
-        ? twist: (0..359) .default 0,
+        ? width: js-uint,
+        ? height: js-uint,
+        ? pressure: (0.0..1.0),
+        ? tangentialPressure: (-1.0..1.0),
+        ? twist: (0..359),
         ; 0 .. Math.PI / 2
-        ? altitudeAngle: (0.0..1.5707963267948966) .default 0.0,
+        ? altitudeAngle: (0.0..1.5707963267948966),
         ; 0 .. 2 * Math.PI
-        ? azimuthAngle: (0.0..6.283185307179586) .default 0.0,
+        ? azimuthAngle: (0.0..6.283185307179586),
       )
 
       input.Origin = "viewport" / "pointer" / input.ElementOrigin


### PR DESCRIPTION
Based on the [pointerevents specification](https://www.w3.org/TR/pointerevents3/#pointerevent-interface) the platform already defines defaults which we should not override with WebDriver, eg. altitudeAngle has a default of Pi/2 while BiDi overrides it with 0.

Further as well define ranges for pressure and tangentialPressure to better indicate the lower and upper bounds.

@jgraham would you mind reviewing the PR? Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/1100.html" title="Last updated on Mar 12, 2026, 3:52 PM UTC (744bf53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1100/e40b28a...whimboo:744bf53.html" title="Last updated on Mar 12, 2026, 3:52 PM UTC (744bf53)">Diff</a>