### PR TITLE
Remote CDDL missing definition of browsingContext.Screencast

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5422,7 +5422,7 @@ the [=local end=] has only read-only access.
     </pre>
     <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
       browsingContext.Screencast = text
-    </pre>    
+    </pre>
    </dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -5526,6 +5526,8 @@ stops the screencast.
       browsingContext.StopScreencastParameters = {
         screencast: browsingContext.Screencast
       }
+
+      browsingContext.Screencast = text
       </pre>
    </dd>
    <dt>Return Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -5528,7 +5528,6 @@ stops the screencast.
       browsingContext.StopScreencastParameters = {
         screencast: browsingContext.Screencast
       }
-
       </pre>
    </dd>
    <dt>Return Type</dt>

--- a/index.bs
+++ b/index.bs
@@ -5419,8 +5419,10 @@ the [=local end=] has only read-only access.
          path: text
       }
 
-      browsingContext.Screencast = text
     </pre>
+    <pre class="cddl" data-cddl-module="local-cddl,remote-cddl">
+      browsingContext.Screencast = text
+    </pre>    
    </dd>
 </dl>
 
@@ -5527,7 +5529,6 @@ stops the screencast.
         screencast: browsingContext.Screencast
       }
 
-      browsingContext.Screencast = text
       </pre>
    </dd>
    <dt>Return Type</dt>


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver-bidi/issues/1125
Remote CDDL uses the same `browsingContext.Screencast` as the local one, but without defining it, which generates an invalid `remote.cddl` file, as pointed out in the issue.

This PR defines it for both remote & local usage to fix the invalid generation.

>[ipr](https://labs.w3.org/repo-manager/pr/id/w3c/webdriver-bidi/1126) — PR has contribution issues. The following users were not in the repository's groups: @dprevost-LMI.

In the past, I was able to contribute without doing `IPR commitments`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dprevost-LMI/webdriver-bidi/pull/1126.html" title="Last updated on May 24, 2026, 2:00 PM UTC (5e60cb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1126/54175aa...dprevost-LMI:5e60cb7.html" title="Last updated on May 24, 2026, 2:00 PM UTC (5e60cb7)">Diff</a>