### PR TITLE
Export EmptyResult definition for cross-spec referencing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -663,6 +663,11 @@ js-int = -9007199254740991..9007199254740991
 js-uint = 0..9007199254740991
 </pre>
 
+<p>
+  The <dfn export>EmptyResult</dfn> type represents a successful command
+  response that contains no specific data.
+</p>
+
 ## Session ## {#session}
 
 WebDriver BiDi extends the [=/session=] concept from [[WEBDRIVER|WebDriver]].


### PR DESCRIPTION
**Problem:**
Currently, `EmptyResult` is only defined within a CDDL block in Section 4.1. Because it lacks a formal definition in the prose using a `<dfn>` tag, it is not exported to the global cross-reference databases (like Specref). This prevents external specifications that extend or use WebDriver BiDi (such as the Digital Credentials API) from cross-referencing `EmptyResult` without getting "definition not found" errors in spec processors like ReSpec.

This PR adds a short paragraph in Section 4.1 defining `EmptyResult` in prose and marks it with `<dfn export>`.

This allows other specs to link to it (e.g. in https://github.com/w3c-fedid/digital-credentials/pull/381)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mohamedamir/webdriver-bidi/pull/1118.html" title="Last updated on May 11, 2026, 1:58 PM UTC (98555c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1118/0e36053...mohamedamir:98555c2.html" title="Last updated on May 11, 2026, 1:58 PM UTC (98555c2)">Diff</a>