### PR TITLE
Flatten video/audio in StartScreencast command options

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5395,12 +5395,8 @@ the [=local end=] has only read-only access.
       browsingContext.StartScreencastParameters = {
         context: browsingContext.BrowsingContext,
         ? mimeType: text,
-        ? streamOptions: browsingContext.MediaStreamOptions,
-      }
-
-      browsingContext.MediaStreamOptions = {
-         ? video: browsingContext.MediaTrackConstraints,
-         ? audio: bool .default false,
+        ? video: browsingContext.MediaTrackConstraints,
+        ? audio: bool .default false,
       }
 
       browsingContext.MediaTrackConstraints = {
@@ -5444,37 +5440,37 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. If the implementation is unable to record a screencast of |navigable| for any
    reason then return [=error=] with [=error code=] [=unsupported operation=].
 
-1. Let |stream options| be |command parameters|["<code>streamOptions</code>"].
-
 1. Let |stream| be a new [=screencast stream=] for |navigable|, constructed as follows:
 
    1. Create a |video track| which must be a live-capture of the [=/browser=] [=display surface=]
       of the [=relevant global object=]'s [=associated `Document`=]'s |navigable|'s
       <a spec=css2>viewport</a>.
 
-   1. If |stream options|["<code>video</code>"] is a map:
+   1. If |command parameters| [=map/contains=] "<code>video</code>":
 
-      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>width</code>:
+      1. Let |video| be |command parameters|["<code>video</code>"].
+
+      1. If |video| [=map/contains=] <code>width</code>:
 
          1. The user agent must attempt to obtain media whose width is as close as possible
-            to the |stream options|["<code>video</code>"]["<code>width</code>"] given the capabilities
+            to |video|["<code>width</code>"] given the capabilities
             of the hardware and the other constraints specified.
 
-      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>height</code>:
+      1. If |video| [=map/contains=] <code>height</code>:
 
          1. The user agent must attempt to obtain media whose height is as close as possible
-            to the |stream options|["<code>video</code>"]["<code>height</code>"] given the capabilities
+            to |video|["<code>height</code>"] given the capabilities
             of the hardware and the other constraints specified.
 
-      1. If |stream options|["<code>video</code>"] [=map/contains=] <code>frameRate</code>:
+      1. If |video| [=map/contains=] <code>frameRate</code>:
 
          1. The user agent must attempt to obtain media whose frame rate is as close as possible
-            to the |stream options|["<code>video</code>"]["<code>frameRate</code>"] given the capabilities
+            to |video|["<code>frameRate</code>"] given the capabilities
             of the hardware and the other constraints specified.
 
    1. [=map/Set=] |video track| to |stream|[[=screencast stream/video track=]].
 
-   1. If |stream options|["<code>audio</code>"] is true:
+   1. If |command parameters|["<code>audio</code>"] is true:
 
       1. Create an |audio track| which contains the combined audio produced by the sum of documents
          that consist of the [=relevant global object=]'s [=associated `Document`=]'s


### PR DESCRIPTION
This pull request refactors how screencast stream options are handled in the `index.bs` specification. The main change is the removal of the `streamOptions` object in favor of passing `video` and `audio` parameters directly at the top level of the command parameters. This simplifies the parameter structure and the logic for handling screencast options.

**Screencast parameter structure simplification:**

* Removed the nested `streamOptions` object from `StartScreencastParameters`, and now `video` and `audio` options are provided directly as top-level parameters.
* Updated the screencast stream construction steps to reference `video` and `audio` directly from `command parameters`, simplifying the logic for handling width, height, frameRate, and audio options.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nvborisenko/w3c-webdriver-bidi/pull/1124.html" title="Last updated on May 22, 2026, 3:38 PM UTC (455e857)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1124/54175aa...nvborisenko:455e857.html" title="Last updated on May 22, 2026, 3:38 PM UTC (455e857)">Diff</a>