### PR TITLE
fix: `input.FileDialogOpened` is only reference in local so not needed in remote

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14666,7 +14666,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 <dl>
    <dt>Event Type</dt>
    <dd>
-      <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
+      <pre class="cddl" data-cddl-module="local-cddl">
          input.FileDialogOpened = (
             method: "input.fileDialogOpened",
             params: input.FileDialogInfo


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver-bidi/issues/1103, by not rendering `input.FileDialogOpened` in `remote.cddl`since it is only used in `local.cddl`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dprevost-LMI/webdriver-bidi/pull/1104.html" title="Last updated on Mar 17, 2026, 2:58 AM UTC (620212d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1104/5182367...dprevost-LMI:620212d.html" title="Last updated on Mar 17, 2026, 2:58 AM UTC (620212d)">Diff</a>