### PR TITLE
Fix broken references for "convert-fetch-timestamp" and "webdriver-session"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -110,7 +110,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: scroll into view; url: dfn-scrolls-into-view
     text: session ID; url: dfn-session-id
     text: session not created; url: dfn-session-not-created
-    text: session; url: dfn-sessions
+    text: session; url: dfn-webdriver-session
     text: set a property; url: dfn-set-a-property
     text: success; url: dfn-success
     text: table for cookie conversion; url: dfn-table-for-cookie-conversion
@@ -265,7 +265,7 @@ spec: INFRA; urlPrefix: https://infra.spec.whatwg.org/
     text: convert a JSON-derived JavaScript value to an Infra value; url: convert-a-json-derived-javascript-value-to-an-infra-value
 spec: RESOURCE-TIMING; urlPrefix: https://w3c.github.io/resource-timing/
   type: dfn
-    text: convert fetch timestamp; url: convert-fetch-timestamp
+    text: convert fetch timestamp; url: dfn-convert-fetch-timestamp
 spec: HR-TIME; urlPrefix: https://w3c.github.io/hr-time/
   type: dfn
     text: get time origin timestamp; url: get-time-origin-timestamp


### PR DESCRIPTION
Fixes #1120.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver-bidi/pull/1121.html" title="Last updated on May 18, 2026, 7:27 PM UTC (9c56599)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1121/585e4f1...whimboo:9c56599.html" title="Last updated on May 18, 2026, 7:27 PM UTC (9c56599)">Diff</a>