### PR TITLE
Add link to Digital Credentials API testing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14995,23 +14995,6 @@ Note: the list is not exhaustive and might not be up to date.
 
 The following external specifications define additional WebDriver BiDi modules:
 
-1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>
-
-1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
-
-1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
-
-1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>
-
-1. <a href="https://www.w3.org/TR/digital-credentials/#automated-testing">Digital Credentials API</a>
-
-1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>
-
-1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
-
-1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
-
-
 1. <a href="https://www.w3.org/TR/digital-credentials/#automated-testing">Digital Credentials API</a>
 
 1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>

--- a/index.bs
+++ b/index.bs
@@ -15004,3 +15004,11 @@ The following external specifications define additional WebDriver BiDi modules:
 1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>
 
 1. <a href="https://www.w3.org/TR/digital-credentials/#automated-testing">Digital Credentials API</a>
+
+1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>
+
+1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
+
+1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
+
+1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>

--- a/index.bs
+++ b/index.bs
@@ -15011,4 +15011,13 @@ The following external specifications define additional WebDriver BiDi modules:
 
 1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
 
+
+1. <a href="https://www.w3.org/TR/digital-credentials/#automated-testing">Digital Credentials API</a>
+
+1. <a href="https://www.w3.org/TR/permissions/#automation-webdriver-bidi">Permissions</a>
+
+1. <a href="https://wicg.github.io/nav-speculation/prefetch.html#automated-testing">nav-speculation</a>
+
+1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
+
 1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>

--- a/index.bs
+++ b/index.bs
@@ -15002,3 +15002,5 @@ The following external specifications define additional WebDriver BiDi modules:
 1. <a href="https://wicg.github.io/ua-client-hints/#automation">User-Agent Client Hints</a>
 
 1. <a href="https://webbluetoothcg.github.io/web-bluetooth/#automated-testing">Web Bluetooth</a>
+
+1. <a href="https://www.w3.org/TR/digital-credentials/#automated-testing">Digital Credentials API</a>


### PR DESCRIPTION
Digital Credentials API WebDrive BiDi support is being added in https://github.com/w3c-fedid/digital-credentials/pull/381

This PR add it to the list of external specifications defining WebDriver BiDi modules.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mohamedamir/webdriver-bidi/pull/1107.html" title="Last updated on Mar 25, 2026, 11:38 AM UTC (75babfd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1107/0e36053...mohamedamir:75babfd.html" title="Last updated on Mar 25, 2026, 11:38 AM UTC (75babfd)">Diff</a>