### PR TITLE
fix: `InputResult` is needed in `local.cddl` not in `remote.cddl`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14265,7 +14265,7 @@ InputCommand = (
 )
 </pre>
 
-<pre class="cddl" data-cddl-module="remote-cddl">
+<pre class="cddl" data-cddl-module="local-cddl">
 InputResult = (
   input.PerformActionsResult /
   input.ReleaseActionsResult /


### PR DESCRIPTION
`InputResult` is missing from `local.cddl` as point-out in the issue.

Fixes https://github.com/w3c/webdriver-bidi/issues/1101


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dprevost-LMI/webdriver-bidi/pull/1102.html" title="Last updated on Mar 16, 2026, 1:27 PM UTC (8f6b1ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1102/e40b28a...dprevost-LMI:8f6b1ca.html" title="Last updated on Mar 16, 2026, 1:27 PM UTC (8f6b1ca)">Diff</a>