### PR TITLE
Update "known subscription ids" when the list of subscribed contexts is empty after a context is destroyed.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5795,6 +5795,8 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given [=/navigabl
 
   1. Let |subscriptions to remove| be a [=/set=].
 
+  1. Let |subscription ids to remove| be a [=/set=].
+
   1. For each |subscription| in |session|'s [=subscriptions=]:
 
      1. If |subscription|'s [=subscription/top-level traversable ids=] [=set/contains=] |navigable|'s [=navigable id=];
@@ -5805,7 +5807,12 @@ the <dfn export>WebDriver BiDi navigable destroyed</dfn> steps given [=/navigabl
 
            1. [=set/Append=] |subscription| to |subscriptions to remove|.
 
-  1. [=list/Remove=] |subscriptions to remove| from |session|'s [=subscriptions=].
+           1. [=set/Append=] |subscription|'s [=subscription/subscription id=] to |subscription ids to remove|.
+
+1. Set |session|'s [=known subscription ids=] to
+   [=set/difference=] between |session|'s [=known subscription ids=] and |subscription ids to remove|.
+
+1. [=list/Remove=] each item in |subscriptions to remove| from |session|'s [=subscriptions=].
 
 Issue: It's unclear if we ought to only fire this event for browsing
 contexts that have active documents; navigation can also cause contexts to


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1143.html" title="Last updated on Aug 4, 2026, 4:19 PM UTC (99a23f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1143/6a2835c...lutien:99a23f8.html" title="Last updated on Aug 4, 2026, 4:19 PM UTC (99a23f8)">Diff</a>