### PR TITLE
Add scrollIntoView action

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14624,7 +14624,7 @@ steps</dfn> given |session|:
   1. Let |element| be the result of [=trying=] to [=deserialize remote reference=]
      with |reference|, |realm|, and |session|.
 
-  1. If |element| doesn't implement {{Element}} return [=error=] with [=error code=]
+  1. If |element| doesn't implement {{Node}} return [=error=] with [=error code=]
      [=no such element=].
 
   1. Return [=success=] with data |element|.
@@ -14668,7 +14668,10 @@ Note: for a detailed description of the behavior of this command, see the
         actions: [*input.NoneSourceAction]
       }
 
-      input.NoneSourceAction = input.PauseAction
+      input.NoneSourceAction = (
+        input.PauseAction /
+        input.ScrollIntoViewAction
+      )
 
       input.KeySourceActions = {
         type: "key",
@@ -14716,6 +14719,18 @@ Note: for a detailed description of the behavior of this command, see the
       input.PauseAction = {
         type: "pause",
         ? duration: js-uint
+      }
+
+      input.ScrollIntoViewBehavior = "auto" / "instant" / "smooth"
+
+      input.ScrollIntoViewAlignment = "start" / "center" / "end" / "nearest"
+
+      input.ScrollIntoViewAction = {
+        type: "scrollIntoView",
+        ? onlyIfNecessary: bool .default true,
+        ? behavior: input.ScrollIntoViewBehavior .default "instant",
+        ? block: input.ScrollIntoViewAlignment .default "end",
+        ? inline: input.ScrollIntoViewAlignment .default "nearest"
       }
 
       input.KeyDownAction = {


### PR DESCRIPTION
This PR adds the `scrollIntoView` action added to WebDriver Classic in w3c/webdriver#1964 to BiDi.

Fixes #544.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hbenl/webdriver-bidi/pull/1127.html" title="Last updated on May 27, 2026, 1:25 PM UTC (6913322)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1127/b18554e...hbenl:6913322.html" title="Last updated on May 27, 2026, 1:25 PM UTC (6913322)">Diff</a>