### PR TITLE
Export EmptyResult dfn for cross-spec referencing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -654,6 +654,9 @@ EventData = (
 )
 </pre>
 
+An <dfn export>EmptyResult</dfn> is a result type with no required fields,
+used as the return type for commands that don't produce result data.
+
 {^Remote end definition^} and {^Local end definition^}
 
 <pre class="cddl" data-cddl-module="remote-cddl,local-cddl">


### PR DESCRIPTION
## Summary
- Adds an exported `<dfn>` for `EmptyResult` so other specs can reference it via xref.

## Motivation

Needed by [w3c-fedid/digital-credentials#381](https://github.com/w3c-fedid/digital-credentials/pull/381) which defines a WebDriver BiDi extension command (`digitalCredentials.setVirtualWalletBehavior`) whose result type references `EmptyResult`.

Currently, the CDDL rule is defined but has no corresponding exported dfn, so cross-spec tooling (ReSpec xref, Bikeshed cross-refs) cannot resolve it.

## Verification

Ran `bikeshed spec` locally — clean build.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/webdriver-bidi/pull/1116.html" title="Last updated on May 7, 2026, 9:25 AM UTC (f1fdef4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1116/0e36053...marcoscaceres:f1fdef4.html" title="Last updated on May 7, 2026, 9:25 AM UTC (f1fdef4)">Diff</a>