### PR TITLE
feat: add accuracyMode to emulation.setGeolocationOverride

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6288,6 +6288,7 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
          latitude: -90.0..90.0,
          longitude: -180.0..180.0,
          ? accuracy: (float .ge 0.0) .default 1.0,
+         ? accuracyMode: "approximate" / "precise",
          ? altitude: float / null .default null,
          ? altitudeAccuracy: (float .ge 0.0) / null .default null,
          ? heading: (0.0...360.0) / null .default null,
@@ -6307,14 +6308,7 @@ The <dfn export for=commands>emulation.setGeolocationOverride</dfn> command modi
    </dd>
 </dl>
 
-A <dfn>geolocation override</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn attribute for="geolocation override">latitude</dfn> which is a float;
-* [=struct/item=] named <dfn attribute for="geolocation override">longitude</dfn> which is a float;
-* [=struct/item=] named <dfn attribute for="geolocation override">accuracy</dfn> which is a float;
-* [=struct/item=] named <dfn attribute for="geolocation override">altitude</dfn> which is a float or null;
-* [=struct/item=] named <dfn attribute for="geolocation override">altitudeAccuracy</dfn> which is a float or null;
-* [=struct/item=] named <dfn attribute for="geolocation override">heading</dfn> which is a float or null;
-* [=struct/item=] named <dfn attribute for="geolocation override">speed</dfn> which is a float or null.
+A <dfn>geolocation override</dfn> is a [=/map=].
 
 A [=remote end=] has a <dfn>geolocation override configuration</dfn>, which is
 [=WebDriver configuration=] with [=WebDriver configuration/associated type=] [=geolocation override=].
@@ -6336,28 +6330,35 @@ To <dfn>update geolocation override</dfn> for [=/navigable=] |navigable|:
 
 The [=remote end steps=] with |command parameters| are:
 
-1. If |command parameters| [=map/contains=] "<code>coordinates</code>" and
-   |command parameters|["<code>coordinates</code>"] [=map/contains=]
-   "<code>altitudeAccuracy</code>" and
-   |command parameters|["<code>coordinates</code>"] doesn't [=map/contain=]
-   "<code>altitude</code>", return [=error=] with [=error code=]
-   [=invalid argument=].
+1. Let |emulated position data| be [=WebDriver configuration/unset=].
 
 1. If |command parameters| [=map/contains=] "<code>error</code>":
 
    1. Assert |command parameters|["<code>error</code>"]["<code>type</code>"] equals
       "<code>positionUnavailable</code>".
 
-   1. Let |emulated position data| be a [=/map=] matching [=GeolocationPositionError=]
-      production, with <code>code</code> field set to [=POSITION_UNAVAILABLE=] and
-      <code>message</code> field set to the empty string.
+   1. Set |emulated position data| to a new [=/map=].
 
-      Note: <code>message</code> will be ignored by implementation according to the geolocation spec.
+   1. [=map/set|Set=] |emulated position data|["<code>error</code>"] to
+      |command parameters|["<code>error</code>"].
 
-1. Otherwise, let |emulated position data| be |command parameters|["<code>coordinates</code>"].
+1. Otherwise, if |command parameters| [=map/contains=] "<code>coordinates</code>":
 
-1. If |emulated position data| is null, set |emulated position data| to
-   [=WebDriver configuration/unset=].
+   1. If |command parameters|["<code>coordinates</code>"] is not null:
+
+      1. Assert |command parameters|["<code>coordinates</code>"] [=map/contains=]
+         "<code>latitude</code>" and |command parameters|["<code>coordinates</code>"]
+         [=map/contains=] "<code>longitude</code>".
+
+      1. If |command parameters|["<code>coordinates</code>"] [=map/contains=] "<code>accuracyMode</code>":
+
+         1. Assert |command parameters|["<code>coordinates</code>"]["<code>accuracyMode</code>"] is "<code>precise</code>"
+            or "<code>approximate</code>".
+
+      1. Set |emulated position data| to a new [=/map=].
+
+      1. [=map/set|Set=] |emulated position data|["<code>coordinates</code>"] to
+         |command parameters|["<code>coordinates</code>"].
 
 1. Let |affected navigables| be the result of [=trying=] to [=store WebDriver configuration=]
    [=geolocation override configuration=] |emulated position data| for |command parameters|.


### PR DESCRIPTION
This pull request adds an optional `accuracyMode` parameter to the `emulation.setGeolocationOverride` command.

This aligns WebDriver BiDi with the upcoming changes to the [W3C Geolocation API](https://github.com/w3c/geolocation/pull/195), which introduces support for approximate geolocation via the `accuracyMode` attribute on the `GeolocationPosition` interface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alvinjiooo/webdriver-bidi/pull/1105.html" title="Last updated on Apr 13, 2026, 7:27 AM UTC (b9a46f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1105/0e36053...alvinjiooo:b9a46f8.html" title="Last updated on Apr 13, 2026, 7:27 AM UTC (b9a46f8)">Diff</a>