### PR TITLE
Add io module for streams with handling streams in the associated document's realm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7918,7 +7918,9 @@ The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of
 [=readable stream=]. If provided, the <code>timeout</code> parameter specifies the
 maximum number of milliseconds to wait for the next chunk. If the timeout
 expires, the command returns an [=error=] with [=error code=] [=timeout=]
-without removing the stream.
+without removing the stream. Only one invocation for the same stream can be
+active at a time. Additional concurrent invocations return an [=error=] with
+[=error code=] [=stream read error=].
 
 <dl>
   <dt>Command Type</dt>
@@ -7955,6 +7957,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |stream id|.
 
+1. If |stream settings|[[=stream settings/read command active=]] is true,
+   return [=error=] with [=error code=] [=stream read error=].
+
+1. Set |stream settings|[[=stream settings/read command active=]] to true.
+
 1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
 
 1. If |realm id| is not null:
@@ -7963,16 +7970,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Let |environment settings| be the [=environment settings object=] whose
       [=realm execution context=]'s Realm component is |realm|.
-
-   1. Let |stream map| be |session|'s [=readable stream settings map=].
-
-   1. Wait until |stream settings|[[=stream settings/read command active=]] is
-      false or |stream map| no longer [=map/contains=] |stream id|.
-
-   1. If |stream map| no longer [=map/contains=] |stream id|, return [=error=]
-      with [=error code=] [=no such stream=].
-
-   1. Set |stream settings|[[=stream settings/read command active=]] to true.
 
    1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 

--- a/index.bs
+++ b/index.bs
@@ -591,6 +591,7 @@ CommandData = (
   BrowsingContextCommand //
   EmulationCommand //
   InputCommand //
+  IoCommand //
   NetworkCommand //
   ScriptCommand //
   SessionCommand //
@@ -633,6 +634,7 @@ ResultData = (
   BrowsingContextResult /
   EmulationResult /
   InputResult /
+  IoResult /
   NetworkResult /
   ScriptResult /
   SessionResult /
@@ -813,11 +815,17 @@ with the following additional codes:
   <dt><dfn for=errors export>no such storage partition</dfn>
   <dd>Tried to access data in a non-existent storage partition.
 
+  <dt><dfn for=errors export>no such stream</dfn>
+  <dd>Tried to access an unknown [=Stream=].
+
   <dt><dfn for=errors export>no such user context</dfn>
   <dd>Tried to reference an unknown [=user context=].
 
   <dt><dfn for=errors export>no such web extension</dfn>
   <dd>Tried to reference an unknown web extension.
+
+  <dt><dfn for=errors export>stream read error</dfn>
+  <dd>Unable to read from a [=Stream=].
 
   <dt><dfn for=errors export>unable to close browser</dfn>
   <dd>Tried to close the browser, but failed to do so.
@@ -854,10 +862,12 @@ ErrorCode = "invalid argument" /
             "no such request" /
             "no such screencast" /
             "no such script" /
+            "no such stream" /
             "no such storage partition" /
             "no such user context" /
             "no such web extension" /
             "session not created" /
+            "stream read error" /
             "unable to capture screen" /
             "unable to close browser" /
             "unable to set cookie" /
@@ -7687,6 +7697,212 @@ is legacy, user agent might run [=implementation-defined=] steps to respect the
    to |maxTouchPoints|.
 
 1. Return [=success=] with data null.
+
+</div>
+
+## The io Module ## {#module-io}
+
+The <dfn export for=modules>io</dfn> module contains commands and events
+relating to IO operations.
+
+### Definition ### {#module-io-definition}
+
+{^remote end definition^}
+
+<pre class="cddl" data-cddl-module="remote-cddl">
+
+IoCommand = (
+  io.Cancel //
+  io.ReadStream //
+)
+
+</pre>
+
+{^local end definition^}
+
+<pre class="cddl" data-cddl-module="local-cddl">
+
+IoResult = (
+   io.ReadStreamResult
+)
+</pre>
+
+A [=BiDi Session=] has a <dfn>readable stream map</dfn> which is a [=/map=] between
+a <code>io.Stream</code> and a [=readable stream=].
+
+<div class="algorithm">
+
+To <dfn>get a readable stream</dfn> given <var ignore>session</var> and |stream|:
+
+1. Let |stream map| be |session|'s [=readable stream map=].
+
+1. If |stream map| [=map/contains=] |stream|, return [=success=] with data
+   |stream map|[|stream|].
+
+1. Return [=error=] with [=error code=] [=no such stream=].
+
+</div>
+
+### Types ### {#module-io-types}
+
+#### The io.ReadableStream Type #### {#type-io-ReadableStream}
+
+<pre class="cddl" data-cddl-module="local-cddl">
+io.ReadableStream = {
+  stream: io.Stream,
+}
+</pre>
+
+The <code>io.ReadableStream</code> type represents a [=readable stream=].
+
+#### The io.ReadData Type #### {#type-io-ReadData}
+
+<pre class="cddl" data-cddl-module="local-cddl">
+io.ReadData = {
+  value: network.BytesValue,
+  done: bool
+}
+</pre>
+
+The <code>io.ReadData</code> type represents the result of reading a value
+from a [=readable stream=].
+
+
+#### The io.Stream Type #### {#type-io-Stream}
+
+<pre class="cddl" data-cddl-module="local-cddl">
+io.Stream = text
+</pre>
+
+The <code>io.Stream</code> type represents a handle to an IO [=stream=].
+
+### Commands ### {#module-io-commands}
+
+#### The io.cancel Command ####  {#command-io-cancel}
+
+The <dfn export for=commands>io.Cancel</dfn> command cancels a [=readable stream=].
+
+<dl>
+  <dt>Command Type</dt>
+  <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      io.Cancel = (
+        method: "io.cancel",
+        params: io.CancelParameters
+      )
+
+      io.CancelParameters = {
+        stream: io.Stream,
+        ? reason: text,
+      }
+      </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      io.CancelResult = EmptyResult
+    </pre>
+  </dd>
+</dl>
+
+<div algorithm="remote end steps for io.Cancel">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |stream| be the result of trying to [=get a readable stream=] with
+   |session| and |command parameters|["<code>stream</code>"].
+
+1. If |command parameters| [=map/contains=] "<code>reason</code>, let |reason|
+   be |command parameters|["<code>reason</code>"]. Otherwise let |reason| be
+   undefined.
+
+1. Run [$ReadableStreamCancel$]\(|stream|, |reason|).
+
+</div>
+
+### The io.readStream Command ### {#command-io.readStream}
+
+The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of a
+[=readable stream=].
+
+<dl>
+  <dt>Command Type</dt>
+  <dd>
+    <pre class="cddl" data-cddl-module="remote-cddl">
+      io.ReadStream = (
+       method: "io.readStream",
+       params: io.ReadStreamParameters
+      )
+
+      io.ReadStreamParameters = {
+        stream: io.Stream,
+      }
+    </pre>
+   </dd>
+   <dt>Return Type</dt>
+   <dd>
+    <pre class="cddl" data-cddl-module="local-cddl">
+      io.ReadStreamResult = io.ReadData
+    </pre>
+   </dd>
+</dl>
+
+
+<div algorithm="remote end steps for io.readStream">
+The [=remote end steps=] given |session| and |command parameters| are:
+
+1. Let |stream| be the result of [=trying=] to [=get a readable stream=] with
+   |session| and |command parameters|["<code>stream</code>"].
+
+1. Let |result| be null.
+
+1. Let |read request| be a new [=read request=] with the following items:
+  <dl>
+    <dt>[=read request/chunk steps=] given |chunk|:
+    <dd>
+      1. Assert: |result| is null.
+
+      1. Let |response| be a new `io.ReadResult` with the <code>value</code>
+         field set to [=serialize protocol bytes=] given |chunk| and the
+         <code>done</code> field set to false.
+
+      1. Let |result| be [=success=] with data |response|.
+    </dd>
+
+    <dt>[=read request/close steps=]:
+    <dd>
+      1. Assert: |result| is null.
+
+      1. Let |response| be a new `io.ReadResult` with the <code>value</code>
+         field set to <code>""</code> and the <code>done</code> field set to
+         true.
+
+      1. Let |result| be [=success=] with data |response|.
+    </dd>
+
+    <dt>[=read request/error steps=] given <var ignore>e</var>:
+    <dd>
+      1. Assert: |result| is null.
+
+      1. Let |result| be [=error=] with [=error code=] [=stream read error=].
+    </dd>
+  </dl>
+
+1. Set |stream|.\[[disturbed]] to true.
+
+1. If |stream|.\[[state]] is "<code>closed</code>", perform |read request|'s close steps.
+
+1. Otherwise, if |stream|.\[[state]] is "<code>errored</code>", perform |read
+   request|'s error steps given |stream|.\[[storedError]].
+
+1. Otherwise,
+
+    1. Assert: stream.\[[state]] is "readable".
+
+    1. Perform ! |stream|.\[[controller]].\[[PullSteps]](|read request|).
+
+1. Assert: |result| is not null.
+
+1. Return |result|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -7781,7 +7781,7 @@ from a [=readable stream=].
 
 #### The io.Stream Type #### {#type-io-Stream}
 
-<pre class="cddl" data-cddl-module="local-cddl">
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 io.Stream = text
 </pre>
 
@@ -12360,7 +12360,8 @@ script.RemoteValue = (
   script.NodeListRemoteValue /
   script.HTMLCollectionRemoteValue /
   script.NodeRemoteValue /
-  script.WindowProxyRemoteValue
+  script.WindowProxyRemoteValue /
+  script.ReadableStreamRemoteValue
 )
 
 script.ListRemoteValue = [*script.RemoteValue];
@@ -12510,6 +12511,13 @@ script.WindowProxyRemoteValue = {
 
 script.WindowProxyProperties = {
   context: browsingContext.BrowsingContext
+}
+
+script.ReadableStreamRemoteValue = {
+  type: "readable-stream",
+  stream: io.Stream,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
 }
 </pre>
 
@@ -12883,6 +12891,31 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        production in the {^local end definition^}, with the <code>handle</code>
        property set to |handle id| if it's not null, or omitted otherwise, and
        the <code>value</code> property set to |serialized|.
+
+    <dt>|value| is a [=platform object=] that implements {{ReadableStream}}
+    <dd>
+    1. Let |stream realm| be |value|'s [=relevant settings object=]'s
+       [=realm execution context=]'s Realm component.
+
+    1. Let |navigable| be the result of [=get the navigable=] with |stream realm|.
+
+    1. If |navigable| is null, let |navigable id| be null. Otherwise, let
+       |navigable id| be the [=navigable id=] for |navigable|.
+
+    1. Let |stream id| be the string representation of a [[!RFC9562|UUID]].
+
+    1. Let |stream settings| be a [=stream settings=] struct with the
+       [=stream settings/stream=] item set to |value| and the
+       [=stream settings/navigable=] item set to |navigable id|.
+
+    1. Set |session|'s [=readable stream settings map=][|stream id|] to
+       |stream settings|.
+
+    1. Let |remote value| be a [=/map=] matching the
+       <code>script.ReadableStreamRemoteValue</code> production in the
+       {^local end definition^}, with the <code>stream</code> property set to
+       |stream id|, and the <code>handle</code> property set to |handle id| if
+       it's not null, or omitted otherwise.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a [=/map=] matching the <code>script.ObjectRemoteValue</code>

--- a/index.bs
+++ b/index.bs
@@ -7799,16 +7799,6 @@ To <dfn>cancel a readable stream</dfn> given |realm|, |stream| and |reason|:
 
 ### Types ### {#module-io-types}
 
-#### The io.ReadableStream Type #### {#type-io-ReadableStream}
-
-<pre class="cddl" data-cddl-module="local-cddl">
-io.ReadableStream = {
-  stream: io.Stream,
-}
-</pre>
-
-The <code>io.ReadableStream</code> type represents a [=readable stream=].
-
 #### The io.ReadData Type #### {#type-io-ReadData}
 
 <pre class="cddl" data-cddl-module="local-cddl">
@@ -7964,11 +7954,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
         <dd>Reject |promise| with |e|.
      </dl>
 
-   1. Let |read request| be the result of [=ReadableStreamDefaultReader/read a chunk=] from |reader| given |read request|.
+   1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given |read request|.
 
-   1. If |read result|.\[[Type]] is <code>normal</code>:
-
-      1. Set |read result| to <a spec=ECMASCRIPT>Await</a>(|read result|.\[[Value]]).
+   1. Let |read result| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
    1. [=Clean up after running script=] with |environment settings|.
 
@@ -12971,6 +12959,9 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        |stream id|, and the <code>handle</code> property set to |handle id| if
        it's not null, or omitted otherwise.
 
+   1. [=Set internal ids if needed=] with |serialization internal map|,
+      |remote value| and |value|.
+
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a [=/map=] matching the <code>script.ObjectRemoteValue</code>
            production in the {^local end definition^}, with the <code>handle</code>
@@ -14156,8 +14147,9 @@ Define the following [=unloading document cleanup steps=] with |document|:
    1. For each |stream id| → |stream settings| in |active session|'s
       [=readable stream settings map=]:
 
-      1. If |stream settings|[[=stream settings/realm=]] equals |realm id|,
-         [=remove a readable stream=] given |active session| and |stream id|.
+      1. If |stream settings|[[=stream settings/realm=]] equals |realm id|:
+
+         1. [=Remove a readable stream=] given |active session| and |stream id|.
 
 1. Let |params| be a [=/map=] matching the
    <code>script.RealmDestroyedParameters</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -816,7 +816,7 @@ with the following additional codes:
   <dd>Tried to access data in a non-existent storage partition.
 
   <dt><dfn for=errors export>no such stream</dfn>
-  <dd>Tried to access an unknown [=Stream=].
+  <dd>Tried to access an unknown [=/stream=].
 
   <dt><dfn for=errors export>no such user context</dfn>
   <dd>Tried to reference an unknown [=user context=].
@@ -824,8 +824,11 @@ with the following additional codes:
   <dt><dfn for=errors export>no such web extension</dfn>
   <dd>Tried to reference an unknown web extension.
 
+  <dt><dfn for=errors export>stream closed</dfn>
+  <dd>Tried to interact with a closed [=/stream=].
+
   <dt><dfn for=errors export>stream read error</dfn>
-  <dd>Unable to read from a [=Stream=].
+  <dd>Unable to read from a [=/stream=].
 
   <dt><dfn for=errors export>unable to close browser</dfn>
   <dd>Tried to close the browser, but failed to do so.
@@ -862,11 +865,12 @@ ErrorCode = "invalid argument" /
             "no such request" /
             "no such screencast" /
             "no such script" /
-            "no such stream" /
             "no such storage partition" /
+            "no such stream" /
             "no such user context" /
             "no such web extension" /
             "session not created" /
+            "stream closed" /
             "stream read error" /
             "unable to capture screen" /
             "unable to close browser" /
@@ -7727,14 +7731,21 @@ IoResult = (
 )
 </pre>
 
-A [=BiDi Session=] has a <dfn>readable stream map</dfn> which is a [=/map=] between
-a <code>io.Stream</code> and a [=readable stream=].
+A <dfn lt="stream|IO stream" export>stream</dfn> is an abstract source of
+data that can be read from or written to.
+
+A [=BiDi Session=] has a <dfn>readable stream settings map</dfn> which is a [=/map=] between
+a <code>io.Stream</code> and [=stream settings=].
+
+<dfn>Stream settings</dfn> is a [=struct=] with
+an [=struct/item=] named <dfn for="stream settings">stream</dfn>, which is a [=readable stream=],
+an [=struct/item=] named <dfn for="stream settings">navigable</dfn>, which is a <code>browsingContext.BrowsingContext</code> or null.
 
 <div class="algorithm">
 
-To <dfn>get a readable stream</dfn> given <var ignore>session</var> and |stream|:
+To <dfn>get readable stream settings</dfn> given <var ignore>session</var> and |stream|:
 
-1. Let |stream map| be |session|'s [=readable stream map=].
+1. Let |stream map| be |session|'s [=readable stream settings map=].
 
 1. If |stream map| [=map/contains=] |stream|, return [=success=] with data
    |stream map|[|stream|].
@@ -7759,7 +7770,7 @@ The <code>io.ReadableStream</code> type represents a [=readable stream=].
 
 <pre class="cddl" data-cddl-module="local-cddl">
 io.ReadData = {
-  value: network.BytesValue,
+  value: network.BytesValue / null,
   done: bool
 }
 </pre>
@@ -7774,7 +7785,7 @@ from a [=readable stream=].
 io.Stream = text
 </pre>
 
-The <code>io.Stream</code> type represents a handle to an IO [=stream=].
+The <code>io.Stream</code> type represents a handle to an IO [=/stream=].
 
 ### Commands ### {#module-io-commands}
 
@@ -7808,18 +7819,51 @@ The <dfn export for=commands>io.Cancel</dfn> command cancels a [=readable stream
 <div algorithm="remote end steps for io.Cancel">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |stream| be the result of trying to [=get a readable stream=] with
+1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |command parameters|["<code>stream</code>"].
 
-1. If |command parameters| [=map/contains=] "<code>reason</code>, let |reason|
+1. Let |stream| be |stream settings|[[=stream settings/stream=]].
+
+1. Let |navigable id| be |stream settings|[[=stream settings/navigable=]].
+
+1. If |command parameters| [=map/contains=] "<code>reason</code>", let |reason|
    be |command parameters|["<code>reason</code>"]. Otherwise let |reason| be
    undefined.
 
-1. Run [$ReadableStreamCancel$]\(|stream|, |reason|).
+1. If |navigable id| is not null:
+
+     1. Let |realm| be the result of [=trying=] to [=get a realm from a navigable=]
+        with |navigable id| and null.
+
+     1. Let |environment settings| be the [=environment settings object=] whose
+        [=realm execution context=]'s Realm component is |realm|.
+
+     1. [=Prepare to run script=] with |environment settings|.
+
+     1. Let |promise| be the result of [=ReadableStream/cancel=] |stream| with
+        |reason|.
+
+     1. [=React=] to |promise|:
+
+      1. If |promise| was rejected, then:
+
+         1. [=Clean up after running script=] with |environment settings|.
+
+         1. Return [=error=] with [=error code=] [=stream closed=].
+
+      1. If |promise| was fulfilled, then:
+
+         1. [=Clean up after running script=] with |environment settings|.
+
+         1. Return [=success=] with data null.
+
+1. Otherwise, return error with [=error code=] [=unsupported operation=].
+
+   TODO: Add support for streams that don't have an associated navigable.
 
 </div>
 
-### The io.readStream Command ### {#command-io.readStream}
+#### The io.readStream Command #### {#command-io.readStream}
 
 The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of a
 [=readable stream=].
@@ -7850,59 +7894,62 @@ The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of
 <div algorithm="remote end steps for io.readStream">
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. Let |stream| be the result of [=trying=] to [=get a readable stream=] with
+1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |command parameters|["<code>stream</code>"].
 
-1. Let |result| be null.
+1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 
-1. Let |read request| be a new [=read request=] with the following items:
-  <dl>
-    <dt>[=read request/chunk steps=] given |chunk|:
-    <dd>
-      1. Assert: |result| is null.
+1. Let |navigable id| be |stream settings|[[=stream settings/navigable=]].
 
-      1. Let |response| be a new `io.ReadResult` with the <code>value</code>
+1. If |navigable id| is not null:
+
+   1. Let |realm| be the result of [=trying=] to [=get a realm from a navigable=]
+      with |navigable id| and null.
+
+   1. Let |environment settings| be the [=environment settings object=] whose
+      [=realm execution context=]'s Realm component is |realm|.
+
+   1. [=Prepare to run script=] with |environment settings|.
+
+   1. Let |reader| be the result of [=ReadableStream/getting a reader=] for |stream|.
+
+   1. Let |read result| be the result of calling {{ReadableStreamDefaultReader/read()}} for |reader|.
+
+   1. If |read result|.\[[Type]] is <code>normal</code>.:
+
+      1. Set |read result| to <a spec=ECMASCRIPT>Await</a>(|read result|.\[[Value]]).
+
+   1. [=Clean up after running script=] with |environment settings|.
+
+   1. [=ReadableStreamDefaultReader/Release=] |reader|.
+
+   1. If |read result|.\[[Type]] is <code>throw</code>, return [=error=] with
+      [=error code=] [=stream read error=].
+
+   1. Assert: |read result|.\[[Type]] is <code>normal</code>.
+
+   1. Let |read value| be |read result|.\[[Value]].
+
+   1. Let |done| be |read value|["<code>done</code>"].
+
+   1. If |done| is true:
+
+      1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
+         field set to null and the <code>done</code> field set to true.
+
+   1. Otherwise:
+
+      1. Let |chunk| be |read value|["<code>value</code>"].
+
+      1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
          field set to [=serialize protocol bytes=] given |chunk| and the
          <code>done</code> field set to false.
 
-      1. Let |result| be [=success=] with data |response|.
-    </dd>
+   1. Return [=success=] with data |response|.
 
-    <dt>[=read request/close steps=]:
-    <dd>
-      1. Assert: |result| is null.
+1. Otherwise, return [=error=] with [=error code=] [=unsupported operation=].
 
-      1. Let |response| be a new `io.ReadResult` with the <code>value</code>
-         field set to <code>""</code> and the <code>done</code> field set to
-         true.
-
-      1. Let |result| be [=success=] with data |response|.
-    </dd>
-
-    <dt>[=read request/error steps=] given <var ignore>e</var>:
-    <dd>
-      1. Assert: |result| is null.
-
-      1. Let |result| be [=error=] with [=error code=] [=stream read error=].
-    </dd>
-  </dl>
-
-1. Set |stream|.\[[disturbed]] to true.
-
-1. If |stream|.\[[state]] is "<code>closed</code>", perform |read request|'s close steps.
-
-1. Otherwise, if |stream|.\[[state]] is "<code>errored</code>", perform |read
-   request|'s error steps given |stream|.\[[storedError]].
-
-1. Otherwise,
-
-    1. Assert: stream.\[[state]] is "readable".
-
-    1. Perform ! |stream|.\[[controller]].\[[PullSteps]](|read request|).
-
-1. Assert: |result| is not null.
-
-1. Return |result|.
+   TODO: Add support for streams that don't have an associated navigable.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -7813,7 +7813,7 @@ The <code>io.ReadableStream</code> type represents a [=readable stream=].
 
 <pre class="cddl" data-cddl-module="local-cddl">
 io.ReadData = {
-  value: network.BytesValue / null,
+  value: text / null,
   done: bool
 }
 </pre>
@@ -7998,8 +7998,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. Let |chunk| be |read value|["<code>value</code>"].
 
       1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
-         field set to [=serialize protocol bytes=] given |chunk| and the
-         <code>done</code> field set to false.
+         field set to [=forgiving-base64 encode=] |chunk| and the <code>done</code> field
+         set to false.
 
    1. Return [=success=] with data |response|.
 

--- a/index.bs
+++ b/index.bs
@@ -1850,6 +1850,21 @@ To <dfn>cleanup the session</dfn> given |session|:
 
    1. [=map/Remove=] |screencast recording| from [=screencast recordings map=].
 
+1. For each <var ignore>stream id</var> → |stream settings| in |session|'s
+   [=readable stream settings map=]:
+
+   1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
+
+   1. If |realm id| is not null and there is a [=/realm=] with
+      [=realm id|id=] |realm id|:
+
+      1. Let |realm| be the [=/realm=] with [=realm id|id=] |realm id|.
+
+      1. [=Cancel a readable stream=] given |realm|,
+         |stream settings|[[=stream settings/stream=]] and undefined.
+
+1. [=map/Clear=] |session|'s [=readable stream settings map=].
+
 1. If [=active sessions=] is [=list/empty=], [=cleanup remote end state=].
 
 1. Perform any implementation-specific cleanup steps.
@@ -7754,6 +7769,34 @@ To <dfn>get readable stream settings</dfn> given <var ignore>session</var> and |
 
 </div>
 
+<div class="algorithm">
+
+To <dfn>remove a readable stream</dfn> given |session| and |stream|:
+
+1. Let |stream map| be |session|'s [=readable stream settings map=].
+
+1. If |stream map| [=map/contains=] |stream|, [=map/remove=] |stream map|[|stream|].
+
+</div>
+
+<div class="algorithm">
+
+To <dfn>cancel a readable stream</dfn> given |realm|, |stream| and |reason|:
+
+1. Let |environment settings| be the [=environment settings object=] whose
+   [=realm execution context=]'s Realm component is |realm|.
+
+1. [=Prepare to run script=] with |environment settings|.
+
+1. Let |promise| be the result of [=ReadableStream/cancel=] |stream| with
+   |reason|.
+
+1. [=Clean up after running script=] with |environment settings|.
+
+1. Return |promise|.
+
+</div>
+
 ### Types ### {#module-io-types}
 
 #### The io.ReadableStream Type #### {#type-io-ReadableStream}
@@ -7819,8 +7862,10 @@ The <dfn export for=commands>io.Cancel</dfn> command cancels a [=readable stream
 <div algorithm="remote end steps for io.Cancel">
 The [=remote end steps=] given |session| and |command parameters| are:
 
+1. Let |stream id| be |command parameters|["<code>stream</code>"].
+
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
-   |session| and |command parameters|["<code>stream</code>"].
+   |session| and |stream id|.
 
 1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 
@@ -7834,15 +7879,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
      1. Let |realm| be the result of [=trying=] to [=get a realm=] with |realm id|.
 
-     1. Let |environment settings| be the [=environment settings object=] whose
-        [=realm execution context=]'s Realm component is |realm|.
+     1. Let |promise| be the result of [=cancel a readable stream=] given
+        |realm|, |stream| and |reason|.
 
-     1. [=Prepare to run script=] with |environment settings|.
-
-     1. Let |promise| be the result of [=ReadableStream/cancel=] |stream| with
-        |reason|.
-
-     1. [=Clean up after running script=] with |environment settings|.
+     1. [=Remove a readable stream=] given |session| and |stream id|.
 
      1. [=React=] to |promise|:
 
@@ -7891,8 +7931,10 @@ The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of
 <div algorithm="remote end steps for io.readStream">
 The [=remote end steps=] given |session| and |command parameters| are:
 
+1. Let |stream id| be |command parameters|["<code>stream</code>"].
+
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
-   |session| and |command parameters|["<code>stream</code>"].
+   |session| and |stream id|.
 
 1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 
@@ -7932,8 +7974,11 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. [=ReadableStreamDefaultReader/Release=] |reader|.
 
-   1. If |read result|.\[[Type]] is <code>throw</code>, return [=error=] with
-      [=error code=] [=stream read error=].
+   1. If |read result|.\[[Type]] is <code>throw</code>:
+
+      1. [=Remove a readable stream=] given |session| and |stream id|.
+
+      1. Return [=error=] with [=error code=] [=stream read error=].
 
    1. Assert: |read result|.\[[Type]] is <code>normal</code>.
 
@@ -7942,6 +7987,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
    1. Let |done| be |read value|["<code>done</code>"].
 
    1. If |done| is true:
+
+      1. [=Remove a readable stream=] given |session| and |stream id|.
 
       1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
          field set to null and the <code>done</code> field set to true.
@@ -14106,10 +14153,11 @@ Define the following [=unloading document cleanup steps=] with |document|:
 
 1. For each |active session| in [=active sessions=]:
 
-   1. For each |stream setting| in [=active sessions=]'s [=readable stream settings map=]:
+   1. For each |stream id| → |stream settings| in |active session|'s
+      [=readable stream settings map=]:
 
-      1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
-         [=map/remove=] |stream setting|.
+      1. If |stream settings|[[=stream settings/realm=]] equals |realm id|,
+         [=remove a readable stream=] given |active session| and |stream id|.
 
 1. Let |params| be a [=/map=] matching the
    <code>script.RealmDestroyedParameters</code> production, with the
@@ -14138,10 +14186,11 @@ worker=] algorithm:
 
 1. For each |active session| in [=active sessions=]:
 
-   1. For each |stream setting| in [=active sessions=]'s [=readable stream settings map=]:
+   1. For each |stream id| → |stream settings| in |active session|'s
+      [=readable stream settings map=]:
 
-      1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
-         [=map/remove=] |stream setting|.
+      1. If |stream settings|[[=stream settings/realm=]] equals |realm id|,
+         [=remove a readable stream=] given |active session| and |stream id|.
 
 1. Let |params| be a [=/map=] matching the <code>script.RealmDestroyedParameters</code>
    production, with the <code>realm</code> field set of |realm id|.

--- a/index.bs
+++ b/index.bs
@@ -8005,7 +8005,18 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
         <dl>
            <dt>[=read request/chunk steps=], given |chunk|
-           <dd>Resolve |promise| with «[ "value" → |chunk|, "done" → false ]».
+           <dd>
+           1. If |chunk| is not a {{Uint8Array}} object:
+
+              1. Let |error| be a new
+                 <a data-link-type="exception">TypeError</a> object in |realm|.
+
+              1. Reject |promise| with |error|.
+
+              1. Return.
+
+           1. Resolve |promise| with «[ "value" → |chunk|, "done" → false ]».
+
            <dt>[=read request/close steps=]
            <dd>Resolve promise with «[ "value" → undefined, "done" → true ]».
            <dt>[=read request/error steps=], given |e|

--- a/index.bs
+++ b/index.bs
@@ -114,6 +114,10 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     text: set a property; url: dfn-set-a-property
     text: success; url: dfn-success
     text: table for cookie conversion; url: dfn-table-for-cookie-conversion
+    text: start the timer; url: dfn-start-the-timer
+    text: timeout; url: dfn-timeout
+    text: timeout fired flag; for: timer; url: dfn-timeout-fired-flag
+    text: timer; url: dfn-timer
     text: try; url: dfn-try
     text: trying; url: dfn-try
     text: unable to capture screen; url: dfn-unable-to-capture-screen
@@ -872,6 +876,7 @@ ErrorCode = "invalid argument" /
             "session not created" /
             "stream closed" /
             "stream read error" /
+            "timeout" /
             "unable to capture screen" /
             "unable to close browser" /
             "unable to set cookie" /
@@ -7894,7 +7899,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 #### The io.readStream Command #### {#command-io.readStream}
 
 The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of a
-[=readable stream=].
+[=readable stream=]. If provided, the <code>timeout</code> parameter specifies the
+maximum number of milliseconds to wait for the next chunk. If the timeout
+expires, the command returns an [=error=] with [=error code=] [=timeout=]
+without removing the stream.
 
 <dl>
   <dt>Command Type</dt>
@@ -7907,6 +7915,7 @@ The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of
 
       io.ReadStreamParameters = {
         stream: io.Stream,
+        ? timeout: js-uint,
       }
     </pre>
    </dd>
@@ -7923,6 +7932,9 @@ The <dfn export for=commands>io.ReadStream</dfn> command reads the next chunk of
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |stream id| be |command parameters|["<code>stream</code>"].
+
+1. Let |timeout| be |command parameters|["<code>timeout</code>"] if present, or
+   null otherwise.
 
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |stream id|.
@@ -7942,6 +7954,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Let |reader| be the result of [=trying=] to [=ReadableStream/getting a reader=] for |stream|.
 
+   1. Let |timer| be a new [=timer=].
+
+   1. If |timeout| is not null, [=start the timer=] with |timer| and |timeout|.
+
    1. Let |promise| be [=a new promise=].
 
    1. Let |read request| be a new [=read request=] with the following [=struct/items=]:
@@ -7957,11 +7973,17 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given |read request|.
 
-   1. Let |read result| be <a spec=ECMASCRIPT>Await</a>(|promise|).
+   1. Wait until |promise| is resolved, or |timer|'s [=timer/timeout fired flag=]
+      is set, whichever occurs first.
 
    1. [=Clean up after running script=] with |environment settings|.
 
    1. [=ReadableStreamDefaultReader/Release=] |reader|.
+
+   1. If |promise| is still pending and |timer|'s [=timer/timeout fired flag=]
+      is set, return [=error=] with [=error code=] [=timeout=].
+
+   1. Let |read result| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
    1. If |read result|.\[[Type]] is <code>throw</code>:
 

--- a/index.bs
+++ b/index.bs
@@ -7731,7 +7731,7 @@ relating to IO operations.
 <pre class="cddl" data-cddl-module="remote-cddl">
 
 IoCommand = (
-  io.Cancel //
+  io.CancelStream //
   io.ReadStream //
 )
 
@@ -7832,20 +7832,20 @@ The <code>io.Stream</code> type represents a handle to an IO [=/stream=].
 
 ### Commands ### {#module-io-commands}
 
-#### The io.cancel Command ####  {#command-io-cancel}
+#### The io.cancelStream Command ####  {#command-io-cancelStream}
 
-The <dfn export for=commands>io.Cancel</dfn> command cancels a [=readable stream=].
+The <dfn export for=commands>io.CancelStream</dfn> command cancels a [=readable stream=].
 
 <dl>
   <dt>Command Type</dt>
   <dd>
     <pre class="cddl" data-cddl-module="remote-cddl">
-      io.Cancel = (
-        method: "io.cancel",
-        params: io.CancelParameters
+      io.CancelStream = (
+        method: "io.cancelStream",
+        params: io.CancelStreamParameters
       )
 
-      io.CancelParameters = {
+      io.CancelStreamParameters = {
         stream: io.Stream,
         ? reason: text,
       }
@@ -7854,12 +7854,12 @@ The <dfn export for=commands>io.Cancel</dfn> command cancels a [=readable stream
    <dt>Return Type</dt>
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
-      io.CancelResult = EmptyResult
+      io.CancelStreamResult = EmptyResult
     </pre>
   </dd>
 </dl>
 
-<div algorithm="remote end steps for io.Cancel">
+<div algorithm="remote end steps for io.CancelStream">
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |stream id| be |command parameters|["<code>stream</code>"].

--- a/index.bs
+++ b/index.bs
@@ -1553,7 +1553,7 @@ explicitly test that scripts running in sandboxes work in all implementations.
 
 ## Sandbox Realms ## {#sandbox-realm}
 
-Each sandbox is a unique ECMAScript [=Realm=]. However the sandbox realm
+Each sandbox is a unique ECMAScript [=/Realm=]. However the sandbox realm
 provides access to platform objects in an existing {{Window}} realm via
 {{SandboxProxy}} objects.
 
@@ -7739,7 +7739,7 @@ a <code>io.Stream</code> and [=stream settings=].
 
 <dfn>Stream settings</dfn> is a [=struct=] with
 an [=struct/item=] named <dfn for="stream settings">stream</dfn>, which is a [=readable stream=],
-an [=struct/item=] named <dfn for="stream settings">navigable</dfn>, which is a <code>browsingContext.BrowsingContext</code> or null.
+an [=struct/item=] named <dfn for="stream settings">realm</dfn>, which is a <code>script.Realm</code> or null.
 
 <div class="algorithm">
 
@@ -7824,16 +7824,15 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 
-1. Let |navigable id| be |stream settings|[[=stream settings/navigable=]].
+1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
 
 1. If |command parameters| [=map/contains=] "<code>reason</code>", let |reason|
    be |command parameters|["<code>reason</code>"]. Otherwise let |reason| be
    undefined.
 
-1. If |navigable id| is not null:
+1. If |realm id| is not null:
 
-     1. Let |realm| be the result of [=trying=] to [=get a realm from a navigable=]
-        with |navigable id| and null.
+     1. Let |realm| be the result of [=trying=] to [=get a realm=] with |realm id|.
 
      1. Let |environment settings| be the [=environment settings object=] whose
         [=realm execution context=]'s Realm component is |realm|.
@@ -7843,23 +7842,21 @@ The [=remote end steps=] given |session| and |command parameters| are:
      1. Let |promise| be the result of [=ReadableStream/cancel=] |stream| with
         |reason|.
 
+     1. [=Clean up after running script=] with |environment settings|.
+
      1. [=React=] to |promise|:
 
       1. If |promise| was rejected, then:
-
-         1. [=Clean up after running script=] with |environment settings|.
 
          1. Return [=error=] with [=error code=] [=stream closed=].
 
       1. If |promise| was fulfilled, then:
 
-         1. [=Clean up after running script=] with |environment settings|.
-
          1. Return [=success=] with data null.
 
 1. Otherwise, return error with [=error code=] [=unsupported operation=].
 
-   TODO: Add support for streams that don't have an associated navigable.
+   TODO: Add support for streams that don't have an associated realm.
 
 </div>
 
@@ -7899,21 +7896,33 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Let |stream| be |stream settings|[[=stream settings/stream=]].
 
-1. Let |navigable id| be |stream settings|[[=stream settings/navigable=]].
+1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
 
-1. If |navigable id| is not null:
+1. If |realm id| is not null:
 
-   1. Let |realm| be the result of [=trying=] to [=get a realm from a navigable=]
-      with |navigable id| and null.
+   1. Let |realm| be the result of [=trying=] to [=get a realm=] with |realm id|.
 
    1. Let |environment settings| be the [=environment settings object=] whose
       [=realm execution context=]'s Realm component is |realm|.
 
    1. [=Prepare to run script=] with |environment settings|.
 
-   1. Let |reader| be the result of [=ReadableStream/getting a reader=] for |stream|.
+   1. Let |reader| be the result of [=trying=] to [=ReadableStream/getting a reader=] for |stream|.
 
-   1. Let |read result| be the result of calling {{ReadableStreamDefaultReader/read()}} for |reader|.
+   1. Let |promise| be [=a new promise=].
+
+   1. Let |read request| be a new [=read request=] with the following [=struct/items=]:
+
+     <dl>
+        <dt>[=read request/chunk steps=], given |chunk|
+        <dd>Resolve |promise| with «[ "value" → |chunk|, "done" → false ]».
+        <dt>[=read request/close steps=]
+        <dd>Resolve promise with «[ "value" → undefined, "done" → true ]».
+        <dt>[=read request/error steps=], given |e|
+        <dd>Reject |promise| with |e|.
+     </dl>
+
+   1. Let |read request| be the result of [=ReadableStreamDefaultReader/read a chunk=] from |reader| given |read request|.
 
    1. If |read result|.\[[Type]] is <code>normal</code>.:
 
@@ -7949,7 +7958,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 1. Otherwise, return [=error=] with [=error code=] [=unsupported operation=].
 
-   TODO: Add support for streams that don't have an associated navigable.
+   TODO: Add support for streams that don't have an associated realm.
 
 </div>
 
@@ -11568,9 +11577,9 @@ script.Handle = text;
 </pre>
 
 The <code>script.Handle</code> type represents a handle to an object owned by
-the ECMAScript runtime. The handle is only valid in a specific [=Realm=].
+the ECMAScript runtime. The handle is only valid in a specific [=/Realm=].
 
-Each ECMAScript [=Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
+Each ECMAScript [=/Realm=] has a corresponding <dfn>handle object map</dfn>. This is a
 strong [=/map=] from handle ids to their corresponding objects.
 
 #### The script.InternalId Type #### {#type-script-InternalId}
@@ -11806,7 +11815,7 @@ on realm creation.
 script.Realm = text;
 </pre>
 
-Each [=realm=] has an associated <dfn export>realm id</dfn>, which is a string
+Each [=/realm=] has an associated <dfn export>realm id</dfn>, which is a string
 uniquely identifying that realm. This is implicitly set when the realm is
 created.
 
@@ -11822,10 +11831,10 @@ To <dfn>get a realm</dfn> given |realm id|:
 
 1. If |realm id| is null, return [=success=] with data null.
 
-1. If there is no [=realm=] with [=realm id|id=] |realm id| return
+1. If there is no [=/realm=] with [=realm id|id=] |realm id| return
    [=error=] with [=error code=] [=no such frame=]
 
-1. Let |realm| be the [=realm=] with [=realm id|id=] |realm id|.
+1. Let |realm| be the [=/realm=] with [=realm id|id=] |realm id|.
 
 1. Return [=success=] with data |realm|
 
@@ -12254,7 +12263,7 @@ script.RemoteObjectReference = {
 
 The <code><dfn>script.RemoteReference</dfn></code> type is either a
 <code>script.RemoteObjectReference</code> representing a remote reference to an
-existing ECMAScript object in [=handle object map=] in the given [=Realm=], or
+existing ECMAScript object in [=handle object map=] in the given [=/Realm=], or
 is a <code>script.SharedReference</code> representing a reference to a [=node=].
 
 Issue: handle "stale object reference" case.
@@ -12897,16 +12906,14 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
     1. Let |stream realm| be |value|'s [=relevant settings object=]'s
        [=realm execution context=]'s Realm component.
 
-    1. Let |navigable| be the result of [=get the navigable=] with |stream realm|.
-
-    1. If |navigable| is null, let |navigable id| be null. Otherwise, let
-       |navigable id| be the [=navigable id=] for |navigable|.
+    1. If |stream realm| is null, let |realm id| be null. Otherwise, let
+       |realm id| be the [=realm id=] for |stream realm|.
 
     1. Let |stream id| be the string representation of a [[!RFC9562|UUID]].
 
     1. Let |stream settings| be a [=stream settings=] struct with the
        [=stream settings/stream=] item set to |value| and the
-       [=stream settings/navigable=] item set to |navigable id|.
+       [=stream settings/realm=] item set to |realm id|.
 
     1. Set |session|'s [=readable stream settings map=][|stream id|] to
        |stream settings|.
@@ -13766,7 +13773,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 #### The script.getRealms Command ####  {#command-script-getRealms}
 
 The <dfn export for=commands>script.getRealms</dfn> command returns a list of
-all realms, optionally filtered to [=realms=] of a specific type, or to the
+all realms, optionally filtered to [=/realms=] of a specific type, or to the
 realm associated with a [=/navigable=]'s [=active document=].
 
 <dl>
@@ -14097,6 +14104,13 @@ Define the following [=unloading document cleanup steps=] with |document|:
 
 1. Let |realm id| be the [=realm id=] for |realm|.
 
+1. For each |active session| in [=active sessions=]:
+
+   1. For each |stream setting| in [=active sessions=]'s [=stream settings=]:
+
+      1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
+         [=map/remove=] |stream setting|.
+
 1. Let |params| be a [=/map=] matching the
    <code>script.RealmDestroyedParameters</code> production, with the
    <code>realm</code> field set to |realm id|.
@@ -14121,6 +14135,13 @@ worker=] algorithm:
 1. Let |realm| be |environment settings|'s [=environment settings object's Realm=].
 
 1. Let |realm id| be the [=realm id=] for |realm|.
+
+1. For each |active session| in [=active sessions=]:
+
+   1. For each |stream setting| in [=active sessions=]'s [=stream settings=]:
+
+      1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
+         [=map/remove=] |stream setting|.
 
 1. Let |params| be a [=/map=] matching the <code>script.RealmDestroyedParameters</code>
    production, with the <code>realm</code> field set of |realm id|.

--- a/index.bs
+++ b/index.bs
@@ -8026,13 +8026,13 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given
          |read request|.
 
+   1. [=Clean up after running script=] with |environment settings|.
+
    1. Wait until |promise| is settled, or |timer|'s [=timer/timeout fired flag=]
       is set, whichever occurs first.
 
    1. If |promise| is still pending and |timer|'s [=timer/timeout fired flag=]
       is set:
-
-      1. [=Clean up after running script=] with |environment settings|.
 
       1. Set |stream settings|[[=stream settings/read command active=]] to false.
 
@@ -8046,11 +8046,15 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
       1. If |reader|'s
          <a spec=STREAMS for=ReadableStreamGenericReader>\[[stream]]</a> internal
-         slot is not undefined, [=ReadableStreamDefaultReader/release=] |reader|.
+         slot is not undefined:
+
+         1. [=Prepare to run script=] with |environment settings|.
+
+         1. [=ReadableStreamDefaultReader/release=] |reader|.
+
+         1. [=Clean up after running script=] with |environment settings|.
 
       1. Set |stream settings|[[=stream settings/reader=]] to null.
-
-      1. [=Clean up after running script=] with |environment settings|.
 
       1. Set |stream settings|[[=stream settings/read command active=]] to false.
 
@@ -8068,7 +8072,13 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
       1. If |reader|'s
          <a spec=STREAMS for=ReadableStreamGenericReader>\[[stream]]</a> internal
-         slot is not undefined, [=ReadableStreamDefaultReader/release=] |reader|.
+         slot is not undefined:
+
+         1. [=Prepare to run script=] with |environment settings|.
+
+         1. [=ReadableStreamDefaultReader/release=] |reader|.
+
+         1. [=Clean up after running script=] with |environment settings|.
 
       1. Set |stream settings|[[=stream settings/reader=]] to null.
 
@@ -8082,8 +8092,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
          field set to [=forgiving-base64 encode=] |chunk| and the <code>done</code> field
          set to false.
-
-   1. [=Clean up after running script=] with |environment settings|.
 
    1. Set |stream settings|[[=stream settings/read command active=]] to false.
 

--- a/index.bs
+++ b/index.bs
@@ -7924,7 +7924,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. Let |read request| be the result of [=ReadableStreamDefaultReader/read a chunk=] from |reader| given |read request|.
 
-   1. If |read result|.\[[Type]] is <code>normal</code>.:
+   1. If |read result|.\[[Type]] is <code>normal</code>:
 
       1. Set |read result| to <a spec=ECMASCRIPT>Await</a>(|read result|.\[[Value]]).
 
@@ -14106,7 +14106,7 @@ Define the following [=unloading document cleanup steps=] with |document|:
 
 1. For each |active session| in [=active sessions=]:
 
-   1. For each |stream setting| in [=active sessions=]'s [=stream settings=]:
+   1. For each |stream setting| in [=active sessions=]'s [=readable stream settings map=]:
 
       1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
          [=map/remove=] |stream setting|.
@@ -14138,7 +14138,7 @@ worker=] algorithm:
 
 1. For each |active session| in [=active sessions=]:
 
-   1. For each |stream setting| in [=active sessions=]'s [=stream settings=]:
+   1. For each |stream setting| in [=active sessions=]'s [=readable stream settings map=]:
 
       1. If |stream setting|[[=stream settings/realm=]] equal |realm id|
          [=map/remove=] |stream setting|.

--- a/index.bs
+++ b/index.bs
@@ -8014,7 +8014,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given
          |read request|.
 
-   1. Wait until |promise| is resolved, or |timer|'s [=timer/timeout fired flag=]
+   1. Wait until |promise| is settled, or |timer|'s [=timer/timeout fired flag=]
       is set, whichever occurs first.
 
    1. If |promise| is still pending and |timer|'s [=timer/timeout fired flag=]

--- a/index.bs
+++ b/index.bs
@@ -7805,8 +7805,10 @@ To <dfn>cancel a readable stream</dfn> given |realm|, |stream settings| and |rea
 
 1. [=Prepare to run script=] with |environment settings|.
 
-1. If |reader| is null, let |promise| be the result of [=ReadableStream/cancel=]
-   |stream| with |reason|.
+1. If |reader| is null or |reader|'s
+   <a spec=STREAMS for=ReadableStreamGenericReader>\[[stream]]</a> internal slot
+   is undefined, let |promise| be the result of [=ReadableStream/cancel=] |stream|
+   with |reason|.
 
 1. Otherwise:
 
@@ -7814,6 +7816,8 @@ To <dfn>cancel a readable stream</dfn> given |realm|, |stream settings| and |rea
       |reader| with |reason|.
 
    1. [=ReadableStreamDefaultReader/Release=] |reader|.
+
+1. Set |stream settings|[[=stream settings/reader=]] to null.
 
 1. [=Clean up after running script=] with |environment settings|.
 
@@ -8029,7 +8033,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. If |read result|.\[[Type]] is <code>throw</code>:
 
-      1. [=ReadableStreamDefaultReader/Release=] |reader|.
+      1. If |reader|'s
+         <a spec=STREAMS for=ReadableStreamGenericReader>\[[stream]]</a> internal
+         slot is not undefined, [=ReadableStreamDefaultReader/release=] |reader|.
 
       1. Set |stream settings|[[=stream settings/reader=]] to null.
 
@@ -8049,7 +8055,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. If |done| is true:
 
-      1. [=ReadableStreamDefaultReader/Release=] |reader|.
+      1. If |reader|'s
+         <a spec=STREAMS for=ReadableStreamGenericReader>\[[stream]]</a> internal
+         slot is not undefined, [=ReadableStreamDefaultReader/release=] |reader|.
 
       1. Set |stream settings|[[=stream settings/reader=]] to null.
 

--- a/index.bs
+++ b/index.bs
@@ -7754,7 +7754,8 @@ a <code>io.Stream</code> and [=stream settings=].
 
 <dfn>Stream settings</dfn> is a [=struct=] with
 an [=struct/item=] named <dfn for="stream settings">stream</dfn>, which is a [=readable stream=],
-an [=struct/item=] named <dfn for="stream settings">realm</dfn>, which is a <code>script.Realm</code> or null.
+an [=struct/item=] named <dfn for="stream settings">realm</dfn>, which is a <code>script.Realm</code> or null, and
+an [=struct/item=] named <dfn for="stream settings">handle</dfn>, which is a <code>script.Handle</code>.
 
 <div class="algorithm">
 
@@ -12559,8 +12560,10 @@ script.WindowProxyProperties = {
 
 script.ReadableStreamRemoteValue = {
   type: "readable-stream",
-  stream: io.Stream,
-  ? handle: script.Handle,
+  ? (
+    stream: io.Stream,
+    handle: script.Handle,
+  ),
   ? internalId: script.InternalId,
 }
 </pre>
@@ -12938,29 +12941,33 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
 
     <dt>|value| is a [=platform object=] that implements {{ReadableStream}}
     <dd>
-    1. Let |stream realm| be |value|'s [=relevant settings object=]'s
-       [=realm execution context=]'s Realm component.
-
-    1. If |stream realm| is null, let |realm id| be null. Otherwise, let
-       |realm id| be the [=realm id=] for |stream realm|.
-
-    1. Let |stream id| be the string representation of a [[!RFC9562|UUID]].
-
-    1. Let |stream settings| be a [=stream settings=] struct with the
-       [=stream settings/stream=] item set to |value| and the
-       [=stream settings/realm=] item set to |realm id|.
-
-    1. Set |session|'s [=readable stream settings map=][|stream id|] to
-       |stream settings|.
-
     1. Let |remote value| be a [=/map=] matching the
        <code>script.ReadableStreamRemoteValue</code> production in the
-       {^local end definition^}, with the <code>stream</code> property set to
-       |stream id|, and the <code>handle</code> property set to |handle id| if
-       it's not null, or omitted otherwise.
+       {^local end definition^}, with the <code>handle</code> property set to
+       |handle id| if it's not null, or omitted otherwise.
 
-   1. [=Set internal ids if needed=] with |serialization internal map|,
-      |remote value| and |value|.
+    1. [=Set internal ids if needed=] with |serialization internal map|,
+       |remote value| and |value|.
+
+    1. If |handle id| is not null:
+
+       1. Let |stream realm| be |value|'s [=relevant settings object=]'s
+          [=realm execution context=]'s Realm component.
+
+       1. If |stream realm| is null, let |realm id| be null. Otherwise, let
+          |realm id| be the [=realm id=] for |stream realm|.
+
+       1. Let |stream id| be the string representation of a [[!RFC9562|UUID]].
+
+       1. Let |stream settings| be a [=stream settings=] struct with the
+          [=stream settings/stream=] item set to |value|, the
+          [=stream settings/realm=] item set to |realm id|, and the
+          [=stream settings/handle=] item set to |handle id|.
+
+       1. Set |session|'s [=readable stream settings map=][|stream id|] to
+          |stream settings|.
+
+       1. Set |remote value|["<code>stream</code>"] to |stream id|.
 
     <dt>|value| is a [=platform object=]
     <dd>1. Let |remote value| be a [=/map=] matching the <code>script.ObjectRemoteValue</code>
@@ -13493,7 +13500,7 @@ other handles or strong ECMAScript references.
 </dl>
 
 <div algorithm="remote end steps for script.disown">
-The [=remote end steps=] with |command parameters| are:
+The [=remote end steps=] with |session| and |command parameters| are:
 
 1. Let |realm| be the result of [=trying=] to [=get a realm from a target=]
    given the value of the <code>target</code> field of |command parameters|.
@@ -13504,7 +13511,19 @@ The [=remote end steps=] with |command parameters| are:
 
    1. Let |handle map| be |realm|'s [=handle object map=]
 
-   1. If |handle map| contains |handle id|, remove |handle id| from the |handle map|.
+   1. If |handle map| contains |handle id|:
+
+      1. Remove |handle id| from the |handle map|.
+
+      1. For each |stream id| → |stream settings| in |session|'s
+         [=readable stream settings map=]:
+
+         1. If |stream settings|[[=stream settings/handle=]] equals |handle id|:
+
+            1. [=Cancel a readable stream=] given |realm|,
+               |stream settings|[[=stream settings/stream=]] and undefined.
+
+            1. [=Remove a readable stream=] given |session| and |stream id|.
 
 1. Return [=success=] with data null.
 

--- a/index.bs
+++ b/index.bs
@@ -1866,7 +1866,7 @@ To <dfn>cleanup the session</dfn> given |session|:
       1. Let |realm| be the [=/realm=] with [=realm id|id=] |realm id|.
 
       1. [=Cancel a readable stream=] given |realm|,
-         |stream settings|[[=stream settings/stream=]] and undefined.
+         |stream settings| and undefined.
 
 1. [=map/Clear=] |session|'s [=readable stream settings map=].
 
@@ -7757,10 +7757,17 @@ data that can be read from or written to.
 A [=BiDi Session=] has a <dfn>readable stream settings map</dfn> which is a [=/map=] between
 a <code>io.Stream</code> and [=stream settings=].
 
-<dfn>Stream settings</dfn> is a [=struct=] with
-an [=struct/item=] named <dfn for="stream settings">stream</dfn>, which is a [=readable stream=],
-an [=struct/item=] named <dfn for="stream settings">realm</dfn>, which is a <code>script.Realm</code> or null, and
-an [=struct/item=] named <dfn for="stream settings">handle</dfn>, which is a <code>script.Handle</code>.
+<dfn>Stream settings</dfn> is a [=struct=] with the following [=struct/items=]:
+
+* <dfn for="stream settings">stream</dfn>, which is a [=readable stream=].
+* <dfn for="stream settings">realm</dfn>, which is a <code>script.Realm</code> or null.
+* <dfn for="stream settings">handle</dfn>, which is a <code>script.Handle</code>.
+* <dfn for="stream settings">reader</dfn>, which is a {{ReadableStreamDefaultReader}}
+  or null, initially null.
+* <dfn for="stream settings">read promise</dfn>, which is a promise or null,
+  initially null.
+* <dfn for="stream settings">read command active</dfn>, which is a boolean,
+  initially false.
 
 <div class="algorithm">
 
@@ -7787,15 +7794,26 @@ To <dfn>remove a readable stream</dfn> given |session| and |stream|:
 
 <div class="algorithm">
 
-To <dfn>cancel a readable stream</dfn> given |realm|, |stream| and |reason|:
+To <dfn>cancel a readable stream</dfn> given |realm|, |stream settings| and |reason|:
+
+1. Let |stream| be |stream settings|[[=stream settings/stream=]].
+
+1. Let |reader| be |stream settings|[[=stream settings/reader=]].
 
 1. Let |environment settings| be the [=environment settings object=] whose
    [=realm execution context=]'s Realm component is |realm|.
 
 1. [=Prepare to run script=] with |environment settings|.
 
-1. Let |promise| be the result of [=ReadableStream/cancel=] |stream| with
-   |reason|.
+1. If |reader| is null, let |promise| be the result of [=ReadableStream/cancel=]
+   |stream| with |reason|.
+
+1. Otherwise:
+
+   1. Let |promise| be the result of [=ReadableStreamDefaultReader/cancel=]
+      |reader| with |reason|.
+
+   1. [=ReadableStreamDefaultReader/Release=] |reader|.
 
 1. [=Clean up after running script=] with |environment settings|.
 
@@ -7863,8 +7881,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |stream id|.
 
-1. Let |stream| be |stream settings|[[=stream settings/stream=]].
-
 1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
 
 1. If |command parameters| [=map/contains=] "<code>reason</code>", let |reason|
@@ -7876,7 +7892,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
      1. Let |realm| be the result of [=trying=] to [=get a realm=] with |realm id|.
 
      1. Let |promise| be the result of [=cancel a readable stream=] given
-        |realm|, |stream| and |reason|.
+        |realm|, |stream settings| and |reason|.
 
      1. [=Remove a readable stream=] given |session| and |stream id|.
 
@@ -7939,8 +7955,6 @@ The [=remote end steps=] given |session| and |command parameters| are:
 1. Let |stream settings| be the result of [=trying=] to [=get readable stream settings=] with
    |session| and |stream id|.
 
-1. Let |stream| be |stream settings|[[=stream settings/stream=]].
-
 1. Let |realm id| be |stream settings|[[=stream settings/realm=]].
 
 1. If |realm id| is not null:
@@ -7950,44 +7964,81 @@ The [=remote end steps=] given |session| and |command parameters| are:
    1. Let |environment settings| be the [=environment settings object=] whose
       [=realm execution context=]'s Realm component is |realm|.
 
+   1. Let |stream map| be |session|'s [=readable stream settings map=].
+
+   1. Wait until |stream settings|[[=stream settings/read command active=]] is
+      false or |stream map| no longer [=map/contains=] |stream id|.
+
+   1. If |stream map| no longer [=map/contains=] |stream id|, return [=error=]
+      with [=error code=] [=no such stream=].
+
+   1. Set |stream settings|[[=stream settings/read command active=]] to true.
+
+   1. Let |stream| be |stream settings|[[=stream settings/stream=]].
+
    1. [=Prepare to run script=] with |environment settings|.
 
-   1. Let |reader| be the result of [=trying=] to [=ReadableStream/getting a reader=] for |stream|.
+   1. Let |reader| be |stream settings|[[=stream settings/reader=]].
+
+   1. If |reader| is null:
+
+      1. Set |reader| to the result of [=ReadableStream/getting a reader=] for
+         |stream|.
+
+      1. Set |stream settings|[[=stream settings/reader=]] to |reader|.
 
    1. Let |timer| be a new [=timer=].
 
    1. If |timeout| is not null, [=start the timer=] with |timer| and |timeout|.
 
-   1. Let |promise| be [=a new promise=].
+   1. Let |promise| be |stream settings|[[=stream settings/read promise=]].
 
-   1. Let |read request| be a new [=read request=] with the following [=struct/items=]:
+   1. If |promise| is null:
 
-     <dl>
-        <dt>[=read request/chunk steps=], given |chunk|
-        <dd>Resolve |promise| with «[ "value" → |chunk|, "done" → false ]».
-        <dt>[=read request/close steps=]
-        <dd>Resolve promise with «[ "value" → undefined, "done" → true ]».
-        <dt>[=read request/error steps=], given |e|
-        <dd>Reject |promise| with |e|.
-     </dl>
+      1. Set |promise| to [=a new promise=].
 
-   1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given |read request|.
+      1. Set |stream settings|[[=stream settings/read promise=]] to |promise|.
+
+      1. Let |read request| be a new [=read request=] with the following
+         [=struct/items=]:
+
+        <dl>
+           <dt>[=read request/chunk steps=], given |chunk|
+           <dd>Resolve |promise| with «[ "value" → |chunk|, "done" → false ]».
+           <dt>[=read request/close steps=]
+           <dd>Resolve promise with «[ "value" → undefined, "done" → true ]».
+           <dt>[=read request/error steps=], given |e|
+           <dd>Reject |promise| with |e|.
+        </dl>
+
+      1. [=ReadableStreamDefaultReader/Read a chunk=] from |reader| given
+         |read request|.
 
    1. Wait until |promise| is resolved, or |timer|'s [=timer/timeout fired flag=]
       is set, whichever occurs first.
 
-   1. Let |timed out| be true if |promise| is still pending and |timer|'s
-      [=timer/timeout fired flag=] is set, or false otherwise.
+   1. If |promise| is still pending and |timer|'s [=timer/timeout fired flag=]
+      is set:
 
-   1. [=Clean up after running script=] with |environment settings|.
+      1. [=Clean up after running script=] with |environment settings|.
 
-   1. [=ReadableStreamDefaultReader/Release=] |reader|.
+      1. Set |stream settings|[[=stream settings/read command active=]] to false.
+
+      1. Return [=error=] with [=error code=] [=timeout=].
 
    1. Let |read result| be <a spec=ECMASCRIPT>Await</a>(|promise|).
 
-   1. If |timed out| is true, return [=error=] with [=error code=] [=timeout=].
+   1. Set |stream settings|[[=stream settings/read promise=]] to null.
 
    1. If |read result|.\[[Type]] is <code>throw</code>:
+
+      1. [=ReadableStreamDefaultReader/Release=] |reader|.
+
+      1. Set |stream settings|[[=stream settings/reader=]] to null.
+
+      1. [=Clean up after running script=] with |environment settings|.
+
+      1. Set |stream settings|[[=stream settings/read command active=]] to false.
 
       1. [=Remove a readable stream=] given |session| and |stream id|.
 
@@ -8001,7 +8052,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
    1. If |done| is true:
 
-      1. [=Remove a readable stream=] given |session| and |stream id|.
+      1. [=ReadableStreamDefaultReader/Release=] |reader|.
+
+      1. Set |stream settings|[[=stream settings/reader=]] to null.
 
       1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
          field set to null and the <code>done</code> field set to true.
@@ -8013,6 +8066,13 @@ The [=remote end steps=] given |session| and |command parameters| are:
       1. Let |response| be a new <code>io.ReadData</code> with the <code>value</code>
          field set to [=forgiving-base64 encode=] |chunk| and the <code>done</code> field
          set to false.
+
+   1. [=Clean up after running script=] with |environment settings|.
+
+   1. Set |stream settings|[[=stream settings/read command active=]] to false.
+
+   1. If |done| is true, [=remove a readable stream=] given |session| and
+      |stream id|.
 
    1. Return [=success=] with data |response|.
 
@@ -12986,7 +13046,10 @@ an |ownership type|, a |serialization internal map|, a |realm| and a |session|:
        1. Let |stream settings| be a [=stream settings=] struct with the
           [=stream settings/stream=] item set to |value|, the
           [=stream settings/realm=] item set to |realm id|, and the
-          [=stream settings/handle=] item set to |handle id|.
+          [=stream settings/handle=] item set to |handle id|, the
+          [=stream settings/reader=] and [=stream settings/read promise=] items
+          set to null, and the [=stream settings/read command active=] item set
+          to false.
 
        1. Set |session|'s [=readable stream settings map=][|stream id|] to
           |stream settings|.
@@ -13545,7 +13608,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
          1. If |stream settings|[[=stream settings/handle=]] equals |handle id|:
 
             1. [=Cancel a readable stream=] given |realm|,
-               |stream settings|[[=stream settings/stream=]] and undefined.
+               |stream settings| and undefined.
 
             1. [=Remove a readable stream=] given |session| and |stream id|.
 

--- a/index.bs
+++ b/index.bs
@@ -7976,14 +7976,16 @@ The [=remote end steps=] given |session| and |command parameters| are:
    1. Wait until |promise| is resolved, or |timer|'s [=timer/timeout fired flag=]
       is set, whichever occurs first.
 
+   1. Let |timed out| be true if |promise| is still pending and |timer|'s
+      [=timer/timeout fired flag=] is set, or false otherwise.
+
    1. [=Clean up after running script=] with |environment settings|.
 
    1. [=ReadableStreamDefaultReader/Release=] |reader|.
 
-   1. If |promise| is still pending and |timer|'s [=timer/timeout fired flag=]
-      is set, return [=error=] with [=error code=] [=timeout=].
-
    1. Let |read result| be <a spec=ECMASCRIPT>Await</a>(|promise|).
+
+   1. If |timed out| is true, return [=error=] with [=error code=] [=timeout=].
 
    1. If |read result|.\[[Type]] is <code>throw</code>:
 


### PR DESCRIPTION
An alternative approach to #1061 to handle streams in the associated document's realm + adding the serialization of ReadableStreams as RemoteValue to demonstrate how the whole flow would look.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1135.html" title="Last updated on Sep 10, 2026, 1:45 PM UTC (c5e536d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1135/d636c85...lutien:c5e536d.html" title="Last updated on Sep 10, 2026, 1:45 PM UTC (c5e536d)">Diff</a>