### PR TITLE
fix: make userContext mandatory in browsingContext.CreateResult

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4144,7 +4144,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
     <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.CreateResult = {
           context: browsingContext.BrowsingContext,
-          ? userContext: browser.UserContext
+          userContext: browser.UserContext
         }
     </pre>
    </dd>


### PR DESCRIPTION
The algorithm for browsingContext.create reads as follows:

> Let body be a [map](https://infra.spec.whatwg.org/#ordered-map) matching the browsingContext.CreateResult production, with the context field set to traversable’s [navigable id](https://w3c.github.io/webdriver-bidi/#navigable-id) and the userContext property set to the [user context id](https://w3c.github.io/webdriver-bidi/#user-context-user-context-id) of traversable’s [associated user context](https://w3c.github.io/webdriver-bidi/#associated-user-context).

Nothing here can lead userContext to be missing so I don't see why the property should be optional?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver-bidi/pull/1122.html" title="Last updated on May 19, 2026, 12:45 PM UTC (c424f7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1122/585e4f1...juliandescottes:c424f7d.html" title="Last updated on May 19, 2026, 12:45 PM UTC (c424f7d)">Diff</a>