### PR TITLE
Alternaitve proposal for screencasting commands without JS primitives

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3258,7 +3258,7 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
 an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
 an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>recordedChunks</code>, which is a list,
+an [=struct/item=] named <code>recordedChunks</code>, which is a [=/list=] of {{BlobEvent/data}},
 an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}

--- a/index.bs
+++ b/index.bs
@@ -3262,11 +3262,11 @@ map between [=/navigables=] or [=user context|user contexts=] and boolean.
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
-an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
-an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>path</code>, which is a string,
-an [=struct/item=] named <code>size</code>, which is a number,
-an [=struct/item=] named <code>context</code>, which is a navigable.
+an [=struct/item=] named <dfn attribute for="screencast recordings map">mediaRecorder</dfn>, which is a {{MediaRecorder}},
+an [=struct/item=] named <dfn attribute for="screencast recordings map">mimeType</dfn>, which is a string,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">path</dfn>, which is a string,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">size</dfn>, which is a number,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">context</dfn>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
 

--- a/index.bs
+++ b/index.bs
@@ -329,9 +329,9 @@ spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
     text: is type supported; url: #abstract-opdef-is-type-supported
     text: MediaRecorder; url: #mediarecorder-api
     text: MediaRecorderOptions; url: #mediarecorderoptions-section
-spec: MEDIACAPTURE-SCREEN-SHARE; urlPrefix: https://w3c.github.io/mediacapture-screen-share/
+spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
-    text: capture a browser tab; url: #dfn-capture-a-browser-tab
+    text: capture a browsing context viewport; url: #dfn-capture-a-browsing-context-viewport
 spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
@@ -5179,7 +5179,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
    with |navigable id| and null.
 
-1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
+1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
 1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).

--- a/index.bs
+++ b/index.bs
@@ -3258,7 +3258,8 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
 an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
 an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>recordedChunks</code>, which is a [=/list=] of {{BlobEvent/data}},
+an [=struct/item=] named <code>path</code>, which is a string,
+an [=struct/item=] named <code>size</code>, which is a number,
 an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
@@ -5149,7 +5150,8 @@ starts the screencast of a given navigable according to provided options.
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StartScreencastResult = {
-         screencast: browsingContext.Screencast
+         screencast: browsingContext.Screencast,
+         path: text
       }
 
       browsingContext.Screencast = text
@@ -5184,7 +5186,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
-1. Let |recorded chunks| be an empty [=/list=].
+1. Let |path| be an implementation-defined file path where the recording will be stored.
 
 1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
 
@@ -5192,25 +5194,33 @@ The [=remote end steps=] with |command parameters| are:
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
+1. Let |recording| be a new [=struct=] with
+   <code>mediaRecorder</code> |media recorder|,
+   <code>mimeType</code> |mime type|,
+   <code>path</code> |path|,
+   <code>size</code> 0,
+   <code>context</code> |navigable|.
+
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
 
    1. Let |data| be |event|'s {{BlobEvent/data}}.
 
-   1. [=list/Append=] |data| to |recorded chunks|.
+   1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-1. Call {{MediaRecorder/start()}} on |media recorder|.
+   1. Append |bytes| to the file at |path|.
+
+   1. Set |recording|["<code>size</code>"] to |recording|["<code>size</code>"] + |bytes|'s length.
+
+1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
-1. Set [=screencast recordings map=][|screencast|] to a struct with
-   <code>mediaRecorder</code> |media recorder|,
-   <code>mimeType</code> |mime type|,
-   <code>recordedChunks</code> |recorded chunks|,
-   <code>context</code> |navigable|.
+1. Set [=screencast recordings map=][|screencast|] to |recording|.
 
 1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
-   with the <code>screencast</code> field set to |screencast|.
+   with the <code>screencast</code> field set to |screencast| and <code>path</code> field
+   set to |path|.
 
 </div>
 
@@ -5257,32 +5267,18 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
 
-1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
-
-1. Let |navigable id| be the [=navigable id=] for |screencast recording|["<code>navigable</code>"].
-
-1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
-   with |navigable id| and null.
+1. Let |path| be |screencast recording|["<code>path</code>"].
 
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
-1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
-
-1. Let |blob| to be a new {{Blob}} in |realm| with {{blobParts}} |recorded chunks| and
-   {{BlobPropertyBag}} |blob options|.
-
-1. Let |path| be an implementation-defined file path where the recording will be stored.
-
-1. Let |bytes| be |blob|'s underlying [=byte sequence=].
-
-1. Write |bytes| to the file system at |path|.
+1. Let |size| be |screencast recording|["<code>size</code>"].
 
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 
 1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path| and <code>size</code> field set to |blob|'s {{Blob/size}}.
+   with the <code>path</code> field set to |path| and <code>size</code> field set to |size|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5237,7 +5237,8 @@ stops the screencast.
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StopScreencastResult = {
-         path: text
+         path: text,
+         size: js-uint
       }
     </pre>
    </dd>
@@ -5281,7 +5282,7 @@ The [=remote end steps=] with |command parameters| are:
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 
 1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path|.
+   with the <code>path</code> field set to |path| and <code>size</code> field set to |blob|'s {{Blob/size}}.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5143,7 +5143,6 @@ starts the screencast of a given navigable according to provided options.
          ? height: js-uint,
          ? aspectRatio: js-uint,
          ? frameRate: js-uint,
-         ? facingMode: text,
          ? resizeMode: text,
          ? sampleRate: js-uint,
          ? sampleSize: js-uint,
@@ -5154,7 +5153,6 @@ starts the screencast of a given navigable according to provided options.
          ? channelCount: js-uint,
          ? deviceId: text,
          ? groupId: text,
-         ? backgroundBlur: bool
       }
 
       </pre>

--- a/index.bs
+++ b/index.bs
@@ -289,12 +289,17 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
     text: web-exposed screen area; url: #web-exposed-screen-area
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
+    text: add an event listener; url: #add-an-event-listener
     text: root; url: #concept-tree-root
     text: document element; url: #ref-for-dom-document-documentelement
     text: evaluate; url: #dom-xpathevaluatorbase-evaluate
     text: nodes; url: #concept-node
     text: ORDERED_NODE_SNAPSHOT_TYPE; url: #dom-xpathresult-ordered_node_snapshot_type
     text: snapshotItem; url: #dom-xpathresult-snapshotitem
+spec: FILE-API; urlPrefix: https://w3c.github.io/FileAPI/
+  type: dfn
+    text: Blob; url: #dfn-Blob
+    text: blobParts; url: #dfn-blobParts
 spec: FULLSCREEN; urlPrefix: https://fullscreen.spec.whatwg.org/
   type: dfn
     text: fullscreen an element; url: #fullscreen-an-element
@@ -319,6 +324,14 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
     text: computed role; url: /#roleMappingComputedRole
+spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
+  type: dfn
+    text: is type supported; url: #abstract-opdef-is-type-supported
+    text: MediaRecorder; url: #mediarecorder-api
+    text: MediaRecorderOptions; url: #mediarecorderoptions-section
+spec: MEDIACAPTURE-SCREEN-SHARE; urlPrefix: https://w3c.github.io/mediacapture-screen-share/
+  type: dfn
+    text: capture a browser tab; url: #dfn-capture-a-browser-tab
 spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
@@ -670,6 +683,9 @@ with the following additional codes:
 
   <dt><dfn for=errors export>no such request</dfn>
   <dd>Tried to continue an unknown [=/request=].
+
+  <dt><dfn for=errors export>no such screencast</dfn>
+  <dd>Tried to stop an unknown screencast recording.
 
   <dt><dfn for=errors export>no such script</dfn>
   <dd>Tried to remove an unknown [=preload script=].
@@ -3146,6 +3162,8 @@ BrowsingContextCommand = (
   browsingContext.Print //
   browsingContext.Reload //
   browsingContext.SetViewport //
+  browsingContext.StartScreencast //
+  browsingContext.StopScreencast //
   browsingContext.TraverseHistory
 )
 </pre>
@@ -3165,6 +3183,8 @@ BrowsingContextResult = (
   browsingContext.PrintResult /
   browsingContext.ReloadResult /
   browsingContext.SetViewportResult /
+  browsingContext.StartScreencastResult /
+  browsingContext.StopScreencastResult /
   browsingContext.TraverseHistoryResult
 )
 
@@ -3233,6 +3253,13 @@ weak map between [=user context|user contexts=] and [=unhandled prompt behavior 
 
 A [=remote end=] has a <dfn>scripting enabled overrides map</dfn> which is a weak
 map between [=/navigables=] or [=user context|user contexts=] and boolean.
+
+A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
+which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
+an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
+an [=struct/item=] named <code>mimeType</code>, which is a string,
+an [=struct/item=] named <code>recordedChunks</code>, which is a list,
+an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5083,6 +5110,179 @@ The [=remote end steps=] with |command parameters| are:
          1. [=Set device pixel ratio override=] with |navigable| and |device pixel ratio|.
 
 1. Return [=success=] with data null.
+
+</div>
+
+#### The browsingContext.startScreencast Command ####  {#command-browsingContext-startScreencast}
+
+The <dfn export for=commands>browsingContext.startScreencast</dfn> command
+starts the screencast of a given navigable according to provided options.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="remote-cddl">
+      browsingContext.StartScreencast = (
+        method: "browsingContext.startScreencast",
+        params: browsingContext.StartScreencastParameters
+      )
+
+      browsingContext.StartScreencastParameters = {
+        context: browsingContext.BrowsingContext,
+        mimeType: text,
+        ? streamOptions: browsingContext.MediaStreamOptions,
+      }
+
+      browsingContext.MediaStreamOptions = {
+         ? video: bool / browsingContext.MediaTrackConstraints .default true;
+         ? audio: bool / browsingContext.MediaTrackConstraints .default false;
+      }
+
+      browsingContext.MediaTrackConstraints = {
+         ? width: js-uint,
+         ? height: js-uint,
+         ? aspectRatio: js-uint,
+         ? frameRate: js-uint,
+         ? facingMode: text,
+         ? resizeMode: text,
+         ? sampleRate: js-uint,
+         ? sampleSize: js-uint,
+         ? echoCancellation: bool / text,
+         ? autoGainControl: bool,
+         ? noiseSuppression: bool,
+         ? latency: js-uint,
+         ? channelCount: js-uint,
+         ? deviceId: text,
+         ? groupId: text,
+         ? backgroundBlur: bool
+      }
+
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      browsingContext.StartScreencastResult = {
+         screencast: browsingContext.Screencast
+      }
+
+      browsingContext.Screencast = text
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.startScreencast">
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
+   with |command parameters|["<code>context</code>"].
+
+1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
+   [=error code=] [=invalid argument=].
+
+1. Let |mime type| to be |command parameters|["<code>mimeType</code>"].
+
+1. If [=is type supported=] with |mime type| returns false, return [=error=] with
+   [=error code=] [=invalid argument=].
+
+1. If the implementation is unable to record a screencast of |navigable| for any
+   reason then return [=error=] with [=error code=] [=unsupported operation=].
+
+1. Let |media stream| be the result of [=trying=] to [=capture a browser tab=] with
+   |navigable| and |command parameters|["<code>streamOptions</code>"].
+
+1. Let |recorded chunks| be an empty [=/list=].
+
+1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
+
+1. Let |media recorder| be a new {{MediaRecorder}} with {{MediaRecorder/stream}} |media stream| and
+   {{MediaRecorderOptions}} |media recorder options|.
+
+1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
+   and callback that performs the following steps given |event|:
+
+   1. Let |data| be |event|'s {{BlobEvent/data}}.
+
+   1. [=list/Append=] |data| to |recorded chunks|.
+
+1. Call {{MediaRecorder/start()}} on |media recorder|.
+
+1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+1. Set [=screencast recordings map=][|screencast|] to a struct with
+   <code>mediaRecorder</code> |media recorder|,
+   <code>mimeType</code> |mime type|,
+   <code>recordedChunks</code> |recorded chunks|,
+   <code>context</code> |navigable|.
+
+1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
+   with the <code>screencast</code> field set to |screencast|.
+
+</div>
+
+#### The browsingContext.stopScreencast Command ####  {#command-browsingContext-stopScreencast}
+
+The <dfn export for=commands>browsingContext.stopScreencast</dfn> command
+stops the screencast.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="remote-cddl">
+      browsingContext.StopScreencast = (
+        method: "browsingContext.stopScreencast",
+        params: browsingContext.StopScreencastParameters
+      )
+
+      browsingContext.StopScreencastParameters = {
+        screencast: browsingContext.Screencast
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      browsingContext.StopScreencastResult = {
+         path: text
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.stopScreencast">
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |screencast| be the value of the "<code>screencast</code>" field in |command
+   parameters|.
+
+1. If [=screencast recordings map=] does not <a for=map>contain</a> |screencast|, return
+   [=error=] with [=error code=] [=no such screencast=].
+
+1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
+
+1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+
+1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
+
+1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
+1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
+
+1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
+
+1. Let |blob| to be a new {{Blob}} with {{blobParts}} |recorded chunks| and
+   {{BlobPropertyBag}} |blob options|.
+
+1. Let |path| be an implementation-defined file path where the recording will be stored.
+
+1. Let |bytes| be |blob|'s underlying [=byte sequence=].
+
+1. Write |bytes| to the file system at |path|.
+
+1. [=map/Remove=] |screencast| from [=screencast recordings map=].
+
+1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+   with the <code>path</code> field set to |path|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5188,8 +5188,10 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let |media stream| be the result of [=trying=] to [=capture a browser tab=] with
+1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
+
+1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
 1. Let |recorded chunks| be an empty [=/list=].
 

--- a/index.bs
+++ b/index.bs
@@ -3261,12 +3261,10 @@ A [=remote end=] has a <dfn>scripting enabled overrides map</dfn> which is a wea
 map between [=/navigables=] or [=user context|user contexts=] and boolean.
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
-which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
-an [=struct/item=] named <dfn attribute for="screencast recordings map">mediaRecorder</dfn>, which is a {{MediaRecorder}},
-an [=struct/item=] named <dfn attribute for="screencast recordings map">mimeType</dfn>, which is a string,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">path</dfn>, which is a string,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">size</dfn>, which is a number,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">context</dfn>, which is a navigable.
+which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>, which is a [=struct=] with
+an [=struct/item=] named <dfn for="screencast recording">mediaRecorder</dfn>, which is a {{MediaRecorder}},
+an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
+an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5200,12 +5198,10 @@ The [=remote end steps=] with |command parameters| are:
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
-1. Let |recording| be a new [=struct=] with
+1. Let |recording| be a new [=screencast recording=] with
    <code>mediaRecorder</code> |media recorder|,
-   <code>mimeType</code> |mime type|,
    <code>path</code> |path|,
-   <code>size</code> 0,
-   <code>context</code> |navigable|.
+   <code>size</code> 0.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
@@ -5271,15 +5267,15 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
 
-1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+1. Let |media recorder| be |screencast recording|'s [=screencast recording/mediaRecorder=].
 
-1. Let |path| be |screencast recording|["<code>path</code>"].
+1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
-1. Let |size| be |screencast recording|["<code>size</code>"].
+1. Let |size| be |screencast recording|'s [=screencast recording/size=].
 
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 

--- a/index.bs
+++ b/index.bs
@@ -5168,7 +5168,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
    [=error code=] [=invalid argument=].
 
-1. Let |mime type| to be |command parameters|["<code>mimeType</code>"].
+1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
 
 1. If [=is type supported=] with |mime type| returns false, return [=error=] with
    [=error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5174,8 +5174,10 @@ starts the screencast of a given navigable according to provided options.
 <div algorithm="remote end steps for browsingContext.startScreencast">
 The [=remote end steps=] with |command parameters| are:
 
+1. Let |navigable id| be |command parameters|["<code>context</code>"].
+
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
-   with |command parameters|["<code>context</code>"].
+   with |navigable id|.
 
 1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
    [=error code=] [=invalid argument=].
@@ -5188,6 +5190,9 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
+1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
+   with |navigable id| and null.
+
 1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
@@ -5197,7 +5202,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
 
-1. Let |media recorder| be a new {{MediaRecorder}} with {{MediaRecorder/stream}} |media stream| and
+1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
+   with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
@@ -5266,13 +5272,18 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
 
+1. Let |navigable id| be the [=navigable id=] for |screencast recording|["<code>navigable</code>"].
+
+1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
+   with |navigable id| and null.
+
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
 1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
 
-1. Let |blob| to be a new {{Blob}} with {{blobParts}} |recorded chunks| and
+1. Let |blob| to be a new {{Blob}} in |realm| with {{blobParts}} |recorded chunks| and
    {{BlobPropertyBag}} |blob options|.
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.

--- a/index.bs
+++ b/index.bs
@@ -5135,24 +5135,12 @@ starts the screencast of a given navigable according to provided options.
 
       browsingContext.MediaStreamOptions = {
          ? video: bool / browsingContext.MediaTrackConstraints .default true;
-         ? audio: bool / browsingContext.MediaTrackConstraints .default false;
+         ? audio: bool .default false;
       }
 
       browsingContext.MediaTrackConstraints = {
          ? width: js-uint,
          ? height: js-uint,
-         ? aspectRatio: js-uint,
-         ? frameRate: js-uint,
-         ? resizeMode: text,
-         ? sampleRate: js-uint,
-         ? sampleSize: js-uint,
-         ? echoCancellation: bool / text,
-         ? autoGainControl: bool,
-         ? noiseSuppression: bool,
-         ? latency: js-uint,
-         ? channelCount: js-uint,
-         ? deviceId: text,
-         ? groupId: text,
       }
 
       </pre>

--- a/index.bs
+++ b/index.bs
@@ -5192,16 +5192,17 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
+1. Let |media recorder options| be a [=struct=] with an [=struct/item=] named <code>mimeType</code>
+   with the value |mime type|.
 
 1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
 1. Let |recording| be a new [=screencast recording=] with
-   <code>mediaRecorder</code> |media recorder|,
-   <code>path</code> |path|,
-   <code>size</code> 0.
+   [=screencast recording/mediaRecorder=] |media recorder|,
+   [=screencast recording/path=] |path|,
+   [=screencast recording/size=] 0.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
@@ -5212,7 +5213,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Append |bytes| to the file at |path|.
 
-   1. Set |recording|["<code>size</code>"] to |recording|["<code>size</code>"] + |bytes|'s length.
+   1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -1709,6 +1709,12 @@ To <dfn>cleanup the session</dfn> given |session|:
    1. For each |collected data| in [=collected network data=], [=remove collector from data=]
       with |collected data| and |collector id|.
 
+1. For each |screencast recording| in |session|'s [=screencast recordings map=]:
+
+   1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+
+   1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
 1. Perform any implementation-specific cleanup steps.

--- a/index.bs
+++ b/index.bs
@@ -3265,7 +3265,8 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>, which is a [=struct=] with
 an [=struct/item=] named <dfn for="screencast recording">mediaRecorder</dfn>, which is a {{MediaRecorder}},
 an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
-an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number.
+an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number,
+an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5213,9 +5214,14 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-   1. Append |bytes| to the file at |path|.
+   1. If appending |bytes| to the file at |path| fails:
 
-   1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
+      1. Set |recording|'s [=screencast recording/writeError=] to an
+         implementation-defined string describing the write failure.
+
+      1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
+   1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
 
@@ -5269,6 +5275,9 @@ The [=remote end steps=] with |command parameters| are:
    [=error=] with [=error code=] [=no such screencast=].
 
 1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
+
+1. If |screencast recording| contains [=screencast recording/writeError=], return
+   [=error=] with [=error code=] [=unknown error=].
 
 1. Let |media recorder| be |screencast recording|'s [=screencast recording/mediaRecorder=].
 

--- a/index.bs
+++ b/index.bs
@@ -5194,6 +5194,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] representing
    a specification execution environment.
 
+   Issue: The specification execution environment has to be better defined.
+
 1. [=Prepare to run script=] with |environment settings|.
 
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
@@ -5212,8 +5214,7 @@ The [=remote end steps=] with |command parameters| are:
 
       1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
-      1. Let |realm| be result of [=trying=] to [=get or create a sandbox realm=] given
-         |screencast| and |navigable|.
+      1. Let |realm| be |environment settings|' [=realm execution context=]'s Realm component.
 
       1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
          with {{MediaRecorder/stream}} |media stream| and

--- a/index.bs
+++ b/index.bs
@@ -5191,9 +5191,6 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
-   with |navigable id| and null.
-
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
@@ -5207,6 +5204,11 @@ The [=remote end steps=] with |command parameters| are:
 
       1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
          set to |mime type|.
+
+      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+      1. Let |realm| be result of [=trying=] to [=get or create a sandbox realm=] given
+         |screencast| and |navigable|.
 
       1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
          with {{MediaRecorder/stream}} |media stream| and
@@ -5232,8 +5234,6 @@ The [=remote end steps=] with |command parameters| are:
          1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
       1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
-
-      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
       1. Set [=screencast recordings map=][|screencast|] to |recording|.
 

--- a/index.bs
+++ b/index.bs
@@ -5195,8 +5195,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |media recorder options| be a [=struct=] with an [=struct/item=] named <code>mimeType</code>
-   with the value |mime type|.
+1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
+   set to |mime type|.
 
 1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
    with {{MediaRecorder/stream}} |media stream| and

--- a/index.bs
+++ b/index.bs
@@ -5191,10 +5191,15 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
+1. Let |environment settings| be the [=environment settings object=] representing
+   a specification execution environment.
+
+1. [=Prepare to run script=] with |environment settings|.
+
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
-1. [=React=] to promise:
+1. [=React=] to |promise|:
 
    1. If |promise| was rejected, return [=error=] with [=error code=] [=unknown error=].
 
@@ -5234,6 +5239,8 @@ The [=remote end steps=] with |command parameters| are:
          1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
       1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
+
+      1. [=Clean up after running script=] with |environment settings|.
 
       1. Set [=screencast recordings map=][|screencast|] to |recording|.
 

--- a/index.bs
+++ b/index.bs
@@ -1714,7 +1714,7 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
 
-   1. Call {{MediaRecorder/stop()}} on |media recorder|.
+   1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -5219,11 +5219,11 @@ The [=remote end steps=] with |command parameters| are:
       1. Set |recording|'s [=screencast recording/writeError=] to an
          implementation-defined string describing the write failure.
 
-      1. Call {{MediaRecorder/stop()}} on |media recorder|.
+      1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
    1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
+1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
@@ -5283,7 +5283,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. Call {{MediaRecorder/stop()}} on |media recorder|.
+1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 

--- a/index.bs
+++ b/index.bs
@@ -5137,6 +5137,7 @@ starts the screencast of a given navigable according to provided options.
         context: browsingContext.BrowsingContext,
         mimeType: text,
         ? streamOptions: browsingContext.MediaStreamOptions,
+        ? timeslice: js-uint .default 1000
       }
 
       browsingContext.MediaStreamOptions = {
@@ -5216,7 +5217,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
+1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 

--- a/index.bs
+++ b/index.bs
@@ -289,7 +289,6 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
     text: web-exposed screen area; url: #web-exposed-screen-area
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
-    text: add an event listener; url: #add-an-event-listener
     text: root; url: #concept-tree-root
     text: document element; url: #ref-for-dom-document-documentelement
     text: evaluate; url: #dom-xpathevaluatorbase-evaluate
@@ -327,6 +326,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
     text: is type supported; url: #abstract-opdef-is-type-supported
+    text: fire a blob event; url: #fire-a-blob-event
     text: MediaRecorder; url: #mediarecorder-api
     text: MediaRecorderOptions; url: #mediarecorderoptions-section
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
@@ -5212,12 +5212,10 @@ The [=remote end steps=] with |command parameters| are:
    [=screencast recording/path=] |path|,
    [=screencast recording/size=] 0.
 
-1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
-   and callback that performs the following steps given |event|:
+1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
+   at |media recorder| with |blob|, run the following steps:
 
-   1. Let |data| be |event|'s {{BlobEvent/data}}.
-
-   1. Let |bytes| be |data|'s underlying [=byte sequence=].
+   1. Let |bytes| be |blob|'s underlying [=byte sequence=].
 
    1. Append |bytes| to the file at |path|. If this fails:
 

--- a/index.bs
+++ b/index.bs
@@ -312,7 +312,8 @@ spec: SELECTORS4; urlPrefix: https://drafts.csswg.org/selectors-4/
 spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: DOMException; url: #idl-DOMException
-    text: SyntaxError; url:#syntaxerror
+    text: SyntaxError; url: #syntaxerror
+    text: react; url: #dfn-perform-steps-once-promise-is-settled
 spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
@@ -5196,45 +5197,49 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
-1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
+1. [=React=] to promise:
 
-1. Let |path| be an implementation-defined file path where the recording will be stored.
+   1. If |promise| was rejected, return [=error=] with [=error code=] [=unknown error=].
 
-1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
-   set to |mime type|.
+   1. If |promise| was fulfilled with value |media stream|, then:
 
-1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
-   with {{MediaRecorder/stream}} |media stream| and
-   {{MediaRecorderOptions}} |media recorder options|.
+      1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |recording| be a new [=screencast recording=] with
-   [=screencast recording/mediaRecorder=] |media recorder|,
-   [=screencast recording/path=] |path|,
-   [=screencast recording/size=] 0.
+      1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
+         set to |mime type|.
 
-1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
-   at |media recorder| with |blob|, run the following steps:
+      1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
+         with {{MediaRecorder/stream}} |media stream| and
+         {{MediaRecorderOptions}} |media recorder options|.
 
-   1. Let |bytes| be |blob|'s underlying [=byte sequence=].
+      1. Let |recording| be a new [=screencast recording=] with
+         [=screencast recording/mediaRecorder=] |media recorder|,
+         [=screencast recording/path=] |path|,
+         [=screencast recording/size=] 0.
 
-   1. Append |bytes| to the file at |path|. If this fails:
+      1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
+         at |media recorder| with |blob|, run the following steps:
 
-      1. Set |recording|'s [=screencast recording/writeError=] to an
-         implementation-defined string describing the write failure.
+         1. Let |bytes| be |blob|'s underlying [=byte sequence=].
 
-      1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
+         1. Append |bytes| to the file at |path|. If this fails:
 
-   1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
+            1. Set |recording|'s [=screencast recording/writeError=] to an
+               implementation-defined string describing the write failure.
 
-1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
+            1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
-1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+         1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Set [=screencast recordings map=][|screencast|] to |recording|.
+      1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
 
-1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
-   with the <code>screencast</code> field set to |screencast| and <code>path</code> field
-   set to |path|.
+      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+      1. Set [=screencast recordings map=][|screencast|] to |recording|.
+
+      1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
+         with the <code>screencast</code> field set to |screencast| and <code>path</code> field
+         set to |path|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5214,7 +5214,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-   1. If appending |bytes| to the file at |path| fails:
+   1. Append |bytes| to the file at |path|. If this fails:
 
       1. Set |recording|'s [=screencast recording/writeError=] to an
          implementation-defined string describing the write failure.

--- a/index.bs
+++ b/index.bs
@@ -732,6 +732,7 @@ ErrorCode = "invalid argument" /
             "no such network data" /
             "no such node" /
             "no such request" /
+            "no such screencast" /
             "no such script" /
             "no such storage partition" /
             "no such user context" /

--- a/index.bs
+++ b/index.bs
@@ -5123,7 +5123,12 @@ The [=remote end steps=] with |command parameters| are:
 #### The browsingContext.startScreencast Command ####  {#command-browsingContext-startScreencast}
 
 The <dfn export for=commands>browsingContext.startScreencast</dfn> command
-starts the screencast of a given navigable according to provided options.
+starts the screencast of a given navigable and writes it to a file.
+
+Note: The [=remote end=] creates and writes the screencast file, but does not delete it.
+Cleaning up the file is left to the [=local end=]. In some configurations this might not be
+possible — for example, if the [=remote end=] has read/write access to the filesystem but
+the [=local end=] has only read-only access.
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -860,6 +860,7 @@ ErrorCode = "invalid argument" /
             "no such network data" /
             "no such node" /
             "no such request" /
+            "no such screencast" /
             "no such script" /
             "no such storage partition" /
             "no such user context" /

--- a/index.bs
+++ b/index.bs
@@ -3398,12 +3398,10 @@ A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 [=response=] and download ids. It is initially empty.
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
-which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
-an [=struct/item=] named <dfn attribute for="screencast recordings map">mediaRecorder</dfn>, which is a {{MediaRecorder}},
-an [=struct/item=] named <dfn attribute for="screencast recordings map">mimeType</dfn>, which is a string,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">path</dfn>, which is a string,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">size</dfn>, which is a number,
-an [=struct/item=] named <dfn attribute for="screencast recordings map">context</dfn>, which is a navigable.
+which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>, which is a [=struct=] with
+an [=struct/item=] named <dfn for="screencast recording">mediaRecorder</dfn>, which is a {{MediaRecorder}},
+an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
+an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5416,12 +5414,10 @@ The [=remote end steps=] with |command parameters| are:
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
-1. Let |recording| be a new [=struct=] with
+1. Let |recording| be a new [=screencast recording=] with
    <code>mediaRecorder</code> |media recorder|,
-   <code>mimeType</code> |mime type|,
    <code>path</code> |path|,
-   <code>size</code> 0,
-   <code>context</code> |navigable|.
+   <code>size</code> 0.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
@@ -5487,15 +5483,15 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
 
-1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+1. Let |media recorder| be |screencast recording|'s [=screencast recording/mediaRecorder=].
 
-1. Let |path| be |screencast recording|["<code>path</code>"].
+1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
-1. Let |size| be |screencast recording|["<code>size</code>"].
+1. Let |size| be |screencast recording|'s [=screencast recording/size=].
 
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 

--- a/index.bs
+++ b/index.bs
@@ -5390,8 +5390,10 @@ starts the screencast of a given navigable according to provided options.
 <div algorithm="remote end steps for browsingContext.startScreencast">
 The [=remote end steps=] with |command parameters| are:
 
+1. Let |navigable id| be |command parameters|["<code>context</code>"].
+
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
-   with |command parameters|["<code>context</code>"].
+   with |navigable id|.
 
 1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
    [=error code=] [=invalid argument=].
@@ -5404,6 +5406,9 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
+1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
+   with |navigable id| and null.
+
 1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
@@ -5413,7 +5418,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
 
-1. Let |media recorder| be a new {{MediaRecorder}} with {{MediaRecorder/stream}} |media stream| and
+1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
+   with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
@@ -5482,13 +5488,18 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
 
+1. Let |navigable id| be the [=navigable id=] for |screencast recording|["<code>navigable</code>"].
+
+1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
+   with |navigable id| and null.
+
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
 1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
 
-1. Let |blob| to be a new {{Blob}} with {{blobParts}} |recorded chunks| and
+1. Let |blob| to be a new {{Blob}} in |realm| with {{blobParts}} |recorded chunks| and
    {{BlobPropertyBag}} |blob options|.
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.

--- a/index.bs
+++ b/index.bs
@@ -296,7 +296,6 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
     text: web-exposed screen area; url: #web-exposed-screen-area
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
-    text: add an event listener; url: #add-an-event-listener
     text: root; url: #concept-tree-root
     text: document element; url: #ref-for-dom-document-documentelement
     text: evaluate; url: #dom-xpathevaluatorbase-evaluate
@@ -334,6 +333,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
     text: is type supported; url: #abstract-opdef-is-type-supported
+    text: fire a blob event; url: #fire-a-blob-event
     text: MediaRecorder; url: #mediarecorder-api
     text: MediaRecorderOptions; url: #mediarecorderoptions-section
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
@@ -5428,12 +5428,10 @@ The [=remote end steps=] with |command parameters| are:
    [=screencast recording/path=] |path|,
    [=screencast recording/size=] 0.
 
-1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
-   and callback that performs the following steps given |event|:
+1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
+   at |media recorder| with |blob|, run the following steps:
 
-   1. Let |data| be |event|'s {{BlobEvent/data}}.
-
-   1. Let |bytes| be |data|'s underlying [=byte sequence=].
+   1. Let |bytes| be |blob|'s underlying [=byte sequence=].
 
    1. Append |bytes| to the file at |path|. If this fails:
 

--- a/index.bs
+++ b/index.bs
@@ -3395,7 +3395,7 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
 an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
 an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>recordedChunks</code>, which is a list,
+an [=struct/item=] named <code>recordedChunks</code>, which is a [=/list=] of {{BlobEvent/data}},
 an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}

--- a/index.bs
+++ b/index.bs
@@ -5411,8 +5411,8 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |media recorder options| be a [=struct=] with an [=struct/item=] named <code>mimeType</code>
-   with the value |mime type|.
+1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
+   set to |mime type|.
 
 1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
    with {{MediaRecorder/stream}} |media stream| and

--- a/index.bs
+++ b/index.bs
@@ -3395,7 +3395,8 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
 an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
 an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>recordedChunks</code>, which is a [=/list=] of {{BlobEvent/data}},
+an [=struct/item=] named <code>path</code>, which is a string,
+an [=struct/item=] named <code>size</code>, which is a number,
 an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
@@ -5365,7 +5366,8 @@ starts the screencast of a given navigable according to provided options.
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StartScreencastResult = {
-         screencast: browsingContext.Screencast
+         screencast: browsingContext.Screencast,
+         path: text
       }
 
       browsingContext.Screencast = text
@@ -5400,7 +5402,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
-1. Let |recorded chunks| be an empty [=/list=].
+1. Let |path| be an implementation-defined file path where the recording will be stored.
 
 1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
 
@@ -5408,25 +5410,33 @@ The [=remote end steps=] with |command parameters| are:
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
+1. Let |recording| be a new [=struct=] with
+   <code>mediaRecorder</code> |media recorder|,
+   <code>mimeType</code> |mime type|,
+   <code>path</code> |path|,
+   <code>size</code> 0,
+   <code>context</code> |navigable|.
+
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
 
    1. Let |data| be |event|'s {{BlobEvent/data}}.
 
-   1. [=list/Append=] |data| to |recorded chunks|.
+   1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-1. Call {{MediaRecorder/start()}} on |media recorder|.
+   1. Append |bytes| to the file at |path|.
+
+   1. Set |recording|["<code>size</code>"] to |recording|["<code>size</code>"] + |bytes|'s length.
+
+1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
-1. Set [=screencast recordings map=][|screencast|] to a struct with
-   <code>mediaRecorder</code> |media recorder|,
-   <code>mimeType</code> |mime type|,
-   <code>recordedChunks</code> |recorded chunks|,
-   <code>context</code> |navigable|.
+1. Set [=screencast recordings map=][|screencast|] to |recording|.
 
 1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
-   with the <code>screencast</code> field set to |screencast|.
+   with the <code>screencast</code> field set to |screencast| and <code>path</code> field
+   set to |path|.
 
 </div>
 
@@ -5473,32 +5483,18 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
 
-1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
-
-1. Let |navigable id| be the [=navigable id=] for |screencast recording|["<code>navigable</code>"].
-
-1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
-   with |navigable id| and null.
+1. Let |path| be |screencast recording|["<code>path</code>"].
 
 1. Call {{MediaRecorder/stop()}} on |media recorder|.
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 
-1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
-
-1. Let |blob| to be a new {{Blob}} in |realm| with {{blobParts}} |recorded chunks| and
-   {{BlobPropertyBag}} |blob options|.
-
-1. Let |path| be an implementation-defined file path where the recording will be stored.
-
-1. Let |bytes| be |blob|'s underlying [=byte sequence=].
-
-1. Write |bytes| to the file system at |path|.
+1. Let |size| be |screencast recording|["<code>size</code>"].
 
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 
 1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path| and <code>size</code> field set to |blob|'s {{Blob/size}}.
+   with the <code>path</code> field set to |path| and <code>size</code> field set to |size|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -328,6 +328,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
+    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn

--- a/index.bs
+++ b/index.bs
@@ -5403,8 +5403,8 @@ the [=local end=] has only read-only access.
       }
 
       browsingContext.MediaStreamOptions = {
-         ? video: browsingContext.MediaTrackConstraints;
-         ? audio: bool .default false;
+         ? video: browsingContext.MediaTrackConstraints,
+         ? audio: bool .default false,
       }
 
       browsingContext.MediaTrackConstraints = {

--- a/index.bs
+++ b/index.bs
@@ -5404,8 +5404,10 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let |media stream| be the result of [=trying=] to [=capture a browser tab=] with
+1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
+
+1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
 1. Let |recorded chunks| be an empty [=/list=].
 

--- a/index.bs
+++ b/index.bs
@@ -295,10 +295,6 @@ spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
     text: nodes; url: #concept-node
     text: ORDERED_NODE_SNAPSHOT_TYPE; url: #dom-xpathresult-ordered_node_snapshot_type
     text: snapshotItem; url: #dom-xpathresult-snapshotitem
-spec: FILE-API; urlPrefix: https://w3c.github.io/FileAPI/
-  type: dfn
-    text: Blob; url: #dfn-Blob
-    text: blobParts; url: #dfn-blobParts
 spec: FULLSCREEN; urlPrefix: https://fullscreen.spec.whatwg.org/
   type: dfn
     text: fullscreen an element; url: #fullscreen-an-element
@@ -313,7 +309,6 @@ spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: DOMException; url: #idl-DOMException
     text: SyntaxError; url: #syntaxerror
-    text: react; url: #dfn-perform-steps-once-promise-is-settled
 spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
@@ -326,10 +321,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
-    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
-    text: MediaRecorder; url: #mediarecorder-api
-    text: MediaRecorderOptions; url: #mediarecorderoptions-section
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
     text: capture a browsing context viewport; url: #dfn-capture-a-browsing-context-viewport

--- a/index.bs
+++ b/index.bs
@@ -336,9 +336,9 @@ spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
     text: is type supported; url: #abstract-opdef-is-type-supported
     text: MediaRecorder; url: #mediarecorder-api
     text: MediaRecorderOptions; url: #mediarecorderoptions-section
-spec: MEDIACAPTURE-SCREEN-SHARE; urlPrefix: https://w3c.github.io/mediacapture-screen-share/
+spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
-    text: capture a browser tab; url: #dfn-capture-a-browser-tab
+    text: capture a browsing context viewport; url: #dfn-capture-a-browsing-context-viewport
 spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
@@ -5395,7 +5395,7 @@ The [=remote end steps=] with |command parameters| are:
 1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
    with |navigable id| and null.
 
-1. Let |promise| be the result of [=trying=] to [=capture a browser tab=] with
+1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
 1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).

--- a/index.bs
+++ b/index.bs
@@ -5400,7 +5400,6 @@ the [=local end=] has only read-only access.
         context: browsingContext.BrowsingContext,
         mimeType: text,
         ? streamOptions: browsingContext.MediaStreamOptions,
-        ? timeslice: js-uint .default 1000
       }
 
       browsingContext.MediaStreamOptions = {
@@ -5494,7 +5493,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Set |session|'s [=screencast recordings map=][|screencast|] to |recording|.
 
-1. [=Start a screencast recording=] given |recording|, |mime type| and |command parameters|["<code>timeslice</code>"].
+1. Let |timeslice| be an implementation-defined value.
+
+1. [=Start a screencast recording=] given |recording|, |mime type| and |timeslice|.
 
 1. Let |body| be a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
    with the <code>screencast</code> field set to |screencast| and

--- a/index.bs
+++ b/index.bs
@@ -1831,9 +1831,6 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. [=Stop a screencast recording=] given |screencast recording|.
 
-   1. Wait until |screencast recording|'s [=screencast recording/state=] is
-      "<code>stopped</code>".
-
    1. [=map/Remove=] |screencast recording| from [=screencast recordings map=].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
@@ -3407,41 +3404,45 @@ an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a 
 an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string or null.
 
 <div algorithm>
-To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording|, |mime type|:
+To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording| and |mime type|:
 
-1. Begin encoding |recording|'s [=screencast recording/stream=] using |mime type|,
-   producing successive chunks of encoded data as [=byte sequences=].
-   Produce a new chunk at the implementation defined interaval while
-   |recording|'s [=screencast recording/state=] is "<code>recording</code>".
+1. Run the following steps [=in parallel=]:
 
-1. For each chunk |bytes| produced for |recording|, run the following steps:
+   1. Begin encoding |recording|'s [=screencast recording/stream=] using |mime type|,
+      producing successive chunks of encoded data as [=byte sequences=].
+      Produce a new chunk at the implementation defined interaval while
+      |recording|'s [=screencast recording/state=] is "<code>recording</code>".
 
-   1. Append |bytes| to the file at |recording|'s [=screencast recording/path=].
-      If this fails:
+   1. For each chunk |bytes| produced for |recording|, run the following steps:
 
-      1. Set |recording|'s [=screencast recording/writeError=] to an
-         implementation-defined string describing the write failure.
+      1. Append |bytes| to the file at |recording|'s [=screencast recording/path=].
+         If this fails:
 
-      1. [=Stop a screencast recording=] given |recording|.
+         1. Set |recording|'s [=screencast recording/writeError=] to an
+            implementation-defined string describing the write failure.
 
-   1. Otherwise, set |recording|'s [=screencast recording/size=] to
-      |recording|'s [=screencast recording/size=] + |bytes|'s length.
+         1. [=Stop a screencast recording=] given |recording|.
+
+      1. Otherwise, set |recording|'s [=screencast recording/size=] to
+         |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 </div>
 
 <div algorithm>
 To <dfn>stop a screencast recording</dfn> given a [=screencast recording=] |recording|:
 
-1. If |recording|'s [=screencast recording/state=] is "<code>recording</code>":
+1. If |recording|'s [=screencast recording/state=] is not "<code>recording</code>" then return.
 
-   1. Set |recording|'s [=screencast recording/state=] to "<code>stopping</code>".
+1. Set |recording|'s [=screencast recording/state=] to "<code>stopping</code>".
 
-   1. Stop producing new chunks for |recording|, flush any remaining encoded
-      data as a final chunk (processed as in [=start a screencast recording=]),
-      stop capturing from |recording|'s [=screencast recording/stream=] and release its
-      [=screencast stream/video track=] and, if present, its
-      [=screencast stream/audio track=], and then set |recording|'s
-      [=screencast recording/state=] to "<code>stopped</code>".
+1. Stop producing new chunks for |recording|, flush any remaining encoded
+   data as a final chunk (processed as in [=start a screencast recording=]),
+   stop capturing from |recording|'s [=screencast recording/stream=] and release its
+   [=screencast stream/video track=] and, if present, its
+   [=screencast stream/audio track=], and then set |recording|'s
+   [=screencast recording/state=] to "<code>stopped</code>".
+
+1. Wait until |recording|'s [=screencast recording/state=] is "<code>stopped</code>".
 
 </div>
 
@@ -5537,7 +5538,8 @@ stops the screencast.
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StopScreencastResult = {
          path: text,
-         size: js-uint
+         size: js-uint,
+         ? error: text
       }
     </pre>
    </dd>
@@ -5555,9 +5557,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |screencast recording| be |session|'s [=screencast recordings map=][|screencast|].
 
 1. [=Stop a screencast recording=] given |screencast recording|.
-
-1. Wait until |screencast recording|'s [=screencast recording/state=] is
-   "<code>stopped</code>".
 
 1. [=map/Remove=] |screencast| from |session|'s [=screencast recordings map=].
 

--- a/index.bs
+++ b/index.bs
@@ -3392,7 +3392,7 @@ A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 
 A <dfn>screencast stream</dfn> is an abstract stream of the viewport of a
 [=/top-level traversable=], consisting of a <dfn for="screencast stream">video track</dfn>
-containing the rendered visual output of the top-level document's viewport,
+containing the rendered visual output of the [=/top-level traversable=]'s document's viewport,
 and optionally an <dfn for="screencast stream">audio track</dfn> containing the audio output of the viewport.
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in

--- a/index.bs
+++ b/index.bs
@@ -3402,7 +3402,8 @@ A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=
 which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>, which is a [=struct=] with
 an [=struct/item=] named <dfn for="screencast recording">mediaRecorder</dfn>, which is a {{MediaRecorder}},
 an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
-an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number.
+an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number,
+an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5429,9 +5430,14 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-   1. Append |bytes| to the file at |path|.
+   1. If appending |bytes| to the file at |path| fails:
 
-   1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
+      1. Set |recording|'s [=screencast recording/writeError=] to an
+         implementation-defined string describing the write failure.
+
+      1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
+   1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
 
@@ -5485,6 +5491,9 @@ The [=remote end steps=] with |command parameters| are:
    [=error=] with [=error code=] [=no such screencast=].
 
 1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
+
+1. If |screencast recording| contains [=screencast recording/writeError=], return
+   [=error=] with [=error code=] [=unknown error=].
 
 1. Let |media recorder| be |screencast recording|'s [=screencast recording/mediaRecorder=].
 

--- a/index.bs
+++ b/index.bs
@@ -5403,7 +5403,7 @@ the [=local end=] has only read-only access.
       }
 
       browsingContext.MediaStreamOptions = {
-         ? video: true / browsingContext.MediaTrackConstraints;
+         ? video: browsingContext.MediaTrackConstraints;
          ? audio: bool .default false;
       }
 

--- a/index.bs
+++ b/index.bs
@@ -1837,6 +1837,12 @@ To <dfn>cleanup the session</dfn> given |session|:
    1. For each |collected data| in [=collected network data=], [=remove collector from data=]
       with |collected data| and |collector id|.
 
+1. For each |screencast recording| in |session|'s [=screencast recordings map=]:
+
+   1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+
+   1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
 1. Perform any implementation-specific cleanup steps.

--- a/index.bs
+++ b/index.bs
@@ -296,12 +296,17 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
     text: web-exposed screen area; url: #web-exposed-screen-area
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
   type: dfn
+    text: add an event listener; url: #add-an-event-listener
     text: root; url: #concept-tree-root
     text: document element; url: #ref-for-dom-document-documentelement
     text: evaluate; url: #dom-xpathevaluatorbase-evaluate
     text: nodes; url: #concept-node
     text: ORDERED_NODE_SNAPSHOT_TYPE; url: #dom-xpathresult-ordered_node_snapshot_type
     text: snapshotItem; url: #dom-xpathresult-snapshotitem
+spec: FILE-API; urlPrefix: https://w3c.github.io/FileAPI/
+  type: dfn
+    text: Blob; url: #dfn-Blob
+    text: blobParts; url: #dfn-blobParts
 spec: FULLSCREEN; urlPrefix: https://fullscreen.spec.whatwg.org/
   type: dfn
     text: fullscreen an element; url: #fullscreen-an-element
@@ -326,6 +331,14 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
     text: computed role; url: /#roleMappingComputedRole
+spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
+  type: dfn
+    text: is type supported; url: #abstract-opdef-is-type-supported
+    text: MediaRecorder; url: #mediarecorder-api
+    text: MediaRecorderOptions; url: #mediarecorderoptions-section
+spec: MEDIACAPTURE-SCREEN-SHARE; urlPrefix: https://w3c.github.io/mediacapture-screen-share/
+  type: dfn
+    text: capture a browser tab; url: #dfn-capture-a-browser-tab
 spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
@@ -798,6 +811,9 @@ with the following additional codes:
 
   <dt><dfn for=errors export>no such request</dfn>
   <dd>Tried to continue an unknown [=/request=].
+
+  <dt><dfn for=errors export>no such screencast</dfn>
+  <dd>Tried to stop an unknown screencast recording.
 
   <dt><dfn for=errors export>no such script</dfn>
   <dd>Tried to remove an unknown [=preload script=].
@@ -3279,6 +3295,8 @@ BrowsingContextCommand = (
   browsingContext.Reload //
   browsingContext.SetBypassCSP //
   browsingContext.SetViewport //
+  browsingContext.StartScreencast //
+  browsingContext.StopScreencast //
   browsingContext.TraverseHistory
 )
 </pre>
@@ -3299,6 +3317,8 @@ BrowsingContextResult = (
   browsingContext.ReloadResult /
   browsingContext.SetBypassCSPResult /
   browsingContext.SetViewportResult /
+  browsingContext.StartScreencastResult /
+  browsingContext.StopScreencastResult /
   browsingContext.TraverseHistoryResult
 )
 
@@ -3370,6 +3390,13 @@ map between [=/navigables=] or [=user context|user contexts=] and boolean.
 
 A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 [=response=] and download ids. It is initially empty.
+
+A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
+which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
+an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
+an [=struct/item=] named <code>mimeType</code>, which is a string,
+an [=struct/item=] named <code>recordedChunks</code>, which is a list,
+an [=struct/item=] named <code>context</code>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5299,6 +5326,179 @@ The [=remote end steps=] with |command parameters| are:
          1. [=Set device pixel ratio override=] with |navigable| and |device pixel ratio|.
 
 1. Return [=success=] with data null.
+
+</div>
+
+#### The browsingContext.startScreencast Command ####  {#command-browsingContext-startScreencast}
+
+The <dfn export for=commands>browsingContext.startScreencast</dfn> command
+starts the screencast of a given navigable according to provided options.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="remote-cddl">
+      browsingContext.StartScreencast = (
+        method: "browsingContext.startScreencast",
+        params: browsingContext.StartScreencastParameters
+      )
+
+      browsingContext.StartScreencastParameters = {
+        context: browsingContext.BrowsingContext,
+        mimeType: text,
+        ? streamOptions: browsingContext.MediaStreamOptions,
+      }
+
+      browsingContext.MediaStreamOptions = {
+         ? video: bool / browsingContext.MediaTrackConstraints .default true;
+         ? audio: bool / browsingContext.MediaTrackConstraints .default false;
+      }
+
+      browsingContext.MediaTrackConstraints = {
+         ? width: js-uint,
+         ? height: js-uint,
+         ? aspectRatio: js-uint,
+         ? frameRate: js-uint,
+         ? facingMode: text,
+         ? resizeMode: text,
+         ? sampleRate: js-uint,
+         ? sampleSize: js-uint,
+         ? echoCancellation: bool / text,
+         ? autoGainControl: bool,
+         ? noiseSuppression: bool,
+         ? latency: js-uint,
+         ? channelCount: js-uint,
+         ? deviceId: text,
+         ? groupId: text,
+         ? backgroundBlur: bool
+      }
+
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      browsingContext.StartScreencastResult = {
+         screencast: browsingContext.Screencast
+      }
+
+      browsingContext.Screencast = text
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.startScreencast">
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |navigable| be the result of [=trying=] to [=get a navigable=]
+   with |command parameters|["<code>context</code>"].
+
+1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
+   [=error code=] [=invalid argument=].
+
+1. Let |mime type| to be |command parameters|["<code>mimeType</code>"].
+
+1. If [=is type supported=] with |mime type| returns false, return [=error=] with
+   [=error code=] [=invalid argument=].
+
+1. If the implementation is unable to record a screencast of |navigable| for any
+   reason then return [=error=] with [=error code=] [=unsupported operation=].
+
+1. Let |media stream| be the result of [=trying=] to [=capture a browser tab=] with
+   |navigable| and |command parameters|["<code>streamOptions</code>"].
+
+1. Let |recorded chunks| be an empty [=/list=].
+
+1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
+
+1. Let |media recorder| be a new {{MediaRecorder}} with {{MediaRecorder/stream}} |media stream| and
+   {{MediaRecorderOptions}} |media recorder options|.
+
+1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
+   and callback that performs the following steps given |event|:
+
+   1. Let |data| be |event|'s {{BlobEvent/data}}.
+
+   1. [=list/Append=] |data| to |recorded chunks|.
+
+1. Call {{MediaRecorder/start()}} on |media recorder|.
+
+1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+1. Set [=screencast recordings map=][|screencast|] to a struct with
+   <code>mediaRecorder</code> |media recorder|,
+   <code>mimeType</code> |mime type|,
+   <code>recordedChunks</code> |recorded chunks|,
+   <code>context</code> |navigable|.
+
+1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
+   with the <code>screencast</code> field set to |screencast|.
+
+</div>
+
+#### The browsingContext.stopScreencast Command ####  {#command-browsingContext-stopScreencast}
+
+The <dfn export for=commands>browsingContext.stopScreencast</dfn> command
+stops the screencast.
+
+<dl>
+   <dt>Command Type</dt>
+   <dd>
+      <pre class="cddl" data-cddl-module="remote-cddl">
+      browsingContext.StopScreencast = (
+        method: "browsingContext.stopScreencast",
+        params: browsingContext.StopScreencastParameters
+      )
+
+      browsingContext.StopScreencastParameters = {
+        screencast: browsingContext.Screencast
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      browsingContext.StopScreencastResult = {
+         path: text
+      }
+    </pre>
+   </dd>
+</dl>
+
+<div algorithm="remote end steps for browsingContext.stopScreencast">
+The [=remote end steps=] with |command parameters| are:
+
+1. Let |screencast| be the value of the "<code>screencast</code>" field in |command
+   parameters|.
+
+1. If [=screencast recordings map=] does not <a for=map>contain</a> |screencast|, return
+   [=error=] with [=error code=] [=no such screencast=].
+
+1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
+
+1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+
+1. Let |recorded chunks| be |screencast recording|["<code>recordedChunks</code>"].
+
+1. Call {{MediaRecorder/stop()}} on |media recorder|.
+
+1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
+
+1. Let |blob options| be a struct with <code>type</code> |screencast recording|["<code>mimeType</code>"].
+
+1. Let |blob| to be a new {{Blob}} with {{blobParts}} |recorded chunks| and
+   {{BlobPropertyBag}} |blob options|.
+
+1. Let |path| be an implementation-defined file path where the recording will be stored.
+
+1. Let |bytes| be |blob|'s underlying [=byte sequence=].
+
+1. Write |bytes| to the file system at |path|.
+
+1. [=map/Remove=] |screencast| from [=screencast recordings map=].
+
+1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+   with the <code>path</code> field set to |path|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5351,24 +5351,12 @@ starts the screencast of a given navigable according to provided options.
 
       browsingContext.MediaStreamOptions = {
          ? video: bool / browsingContext.MediaTrackConstraints .default true;
-         ? audio: bool / browsingContext.MediaTrackConstraints .default false;
+         ? audio: bool .default false;
       }
 
       browsingContext.MediaTrackConstraints = {
          ? width: js-uint,
          ? height: js-uint,
-         ? aspectRatio: js-uint,
-         ? frameRate: js-uint,
-         ? resizeMode: text,
-         ? sampleRate: js-uint,
-         ? sampleSize: js-uint,
-         ? echoCancellation: bool / text,
-         ? autoGainControl: bool,
-         ? noiseSuppression: bool,
-         ? latency: js-uint,
-         ? channelCount: js-uint,
-         ? deviceId: text,
-         ? groupId: text,
       }
 
       </pre>

--- a/index.bs
+++ b/index.bs
@@ -5533,7 +5533,7 @@ stops the screencast.
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StopScreencastResult = {
          path: text,
-         size: js-uint,
+         ? size: js-uint,
          ? error: text
       }
     </pre>
@@ -5559,13 +5559,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. Let |size| be the size in bytes of the recording file located at |path|.
+1. If |error| is not null:
 
-1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path|, <code>size</code> field set to |size|,
-   <code>error</code> field set to |error| if |error| is not null or omitted otherwise.
+   1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+      with the <code>path</code> field set to |path|, <code>error</code> field set to |error|.
 
-1. Return [=success=] with data |body|.
+   1. Return [=success=] with data |body|.
+
+1. Otherwise:
+
+   1. Let |size| be the size in bytes of the recording file located at |path|.
+
+   1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+      with the <code>path</code> field set to |path|, <code>size</code> field set to |size|.
+
+   1. Return [=success=] with data |body|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3407,13 +3407,12 @@ an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a 
 an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string or null.
 
 <div algorithm>
-To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording|, |mime type| and |timeslice|:
+To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording|, |mime type|:
 
 1. The implementation must begin encoding |recording|'s
    [=screencast recording/stream=] using |mime type|, producing successive chunks of encoded data as
-   [=byte sequences=]. A new chunk must be produced at least every |timeslice|
-   milliseconds while |recording|'s [=screencast recording/state=] is
-   "<code>recording</code>".
+   [=byte sequences=]. Produce a new chunk at the implementation defined interaval
+   while |recording|'s [=screencast recording/state=] is "<code>recording</code>".
 
 1. For each chunk |bytes| produced for |recording|, run the following steps:
 
@@ -5505,9 +5504,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Set |session|'s [=screencast recordings map=][|screencast|] to |recording|.
 
-1. Let |timeslice| be an implementation-defined value.
-
-1. [=Start a screencast recording=] given |recording|, |mime type| and |timeslice|.
+1. [=Start a screencast recording=] given |recording| and |mime type|.
 
 1. Let |body| be a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
    with the <code>screencast</code> field set to |screencast| and

--- a/index.bs
+++ b/index.bs
@@ -5339,7 +5339,12 @@ The [=remote end steps=] with |command parameters| are:
 #### The browsingContext.startScreencast Command ####  {#command-browsingContext-startScreencast}
 
 The <dfn export for=commands>browsingContext.startScreencast</dfn> command
-starts the screencast of a given navigable according to provided options.
+starts the screencast of a given navigable and writes it to a file.
+
+Note: The [=remote end=] creates and writes the screencast file, but does not delete it.
+Cleaning up the file is left to the [=local end=]. In some configurations this might not be
+possible — for example, if the [=remote end=] has read/write access to the filesystem but
+the [=local end=] has only read-only access.
 
 <dl>
    <dt>Command Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -5461,21 +5461,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
       1. If |stream options|["<code>video</code>"] [=map/contains=] <code>width</code>:
 
-         1. The [=screencast stream/video track=] must satisfy its <code>width</code>,
-            otherwise if the implementation cannot satisfy these constraints,
-            return [=error=] with [=error code=] [=unknown error=].
+         1. The user agent must attempt to obtain media whose width is as close as possible
+            to the |stream options|["<code>video</code>"]["<code>width</code>"] given the capabilities
+            of the hardware and the other constraints specified.
 
       1. If |stream options|["<code>video</code>"] [=map/contains=] <code>height</code>:
 
-         1. The [=screencast stream/video track=] must satisfy its <code>height</code>,
-            otherwise if the implementation cannot satisfy these constraints,
-            return [=error=] with [=error code=] [=unknown error=].
+         1. The user agent must attempt to obtain media whose height is as close as possible
+            to the |stream options|["<code>video</code>"]["<code>height</code>"] given the capabilities
+            of the hardware and the other constraints specified.
 
       1. If |stream options|["<code>video</code>"] [=map/contains=] <code>frameRate</code>:
 
-         1. The [=screencast stream/video track=] must satisfy its <code>frameRate</code>,
-            otherwise if the implementation cannot satisfy these constraints,
-            return [=error=] with [=error code=] [=unknown error=].
+         1. The user agent must attempt to obtain media whose frame rate is as close as possible
+            to the |stream options|["<code>video</code>"]["<code>frameRate</code>"] given the capabilities
+            of the hardware and the other constraints specified.
 
    1. [=map/Set=] |video track| to |stream|[[=screencast stream/video track=]].
 

--- a/index.bs
+++ b/index.bs
@@ -328,7 +328,6 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
-    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
@@ -5394,7 +5393,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
 
-1. If [=is type supported=] with |mime type| returns false, return [=error=] with
+1. If [$is type supported$] with |mime type| returns false, return [=error=] with
    [=error code=] [=invalid argument=].
 
 1. If the implementation is unable to record a screencast of |navigable| for any

--- a/index.bs
+++ b/index.bs
@@ -3393,7 +3393,8 @@ A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 A <dfn>screencast stream</dfn> is an abstract stream of the viewport of a
 [=/top-level traversable=], consisting of a <dfn for="screencast stream">video track</dfn>
 containing the rendered visual output of the [=/top-level traversable=]'s document's viewport,
-and optionally an <dfn for="screencast stream">audio track</dfn> containing the audio output of the viewport.
+and optionally an <dfn for="screencast stream">audio track</dfn> containing the audio output
+of the [=/top-level traversable=]'s document.
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
 which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>,

--- a/index.bs
+++ b/index.bs
@@ -5533,7 +5533,6 @@ stops the screencast.
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StopScreencastResult = {
          path: text,
-         ? size: js-uint,
          ? error: text
       }
     </pre>
@@ -5559,21 +5558,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. If |error| is not null:
+1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+   with the <code>path</code> field set to |path|, <code>error</code> field set to |error|
+   if |error| is not null or omitted otherwise.
 
-   1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-      with the <code>path</code> field set to |path|, <code>error</code> field set to |error|.
-
-   1. Return [=success=] with data |body|.
-
-1. Otherwise:
-
-   1. Let |size| be the size in bytes of the recording file located at |path|.
-
-   1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-      with the <code>path</code> field set to |path|, <code>size</code> field set to |size|.
-
-   1. Return [=success=] with data |body|.
+1. Return [=success=] with data |body|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -217,6 +217,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: activation notification; url: interaction.html#activation-notification
     text: active window; url: document-sequences.html#nav-window
     text: alert; url: timers-and-user-prompts.html#dom-alert
+    text: associated `Document`; url: nav-history-apis.html#concept-document-window
     text: close; url: document-sequences.html#close-a-top-level-traversable
     text: disabled; url: form-control-infrastructure.html#concept-fe-disabled
     text: File Upload state; url: input.html#file-upload-state-(type=file)
@@ -326,12 +327,6 @@ spec: ACCNAME; urlPrefix:https://www.w3.org/TR/accname-1.2
 spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
   type: dfn
     text: computed role; url: /#roleMappingComputedRole
-spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
-  type: dfn
-    text: fire a blob event; url: #fire-a-blob-event
-spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
-  type: dfn
-    text: capture a browsing context viewport; url: #dfn-capture-a-browsing-context-viewport
 spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
@@ -340,9 +335,10 @@ spec: RFC9110; urlPrefix: https://httpwg.org/specs/rfc9110.html
   type: dfn
     text: field-name token; url: #fields.names
     text: method token; url: #method.overview
-spec: STREAMS; urlPrefix: https://streams.spec.whatwg.org/
+spec: SCREEN-CAPTURE; urlPrefix: https://www.w3.org/TR/screen-capture/
   type: dfn
-    text: ReadableStream; url: #readablestream
+    text: browser; url: #dfn-browser
+    text: display surface; url: dfn-display-surface
 spec: TOUCH-EVENTS; urlPrefix: https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/
   type: dfn
     text: expose legacy touch event APIs; url: #conditionally-exposing-legacy-touch-event-apis
@@ -1833,9 +1829,12 @@ To <dfn>cleanup the session</dfn> given |session|:
 
 1. For each |screencast recording| in |session|'s [=screencast recordings map=]:
 
-   1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
+   1. [=Stop a screencast recording=] given |screencast recording|.
 
-   1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
+   1. Wait until |screencast recording|'s [=screencast recording/state=] is
+      "<code>stopped</code>".
+
+   1. [=map/Remove=] |screencast recording| from [=screencast recordings map=].
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -3391,12 +3390,61 @@ map between [=/navigables=] or [=user context|user contexts=] and boolean.
 A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 [=response=] and download ids. It is initially empty.
 
+A <dfn>screencast stream</dfn> is an abstract stream of the viewport of a
+[=/top-level traversable=], consisting of a <dfn for="screencast stream">video track</dfn>
+containing the rendered visual output of the top-level document's viewport,
+and optionally an <dfn for="screencast stream">audio track</dfn> containing the audio output of the viewport.
+
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
-which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>, which is a [=struct=] with
-an [=struct/item=] named <dfn for="screencast recording">mediaRecorder</dfn>, which is a {{MediaRecorder}},
+which the keys are [[!RFC9562|UUID]]s, and the values are <dfn>screencast recording</dfn>,
+which is a [=struct=] with
+an [=struct/item=] named <dfn for="screencast recording">stream</dfn>, which is a [=screencast stream=],
 an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
+an [=struct/item=] named <dfn for="screencast recording">state</dfn>, which is one of
+"<code>recording</code>", "<code>stopping</code>", "<code>stopped</code>",
 an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number,
-an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string.
+an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string or null.
+
+<div algorithm>
+To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording|, |mime type| and |timeslice|:
+
+1. The implementation must begin encoding |recording|'s
+   [=screencast recording/stream=] using |mime type|, producing successive chunks of encoded data as
+   [=byte sequences=]. A new chunk must be produced at least every |timeslice|
+   milliseconds while |recording|'s [=screencast recording/state=] is
+   "<code>recording</code>".
+
+1. For each chunk |bytes| produced for |recording|, run the following steps:
+
+   1. Append |bytes| to the file at |recording|'s [=screencast recording/path=].
+      If this fails:
+
+      1. Set |recording|'s [=screencast recording/writeError=] to an
+         implementation-defined string describing the write failure.
+
+      1. [=Stop a screencast recording=] given |recording|.
+
+   1. Otherwise, set |recording|'s [=screencast recording/size=] to
+      |recording|'s [=screencast recording/size=] + |bytes|'s length.
+
+</div>
+
+<div algorithm>
+To <dfn>stop a screencast recording</dfn> given a [=screencast recording=] |recording|:
+
+1. If |recording|'s [=screencast recording/state=] is "<code>recording</code>":
+
+   1. Set |recording|'s [=screencast recording/state=] to "<code>stopping</code>".
+
+   1. The implementation must stop producing new chunks for |recording|, flush any
+      remaining encoded data as a final chunk (processed as in
+      [=start a screencast recording=]), stop capturing from |recording|'s
+      [=screencast recording/stream=] and release its
+      [=screencast stream/video track=] and, if present, its
+      [=screencast stream/audio track=], and then set |recording|'s
+      [=screencast recording/state=] to "<code>stopped</code>".
+
+</div>
 
 ### Types ### {#module-browsingcontext-types}
 
@@ -5356,7 +5404,7 @@ the [=local end=] has only read-only access.
       }
 
       browsingContext.MediaStreamOptions = {
-         ? video: bool / browsingContext.MediaTrackConstraints .default true;
+         ? video: true / browsingContext.MediaTrackConstraints;
          ? audio: bool .default false;
       }
 
@@ -5381,7 +5429,7 @@ the [=local end=] has only read-only access.
 </dl>
 
 <div algorithm="remote end steps for browsingContext.startScreencast">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |navigable id| be |command parameters|["<code>context</code>"].
 
@@ -5393,69 +5441,66 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
 
-1. If [$is type supported$] with |mime type| returns false, return [=error=] with
-   [=error code=] [=invalid argument=].
-
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let |environment settings| be the [=environment settings object=] representing
-   a specification execution environment.
+1. Let |stream options| be |command parameters|["<code>streamOptions</code>"].
 
-   Issue: The specification execution environment has to be better defined.
+1. Let |stream| be a new [=screencast stream=] for |navigable|, constructed as follows:
 
-1. [=Prepare to run script=] with |environment settings|.
+   1. Create a |video track| which must be a live-capture of the [=/browser=] [=display surface=]
+      of the [=relevant global object=]'s [=associated `Document`=]'s |navigable|'s
+      <a spec=css2>viewport</a>.
 
-1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
-   |navigable| and |command parameters|["<code>streamOptions</code>"].
+   1. If |stream options|["<code>video</code>"] is a map:
 
-1. [=React=] to |promise|:
+      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>width</code>:
 
-   1. If |promise| was rejected, return [=error=] with [=error code=] [=unknown error=].
+         1. The [=screencast stream/video track=] must satisfy its <code>width</code>,
+            otherwise if the implementation cannot satisfy these constraints,
+            return [=error=] with [=error code=] [=unknown error=].
 
-   1. If |promise| was fulfilled with value |media stream|, then:
+      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>height</code>:
 
-      1. Let |path| be an implementation-defined file path where the recording will be stored.
+         1. The [=screencast stream/video track=] must satisfy its <code>height</code>,
+            otherwise if the implementation cannot satisfy these constraints,
+            return [=error=] with [=error code=] [=unknown error=].
 
-      1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
-         set to |mime type|.
+   1. [=map/Set=] |video track| to |stream|[[=screencast stream/video track=]].
 
-      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+   1. If |stream options|["<code>audio</code>"] is true:
 
-      1. Let |realm| be |environment settings|' [=realm execution context=]'s Realm component.
+      1. Create an |audio track| which must be the combined audio produced by the sum of documents
+         that consist of the [=relevant global object=]'s [=associated `Document`=]'s
+         |navigable|'s [=navigable/active document=], and all [=navigable/active documents=]
+         in nested [=/browsing context=]s of the [=relevant global object=]'s [=associated `Document`=]'s |navigable|.
 
-      1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
-         with {{MediaRecorder/stream}} |media stream| and
-         {{MediaRecorderOptions}} |media recorder options|.
+      1. [=map/Set=] |audio track| to |stream|[[=screencast stream/audio track=]].
 
-      1. Let |recording| be a new [=screencast recording=] with
-         [=screencast recording/mediaRecorder=] |media recorder|,
-         [=screencast recording/path=] |path|,
-         [=screencast recording/size=] 0.
+   1. If the implementation is unable to produce |stream|, return [=error=] with
+      [=error code=] [=unknown error=].
 
-      1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
-         at |media recorder| with |blob|, run the following steps:
+1. Let |path| be an implementation-defined file path where the recording will
+   be stored.
 
-         1. Let |bytes| be |blob|'s underlying [=byte sequence=].
+1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
-         1. Append |bytes| to the file at |path|. If this fails:
+1. Let |recording| be a new [=screencast recording=] with
+   [=screencast recording/stream=] |stream|,
+   [=screencast recording/path=] |path|,
+   [=screencast recording/state=] "<code>recording</code>",
+   [=screencast recording/size=] 0,
+   [=screencast recording/writeError=] null.
 
-            1. Set |recording|'s [=screencast recording/writeError=] to an
-               implementation-defined string describing the write failure.
+1. Set |session|'s [=screencast recordings map=][|screencast|] to |recording|.
 
-            1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
+1. [=Start a screencast recording=] given |recording|, |mime type| and |command parameters|["<code>timeslice</code>"].
 
-         1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
+1. Let |body| be a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
+   with the <code>screencast</code> field set to |screencast| and
+   <code>path</code> field set to |path|.
 
-      1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
-
-      1. [=Clean up after running script=] with |environment settings|.
-
-      1. Set [=screencast recordings map=][|screencast|] to |recording|.
-
-      1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
-         with the <code>screencast</code> field set to |screencast| and <code>path</code> field
-         set to |path|.
+1. Return [=success=] with data |body|.
 
 </div>
 
@@ -5490,33 +5535,34 @@ stops the screencast.
 </dl>
 
 <div algorithm="remote end steps for browsingContext.stopScreencast">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |screencast| be the value of the "<code>screencast</code>" field in |command
    parameters|.
 
-1. If [=screencast recordings map=] does not <a for=map>contain</a> |screencast|, return
-   [=error=] with [=error code=] [=no such screencast=].
+1. If |session|'s [=screencast recordings map=] does not <a for=map>contain</a>
+   |screencast|, return [=error=] with [=error code=] [=no such screencast=].
 
-1. Let |screencast recording| be [=screencast recordings map=][|screencast|].
+1. Let |screencast recording| be |session|'s [=screencast recordings map=][|screencast|].
 
-1. If |screencast recording| contains [=screencast recording/writeError=], return
-   [=error=] with [=error code=] [=unknown error=].
+1. [=Stop a screencast recording=] given |screencast recording|.
 
-1. Let |media recorder| be |screencast recording|'s [=screencast recording/mediaRecorder=].
+1. Wait until |screencast recording|'s [=screencast recording/state=] is
+   "<code>stopped</code>".
+
+1. [=map/Remove=] |screencast| from |session|'s [=screencast recordings map=].
+
+1. If |screencast recording|'s [=screencast recording/writeError=] is not null,
+   return [=error=] with [=error code=] [=unknown error=].
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
-
-1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
-
 1. Let |size| be |screencast recording|'s [=screencast recording/size=].
 
-1. [=map/Remove=] |screencast| from [=screencast recordings map=].
-
-1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
+1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
    with the <code>path</code> field set to |path| and <code>size</code> field set to |size|.
+
+1. Return [=success=] with data |body|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5359,7 +5359,6 @@ starts the screencast of a given navigable according to provided options.
          ? height: js-uint,
          ? aspectRatio: js-uint,
          ? frameRate: js-uint,
-         ? facingMode: text,
          ? resizeMode: text,
          ? sampleRate: js-uint,
          ? sampleSize: js-uint,
@@ -5370,7 +5369,6 @@ starts the screencast of a given navigable according to provided options.
          ? channelCount: js-uint,
          ? deviceId: text,
          ? groupId: text,
-         ? backgroundBlur: bool
       }
 
       </pre>

--- a/index.bs
+++ b/index.bs
@@ -1842,7 +1842,7 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. Let |media recorder| be |screencast recording|["<code>mediaRecorder</code>"].
 
-   1. Call {{MediaRecorder/stop()}} on |media recorder|.
+   1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
@@ -5435,11 +5435,11 @@ The [=remote end steps=] with |command parameters| are:
       1. Set |recording|'s [=screencast recording/writeError=] to an
          implementation-defined string describing the write failure.
 
-      1. Call {{MediaRecorder/stop()}} on |media recorder|.
+      1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
    1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
+1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
@@ -5499,7 +5499,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. Call {{MediaRecorder/stop()}} on |media recorder|.
+1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
 1. Wait until |media recorder|'s {{MediaRecorder/stop}} [=fire an event|event fires=].
 

--- a/index.bs
+++ b/index.bs
@@ -321,7 +321,6 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
-    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
@@ -5178,7 +5177,7 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
 
-1. If [=is type supported=] with |mime type| returns false, return [=error=] with
+1. If [$is type supported$] with |mime type| returns false, return [=error=] with
    [=error code=] [=invalid argument=].
 
 1. If the implementation is unable to record a screencast of |navigable| for any

--- a/index.bs
+++ b/index.bs
@@ -5560,15 +5560,16 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. [=map/Remove=] |screencast| from |session|'s [=screencast recordings map=].
 
-1. If |screencast recording|'s [=screencast recording/writeError=] is not null,
-   return [=error=] with [=error code=] [=unknown error=].
+1. Let |error| be |screencast recording|'s [=screencast recording/writeError=].
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
 1. Let |size| be |screencast recording|'s [=screencast recording/size=].
 
 1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path| and <code>size</code> field set to |size|.
+   with the <code>path</code> field set to |path|, <code>size</code> field set to |size|,
+   <code>error</code> field set to |error| if |error| is not null or omitted otherwise.
+
 
 1. Return [=success=] with data |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -5408,16 +5408,17 @@ The [=remote end steps=] with |command parameters| are:
 
 1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |media recorder options| be a struct with <code>mimeType</code> |mime type|.
+1. Let |media recorder options| be a [=struct=] with an [=struct/item=] named <code>mimeType</code>
+   with the value |mime type|.
 
 1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
    with {{MediaRecorder/stream}} |media stream| and
    {{MediaRecorderOptions}} |media recorder options|.
 
 1. Let |recording| be a new [=screencast recording=] with
-   <code>mediaRecorder</code> |media recorder|,
-   <code>path</code> |path|,
-   <code>size</code> 0.
+   [=screencast recording/mediaRecorder=] |media recorder|,
+   [=screencast recording/path=] |path|,
+   [=screencast recording/size=] 0.
 
 1. [=Add an event listener=] to |media recorder| with type {{MediaRecorder/dataavailable}}
    and callback that performs the following steps given |event|:
@@ -5428,7 +5429,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Append |bytes| to the file at |path|.
 
-   1. Set |recording|["<code>size</code>"] to |recording|["<code>size</code>"] + |bytes|'s length.
+   1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -3409,10 +3409,10 @@ an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which
 <div algorithm>
 To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |recording|, |mime type|:
 
-1. The implementation must begin encoding |recording|'s
-   [=screencast recording/stream=] using |mime type|, producing successive chunks of encoded data as
-   [=byte sequences=]. Produce a new chunk at the implementation defined interaval
-   while |recording|'s [=screencast recording/state=] is "<code>recording</code>".
+1. Begin encoding |recording|'s [=screencast recording/stream=] using |mime type|,
+   producing successive chunks of encoded data as [=byte sequences=].
+   Produce a new chunk at the implementation defined interaval while
+   |recording|'s [=screencast recording/state=] is "<code>recording</code>".
 
 1. For each chunk |bytes| produced for |recording|, run the following steps:
 
@@ -3436,10 +3436,9 @@ To <dfn>stop a screencast recording</dfn> given a [=screencast recording=] |reco
 
    1. Set |recording|'s [=screencast recording/state=] to "<code>stopping</code>".
 
-   1. The implementation must stop producing new chunks for |recording|, flush any
-      remaining encoded data as a final chunk (processed as in
-      [=start a screencast recording=]), stop capturing from |recording|'s
-      [=screencast recording/stream=] and release its
+   1. Stop producing new chunks for |recording|, flush any remaining encoded
+      data as a final chunk (processed as in [=start a screencast recording=]),
+      stop capturing from |recording|'s [=screencast recording/stream=] and release its
       [=screencast stream/video track=] and, if present, its
       [=screencast stream/audio track=], and then set |recording|'s
       [=screencast recording/state=] to "<code>stopped</code>".

--- a/index.bs
+++ b/index.bs
@@ -321,6 +321,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
+    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn

--- a/index.bs
+++ b/index.bs
@@ -5407,10 +5407,15 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
+1. Let |environment settings| be the [=environment settings object=] representing
+   a specification execution environment.
+
+1. [=Prepare to run script=] with |environment settings|.
+
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
-1. [=React=] to promise:
+1. [=React=] to |promise|:
 
    1. If |promise| was rejected, return [=error=] with [=error code=] [=unknown error=].
 
@@ -5450,6 +5455,8 @@ The [=remote end steps=] with |command parameters| are:
          1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
       1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
+
+      1. [=Clean up after running script=] with |environment settings|.
 
       1. Set [=screencast recordings map=][|screencast|] to |recording|.
 

--- a/index.bs
+++ b/index.bs
@@ -5480,7 +5480,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. If |stream options|["<code>audio</code>"] is true:
 
-      1. Create an |audio track| which must be the combined audio produced by the sum of documents
+      1. Create an |audio track| which contains the combined audio produced by the sum of documents
          that consist of the [=relevant global object=]'s [=associated `Document`=]'s
          |navigable|'s [=navigable/active document=], and all [=navigable/active documents=]
          in nested [=/browsing context=]s of the [=relevant global object=]'s [=associated `Document`=]'s |navigable|.

--- a/index.bs
+++ b/index.bs
@@ -3400,7 +3400,6 @@ an [=struct/item=] named <dfn for="screencast recording">stream</dfn>, which is 
 an [=struct/item=] named <dfn for="screencast recording">path</dfn>, which is a string,
 an [=struct/item=] named <dfn for="screencast recording">state</dfn>, which is one of
 "<code>recording</code>", "<code>stopping</code>", "<code>stopped</code>",
-an [=struct/item=] named <dfn for="screencast recording">size</dfn>, which is a number,
 an [=struct/item=] named <dfn for="screencast recording">writeError</dfn>, which is a string or null.
 
 <div algorithm>
@@ -3422,9 +3421,6 @@ To <dfn>start a screencast recording</dfn> given a [=screencast recording=] |rec
             implementation-defined string describing the write failure.
 
          1. [=Stop a screencast recording=] given |recording|.
-
-      1. Otherwise, set |recording|'s [=screencast recording/size=] to
-         |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
 </div>
 
@@ -5499,7 +5495,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
    [=screencast recording/stream=] |stream|,
    [=screencast recording/path=] |path|,
    [=screencast recording/state=] "<code>recording</code>",
-   [=screencast recording/size=] 0,
    [=screencast recording/writeError=] null.
 
 1. Set |session|'s [=screencast recordings map=][|screencast|] to |recording|.
@@ -5564,12 +5559,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |path| be |screencast recording|'s [=screencast recording/path=].
 
-1. Let |size| be |screencast recording|'s [=screencast recording/size=].
+1. Let |size| be the size in bytes of the recording file located at |path|.
 
 1. Let |body| be a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
    with the <code>path</code> field set to |path|, <code>size</code> field set to |size|,
    <code>error</code> field set to |error| if |error| is not null or omitted otherwise.
-
 
 1. Return [=success=] with data |body|.
 

--- a/index.bs
+++ b/index.bs
@@ -5407,9 +5407,6 @@ The [=remote end steps=] with |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let <var>realm</var> be the result of [=trying=] to [=get a realm from a navigable=]
-   with |navigable id| and null.
-
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
@@ -5423,6 +5420,11 @@ The [=remote end steps=] with |command parameters| are:
 
       1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
          set to |mime type|.
+
+      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+      1. Let |realm| be result of [=trying=] to [=get or create a sandbox realm=] given
+         |screencast| and |navigable|.
 
       1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
          with {{MediaRecorder/stream}} |media stream| and
@@ -5448,8 +5450,6 @@ The [=remote end steps=] with |command parameters| are:
          1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
       1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
-
-      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
       1. Set [=screencast recordings map=][|screencast|] to |recording|.
 

--- a/index.bs
+++ b/index.bs
@@ -5410,6 +5410,7 @@ the [=local end=] has only read-only access.
       browsingContext.MediaTrackConstraints = {
          ? width: js-uint,
          ? height: js-uint,
+         ? frameRate: js-uint,
       }
 
       </pre>
@@ -5462,6 +5463,12 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. If |stream options|["<code>video</code>"] [=map/contains=] <code>height</code>:
 
          1. The [=screencast stream/video track=] must satisfy its <code>height</code>,
+            otherwise if the implementation cannot satisfy these constraints,
+            return [=error=] with [=error code=] [=unknown error=].
+
+      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>frameRate</code>:
+
+         1. The [=screencast stream/video track=] must satisfy its <code>frameRate</code>,
             otherwise if the implementation cannot satisfy these constraints,
             return [=error=] with [=error code=] [=unknown error=].
 

--- a/index.bs
+++ b/index.bs
@@ -5453,7 +5453,8 @@ stops the screencast.
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
       browsingContext.StopScreencastResult = {
-         path: text
+         path: text,
+         size: js-uint
       }
     </pre>
    </dd>
@@ -5497,7 +5498,7 @@ The [=remote end steps=] with |command parameters| are:
 1. [=map/Remove=] |screencast| from [=screencast recordings map=].
 
 1. Return a new [=/map=] matching the <code>browsingContext.StopScreencastResult</code>
-   with the <code>path</code> field set to |path|.
+   with the <code>path</code> field set to |path| and <code>size</code> field set to |blob|'s {{Blob/size}}.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5384,7 +5384,7 @@ The [=remote end steps=] with |command parameters| are:
 1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
    [=error code=] [=invalid argument=].
 
-1. Let |mime type| to be |command parameters|["<code>mimeType</code>"].
+1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
 
 1. If [=is type supported=] with |mime type| returns false, return [=error=] with
    [=error code=] [=invalid argument=].

--- a/index.bs
+++ b/index.bs
@@ -5353,6 +5353,7 @@ starts the screencast of a given navigable according to provided options.
         context: browsingContext.BrowsingContext,
         mimeType: text,
         ? streamOptions: browsingContext.MediaStreamOptions,
+        ? timeslice: js-uint .default 1000
       }
 
       browsingContext.MediaStreamOptions = {
@@ -5432,7 +5433,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Call {{MediaRecorder/start()}} on |media recorder| with <code>1000</code>.
+1. Call {{MediaRecorder/start()}} on |media recorder| with |command parameters|["<code>timeslice</code>"].
 
 1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 

--- a/index.bs
+++ b/index.bs
@@ -3399,11 +3399,11 @@ A [=remote end=] has a <dfn>download id map</dfn> which is is a weak map between
 
 A [=BiDi session=] has a <dfn>screencast recordings map</dfn> which is a [=/map=] in
 which the keys are [[!RFC9562|UUID]]s, and the values are [=structs=] with
-an [=struct/item=] named <code>mediaRecorder</code>, which is a {{MediaRecorder}},
-an [=struct/item=] named <code>mimeType</code>, which is a string,
-an [=struct/item=] named <code>path</code>, which is a string,
-an [=struct/item=] named <code>size</code>, which is a number,
-an [=struct/item=] named <code>context</code>, which is a navigable.
+an [=struct/item=] named <dfn attribute for="screencast recordings map">mediaRecorder</dfn>, which is a {{MediaRecorder}},
+an [=struct/item=] named <dfn attribute for="screencast recordings map">mimeType</dfn>, which is a string,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">path</dfn>, which is a string,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">size</dfn>, which is a number,
+an [=struct/item=] named <dfn attribute for="screencast recordings map">context</dfn>, which is a navigable.
 
 ### Types ### {#module-browsingcontext-types}
 

--- a/index.bs
+++ b/index.bs
@@ -302,10 +302,6 @@ spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
     text: nodes; url: #concept-node
     text: ORDERED_NODE_SNAPSHOT_TYPE; url: #dom-xpathresult-ordered_node_snapshot_type
     text: snapshotItem; url: #dom-xpathresult-snapshotitem
-spec: FILE-API; urlPrefix: https://w3c.github.io/FileAPI/
-  type: dfn
-    text: Blob; url: #dfn-Blob
-    text: blobParts; url: #dfn-blobParts
 spec: FULLSCREEN; urlPrefix: https://fullscreen.spec.whatwg.org/
   type: dfn
     text: fullscreen an element; url: #fullscreen-an-element
@@ -320,7 +316,6 @@ spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: DOMException; url: #idl-DOMException
     text: SyntaxError; url: #syntaxerror
-    text: react; url: #dfn-perform-steps-once-promise-is-settled
 spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
@@ -333,10 +328,7 @@ spec: CORE-AAM; urlPrefix:https://www.w3.org/TR/core-aam-1.2
     text: computed role; url: /#roleMappingComputedRole
 spec: MEDIACAPTURE-RECORD; urlPrefix: https://w3c.github.io/mediacapture-record/
   type: dfn
-    text: is type supported; url: #abstract-opdef-is-type-supported
     text: fire a blob event; url: #fire-a-blob-event
-    text: MediaRecorder; url: #mediarecorder-api
-    text: MediaRecorderOptions; url: #mediarecorderoptions-section
 spec: MEDIACAPTURE-VIEWPORT; urlPrefix: https://w3c.github.io/mediacapture-viewport/
   type: dfn
     text: capture a browsing context viewport; url: #dfn-capture-a-browsing-context-viewport

--- a/index.bs
+++ b/index.bs
@@ -5430,7 +5430,7 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Let |bytes| be |data|'s underlying [=byte sequence=].
 
-   1. If appending |bytes| to the file at |path| fails:
+   1. Append |bytes| to the file at |path|. If this fails:
 
       1. Set |recording|'s [=screencast recording/writeError=] to an
          implementation-defined string describing the write failure.

--- a/index.bs
+++ b/index.bs
@@ -319,7 +319,8 @@ spec: SELECTORS4; urlPrefix: https://drafts.csswg.org/selectors-4/
 spec: WEB-IDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: DOMException; url: #idl-DOMException
-    text: SyntaxError; url:#syntaxerror
+    text: SyntaxError; url: #syntaxerror
+    text: react; url: #dfn-perform-steps-once-promise-is-settled
 spec: UNICODE; urlPrefix: https://www.unicode.org/versions/Unicode15.0.0/
   type: dfn
     text: Unicode Default Case Conversion algorithm; url: ch03.pdf#G34944
@@ -5412,45 +5413,49 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
    |navigable| and |command parameters|["<code>streamOptions</code>"].
 
-1. Let |media stream| be <a spec=ECMASCRIPT>Await</a>(|promise|).
+1. [=React=] to promise:
 
-1. Let |path| be an implementation-defined file path where the recording will be stored.
+   1. If |promise| was rejected, return [=error=] with [=error code=] [=unknown error=].
 
-1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
-   set to |mime type|.
+   1. If |promise| was fulfilled with value |media stream|, then:
 
-1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
-   with {{MediaRecorder/stream}} |media stream| and
-   {{MediaRecorderOptions}} |media recorder options|.
+      1. Let |path| be an implementation-defined file path where the recording will be stored.
 
-1. Let |recording| be a new [=screencast recording=] with
-   [=screencast recording/mediaRecorder=] |media recorder|,
-   [=screencast recording/path=] |path|,
-   [=screencast recording/size=] 0.
+      1. Let |media recorder options| be a new [=/map=] with the <code>mimeType</code> field
+         set to |mime type|.
 
-1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
-   at |media recorder| with |blob|, run the following steps:
+      1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
+         with {{MediaRecorder/stream}} |media stream| and
+         {{MediaRecorderOptions}} |media recorder options|.
 
-   1. Let |bytes| be |blob|'s underlying [=byte sequence=].
+      1. Let |recording| be a new [=screencast recording=] with
+         [=screencast recording/mediaRecorder=] |media recorder|,
+         [=screencast recording/path=] |path|,
+         [=screencast recording/size=] 0.
 
-   1. Append |bytes| to the file at |path|. If this fails:
+      1. Whenever the implementation is going to [=fire a blob event=] named {{MediaRecorder/dataavailable}}
+         at |media recorder| with |blob|, run the following steps:
 
-      1. Set |recording|'s [=screencast recording/writeError=] to an
-         implementation-defined string describing the write failure.
+         1. Let |bytes| be |blob|'s underlying [=byte sequence=].
 
-      1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
+         1. Append |bytes| to the file at |path|. If this fails:
 
-   1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
+            1. Set |recording|'s [=screencast recording/writeError=] to an
+               implementation-defined string describing the write failure.
 
-1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
+            1. [=Call=]({{MediaRecorder/stop}}, |media recorder|).
 
-1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+         1. Otherwise, set |recording|'s [=screencast recording/size=] to |recording|'s [=screencast recording/size=] + |bytes|'s length.
 
-1. Set [=screencast recordings map=][|screencast|] to |recording|.
+      1. [=Call=]({{MediaRecorder/start}}, |media recorder|, |command parameters|["<code>timeslice</code>"]).
 
-1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
-   with the <code>screencast</code> field set to |screencast| and <code>path</code> field
-   set to |path|.
+      1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
+
+      1. Set [=screencast recordings map=][|screencast|] to |recording|.
+
+      1. Return a new [=/map=] matching the <code>browsingContext.StartScreencastResult</code>
+         with the <code>screencast</code> field set to |screencast| and <code>path</code> field
+         set to |path|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -5398,7 +5398,7 @@ the [=local end=] has only read-only access.
 
       browsingContext.StartScreencastParameters = {
         context: browsingContext.BrowsingContext,
-        mimeType: text,
+        ? mimeType: text,
         ? streamOptions: browsingContext.MediaStreamOptions,
       }
 
@@ -5439,7 +5439,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If |navigable| is not a [=/top-level traversable=], return [=error=] with
    [=error code=] [=invalid argument=].
 
-1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
+1. If |command parameters| [=map/contains=] the <code>mimeType</code> field:
+
+   1. Let |mime type| be |command parameters|["<code>mimeType</code>"].
+
+1. Otherwise, set |mime type| to the implementation-defined default format.
 
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].

--- a/index.bs
+++ b/index.bs
@@ -5410,6 +5410,8 @@ The [=remote end steps=] with |command parameters| are:
 1. Let |environment settings| be the [=environment settings object=] representing
    a specification execution environment.
 
+   Issue: The specification execution environment has to be better defined.
+
 1. [=Prepare to run script=] with |environment settings|.
 
 1. Let |promise| be the result of [=trying=] to [=capture a browsing context viewport=] with
@@ -5428,8 +5430,7 @@ The [=remote end steps=] with |command parameters| are:
 
       1. Let |screencast| be the string representation of a [[!RFC9562|UUID]].
 
-      1. Let |realm| be result of [=trying=] to [=get or create a sandbox realm=] given
-         |screencast| and |navigable|.
+      1. Let |realm| be |environment settings|' [=realm execution context=]'s Realm component.
 
       1. Let |media recorder| be a new {{MediaRecorder}} in |realm|
          with {{MediaRecorder/stream}} |media stream| and


### PR DESCRIPTION
An attempt to specify screencasting algorithms without JS primitives to not require running JS.

Only the last commit is different from #1069.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1113.html" title="Last updated on May 22, 2026, 8:44 AM UTC (18c3740)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1113/e9b871c...lutien:18c3740.html" title="Last updated on May 22, 2026, 8:44 AM UTC (18c3740)">Diff</a>