### PR TITLE
Add a CDDL extension point for webExtension.install parameters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -730,13 +730,10 @@ Authors of external specifications are encouraged to to add new modules rather t
 existing ones. Where it is desired to extend an existing module, it is preferred to integrate the
 extension directly into the specification containing the original module definition.
 
-Some [=command parameters=] types include a dedicated [[!RFC8610|CDDL]]
-extension group, named after the parameters type with an "<code>Extension</code>"
-suffix and having the value <code>Extensible</code>. An implementation may add
-vendor-specific fields to such a type by extending that group with a group
-choice ("<code>//=</code>"). To avoid conflicts with other implementations, each
-added field name must begin with a prefix that is unique to the implementation,
-followed by a U+003A (:) character.
+An implementation may add vendor-specific fields to the [=command parameters=]
+of a [=command=]. To avoid conflicts with other implementations, each such field
+name must begin with a prefix that is unique to the implementation, followed by
+a U+003A (:) character.
 
 ## Commands ## {#commands}
 
@@ -15110,10 +15107,7 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
 
       webExtension.InstallParameters = {
          extensionData: webExtension.ExtensionData,
-         webExtension.InstallParametersExtension,
       }
-
-      webExtension.InstallParametersExtension = ( Extensible )
 
       webExtension.ExtensionData = (
          webExtension.ExtensionArchivePath /

--- a/index.bs
+++ b/index.bs
@@ -730,6 +730,16 @@ Authors of external specifications are encouraged to to add new modules rather t
 existing ones. Where it is desired to extend an existing module, it is preferred to integrate the
 extension directly into the specification containing the original module definition.
 
+An implementation may extend a [=command=]'s [=command parameters=] with
+vendor-specific fields. For this to be expressible in the {^remote end
+definition^}, a parameter map that permits such extension exposes a
+[[!RFC8610|CDDL]] group socket whose name is the parameters type name
+followed by "<code>.extension</code>", prefixed with "<code>$$</code>", and
+whose default is the empty group. An [=extension module=] adds fields by
+augmenting that socket. As with the [=module names=] of [=extension modules=],
+each field name added in this way must begin with a prefix that is unique for a
+given implementation, followed by a U+003A (:) character.
+
 ## Commands ## {#commands}
 
 A <dfn export>command</dfn> is an asynchronous operation, requested by
@@ -15102,7 +15112,10 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
 
       webExtension.InstallParameters = {
          extensionData: webExtension.ExtensionData,
+         $$webExtension.InstallParameters.extension,
       }
+
+      $$webExtension.InstallParameters.extension //= ()
 
       webExtension.ExtensionData = (
          webExtension.ExtensionArchivePath /

--- a/index.bs
+++ b/index.bs
@@ -730,15 +730,13 @@ Authors of external specifications are encouraged to to add new modules rather t
 existing ones. Where it is desired to extend an existing module, it is preferred to integrate the
 extension directly into the specification containing the original module definition.
 
-An implementation may extend a [=command=]'s [=command parameters=] with
-vendor-specific fields. For this to be expressible in the {^remote end
-definition^}, a parameter map that permits such extension includes a dedicated
-[[!RFC8610|CDDL]] group, named after the parameters type with an
-"<code>Extension</code>" suffix, whose value is <code>Extensible</code>. As
-with the [=module names=] of [=extension modules=], each such field name must
-begin with a prefix that is unique for a given implementation, followed by a
-U+003A (:) character. An [=extension module=] may declare the specific fields it
-adds by extending this group with a group choice ("<code>//=</code>").
+Some [=command parameters=] types include a dedicated [[!RFC8610|CDDL]]
+extension group, named after the parameters type with an "<code>Extension</code>"
+suffix and having the value <code>Extensible</code>. An implementation may add
+vendor-specific fields to such a type by extending that group with a group
+choice ("<code>//=</code>"). To avoid conflicts with other implementations, each
+added field name must begin with a prefix that is unique to the implementation,
+followed by a U+003A (:) character.
 
 ## Commands ## {#commands}
 

--- a/index.bs
+++ b/index.bs
@@ -732,11 +732,11 @@ extension directly into the specification containing the original module definit
 
 An implementation may extend a [=command=]'s [=command parameters=] with
 vendor-specific fields. For this to be expressible in the {^remote end
-definition^}, a parameter map that permits such extension exposes a
-[[!RFC8610|CDDL]] group socket whose name is the parameters type name
-followed by "<code>.extension</code>", prefixed with "<code>$$</code>", and
-whose default is the empty group. An [=extension module=] adds fields by
-augmenting that socket. As with the [=module names=] of [=extension modules=],
+definition^}, a parameter map that permits such extension includes a dedicated
+[[!RFC8610|CDDL]] group, named after the parameters type with an
+"<code>Extension</code>" suffix, that is empty by default. An [=extension
+module=] adds fields by extending that group with a group choice
+("<code>//=</code>"). As with the [=module names=] of [=extension modules=],
 each field name added in this way must begin with a prefix that is unique for a
 given implementation, followed by a U+003A (:) character.
 
@@ -15112,10 +15112,10 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
 
       webExtension.InstallParameters = {
          extensionData: webExtension.ExtensionData,
-         $$webExtension.InstallParameters.extension,
+         webExtension.InstallParametersExtension,
       }
 
-      $$webExtension.InstallParameters.extension //= ()
+      webExtension.InstallParametersExtension = ()
 
       webExtension.ExtensionData = (
          webExtension.ExtensionArchivePath /

--- a/index.bs
+++ b/index.bs
@@ -734,11 +734,11 @@ An implementation may extend a [=command=]'s [=command parameters=] with
 vendor-specific fields. For this to be expressible in the {^remote end
 definition^}, a parameter map that permits such extension includes a dedicated
 [[!RFC8610|CDDL]] group, named after the parameters type with an
-"<code>Extension</code>" suffix, that is empty by default. An [=extension
-module=] adds fields by extending that group with a group choice
-("<code>//=</code>"). As with the [=module names=] of [=extension modules=],
-each field name added in this way must begin with a prefix that is unique for a
-given implementation, followed by a U+003A (:) character.
+"<code>Extension</code>" suffix, whose value is <code>Extensible</code>. As
+with the [=module names=] of [=extension modules=], each such field name must
+begin with a prefix that is unique for a given implementation, followed by a
+U+003A (:) character. An [=extension module=] may declare the specific fields it
+adds by extending this group with a group choice ("<code>//=</code>").
 
 ## Commands ## {#commands}
 
@@ -15115,7 +15115,7 @@ The <dfn export for=commands>webExtension.install</dfn> command installs a web e
          webExtension.InstallParametersExtension,
       }
 
-      webExtension.InstallParametersExtension = ()
+      webExtension.InstallParametersExtension = ( Extensible )
 
       webExtension.ExtensionData = (
          webExtension.ExtensionArchivePath /


### PR DESCRIPTION
Adds a per-command CDDL extension point so vendor-specific command parameters can be declared with their own types in the remote end definition. Addresses the parameter-map case of w3c/webdriver-bidi#274, and gives the auto-generated clients in w3c/webdriver-bidi#791 something typed to generate from.

### Context

- `webExtension.InstallParameters` is a closed CDDL map, so a remote end that accepts extra install parameters cannot describe them in the remote end definition.
- Concretely, Firefox ships `moz:permanent` and `moz:allowPrivateBrowsing` on `webExtension.install`. Mozilla is maintaining a machine-readable `Extensions.cddl` for these ([bug 2057588](https://bugzilla.mozilla.org/show_bug.cgi?id=2057588)); this PR adds the base-side extension point that vendor file plugs into.

### Change

- Adds a `webExtension.InstallParametersExtension` group, referenced from `InstallParameters`, whose value is `Extensible`. A vendor or extension spec declares its specific fields by extending this group with a group choice (`//=`), e.g. `webExtension.InstallParametersExtension //= (? "moz:permanent": bool)`.
- Documents the convention generally: an extensible parameter map exposes a named `…Extension` group that vendors extend, with vendor-prefixed field names.

### Notes

- **Forward-compatible and additive.** The group's value is `Extensible` (`* text => any`), so the base still accepts unknown keys exactly as the envelope types do; adding it changes nothing about what `InstallParameters` validates today.
- **Typed, not just tolerated.** Unlike a bare `Extensible` in the map, the named group gives vendor CDDL a stable target to attach *typed* fields to. A code generator can then emit real typed parameters (e.g. a `boolean permanent` argument) instead of an untyped string→any map — which is the difference between a usable and an unusable API in statically-typed client bindings.
- **Scoped to command parameter maps.** These are dispatched by `method`, so they avoid the structural-typing ambiguity behind the broader discussion in w3c/webdriver-bidi#274.
- **Named group rather than an RFC 8610 socket.** A `$$…` group socket would be the idiomatic construct, but the spec toolchain (Bikeshed / cddlparser) has no socket support — it treats every `//=` as extending a prior `=` definition. A named group whose value is `Extensible` is the equivalent the toolchain accepts, and reuses the existing `Extensible` production.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver-bidi/pull/1140.html" title="Last updated on Aug 6, 2026, 5:38 PM UTC (9ae210c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1140/a7b8b67...titusfortner:9ae210c.html" title="Last updated on Aug 6, 2026, 5:38 PM UTC (9ae210c)">Diff</a>