### PR TITLE
fix: make userContext mandatory in event payloads

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3739,7 +3739,7 @@ browsingContext.BaseNavigationInfo = (
   navigation: browsingContext.Navigation / null,
   timestamp: js-uint,
   url: text,
-  ? userContext: browser.UserContext,
+  userContext: browser.UserContext,
 )
 
 browsingContext.NavigationInfo = {
@@ -4239,7 +4239,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
     <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.CreateResult = {
           context: browsingContext.BrowsingContext,
-          ? userContext: browser.UserContext
+          userContext: browser.UserContext
         }
     </pre>
    </dd>
@@ -5907,7 +5907,7 @@ given [=/navigable=] |navigable| and [=WebDriver BiDi navigation status|navigati
           context: browsingContext.BrowsingContext,
           timestamp: js-uint,
           url: text,
-          ? userContext: browser.UserContext
+          userContext: browser.UserContext
         }
       </pre>
    </dd>
@@ -6305,7 +6305,7 @@ given [=/navigable=] |navigable| and [=WebDriver BiDi navigation status|navigati
           context: browsingContext.BrowsingContext,
           accepted: bool,
           type: browsingContext.UserPromptType,
-          ? userContext: browser.UserContext,
+          userContext: browser.UserContext,
           ? userText: text
         }
       </pre>
@@ -6359,7 +6359,7 @@ given {{Window}} |window|, string |type|, boolean |accepted| and optional text |
           handler: session.UserPromptHandlerType,
           message: text,
           type: browsingContext.UserPromptType,
-          ? userContext: browser.UserContext,
+          userContext: browser.UserContext,
           ? defaultValue: text
         }
       </pre>
@@ -8471,13 +8471,17 @@ network.BaseParameters = (
     redirectCount: js-uint,
     request: network.RequestData,
     timestamp: js-uint,
-    ? userContext: browser.UserContext / null,
+    userContext: browser.UserContext / null,
     ? intercepts: [+network.Intercept]
 )
 </pre>
 
 The <code>network.BaseParameters</code> type is an abstract type representing
 the data that's common to all network events.
+
+Note: the <code>context</code> and <code>userContext</code> fields are either
+both non-null, when the request is associated with a [=/navigable=], or both
+null.
 
 Issue: Consider including the `sharedId` of the document node that initiated the
 request in addition to the context.
@@ -11922,7 +11926,7 @@ script.WindowRealmInfo = {
   script.BaseRealmInfo,
   type: "window",
   context: browsingContext.BrowsingContext,
-  ? userContext: browser.UserContext,
+  userContext: browser.UserContext,
   ? sandbox: text
 }
 
@@ -13081,6 +13085,10 @@ The <code>script.Source</code> type represents a <code>script.Realm</code> with
 an optional <code>browsingContext.BrowsingContext</code> and related
 <code>browser.UserContext</code> in which a script related event occurred.
 
+Note: the <code>context</code> and <code>userContext</code> fields are either
+both present, when the realm is associated with a [=/navigable=], or both
+omitted.
+
 <div algorithm>
 To <dfn>get the source</dfn> given |source realm|:
 
@@ -13097,7 +13105,8 @@ To <dfn>get the source</dfn> given |source realm|:
 
   1. Let |navigable id| be the [=navigable id=] for |navigable| if |navigable| is not null.
 
-  1. Let |user context id| be the [=user context id=] of |navigable|'s [=associated user context=].
+  1. Let |user context id| be the [=user context id=] of |navigable|'s
+     [=associated user context=] if |navigable| is not null.
 
   Otherwise let |navigable| be null.
 
@@ -13106,7 +13115,7 @@ To <dfn>get the source</dfn> given |source realm|:
    field set to |realm|, the <code>context</code> field set
    to |navigable id| if |navigable| is not null, or unset otherwise,
    and the <code>userContext</code> field set to |user context id| if
-   |navigable is not null, or unset otherwise.
+   |navigable| is not null, or unset otherwise.
 
 1. Return |source|.
 
@@ -15132,9 +15141,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
          input.FileDialogInfo = {
             context: browsingContext.BrowsingContext,
-            ? userContext: browser.UserContext,
-            ? element: script.SharedReference,
             multiple: bool,
+            userContext: browser.UserContext,
+            ? element: script.SharedReference,
          }
       </pre>
    </dd>

--- a/index.bs
+++ b/index.bs
@@ -6060,8 +6060,9 @@ The [=remote end event trigger=] is the
    <code>navigation</code> field set to |navigation info|["<code>navigation</code>"],
    the <code>timestamp</code> field set to
    |navigation info|["<code>timestamp</code>"], the <code>url</code> field set to
-   |navigation info|["<code>url</code>"], the <code>download</code> field set to |download|
-   and the <code>suggestedFilename</code> field set to
+   |navigation info|["<code>url</code>"], the <code>userContext</code> field set to
+   |navigation info|["<code>userContext</code>"], the <code>download</code> field
+   set to |download| and the <code>suggestedFilename</code> field set to
    |navigation status|'s [=WebDriver BiDi navigation status/suggestedFilename=].
 
 1. Let |body| be a [=/map=] matching the
@@ -6145,8 +6146,9 @@ The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download end<
    <code>context</code> field set to |navigation info|["<code>context</code>"], the
    <code>navigation</code> field set to |navigation info|["<code>navigation</code>"],
    the <code>timestamp</code> field set to
-   |navigation info|["<code>timestamp</code>"], and the <code>url</code> field set to
-   |navigation info|["<code>url</code>"].
+   |navigation info|["<code>timestamp</code>"], the <code>url</code> field set to
+   |navigation info|["<code>url</code>"], and the <code>userContext</code> field
+   set to |navigation info|["<code>userContext</code>"].
 
    Note: <code>filepath</code> can be null for completed downloads if the filepath is
    not available for whatever reason.
@@ -6156,8 +6158,9 @@ The [=remote end event trigger=] is the <dfn export>WebDriver BiDi download end<
    set to |download|, the <code>context</code> field set to |navigation info|["<code>context</code>"],
    the <code>navigation</code> field set to |navigation info|["<code>navigation</code>"],
    the <code>timestamp</code> field set to
-   |navigation info|["<code>timestamp</code>"], and the <code>url</code> field set to
-   |navigation info|["<code>url</code>"].
+   |navigation info|["<code>timestamp</code>"], the <code>url</code> field set to
+   |navigation info|["<code>url</code>"], and the <code>userContext</code> field
+   set to |navigation info|["<code>userContext</code>"].
 
 1. Let |body| be a [=/map=] matching the
    <code>browsingContext.DownloadEnd</code> production, with the

--- a/index.bs
+++ b/index.bs
@@ -3739,7 +3739,7 @@ browsingContext.BaseNavigationInfo = (
   navigation: browsingContext.Navigation / null,
   timestamp: js-uint,
   url: text,
-  ? userContext: browser.UserContext,
+  userContext: browser.UserContext,
 )
 
 browsingContext.NavigationInfo = {
@@ -4239,7 +4239,7 @@ The <dfn export for=commands>browsingContext.create</dfn> command creates a new
     <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.CreateResult = {
           context: browsingContext.BrowsingContext,
-          ? userContext: browser.UserContext
+          userContext: browser.UserContext
         }
     </pre>
    </dd>
@@ -5907,7 +5907,7 @@ given [=/navigable=] |navigable| and [=WebDriver BiDi navigation status|navigati
           context: browsingContext.BrowsingContext,
           timestamp: js-uint,
           url: text,
-          ? userContext: browser.UserContext
+          userContext: browser.UserContext
         }
       </pre>
    </dd>
@@ -6305,7 +6305,7 @@ given [=/navigable=] |navigable| and [=WebDriver BiDi navigation status|navigati
           context: browsingContext.BrowsingContext,
           accepted: bool,
           type: browsingContext.UserPromptType,
-          ? userContext: browser.UserContext,
+          userContext: browser.UserContext,
           ? userText: text
         }
       </pre>
@@ -6359,7 +6359,7 @@ given {{Window}} |window|, string |type|, boolean |accepted| and optional text |
           handler: session.UserPromptHandlerType,
           message: text,
           type: browsingContext.UserPromptType,
-          ? userContext: browser.UserContext,
+          userContext: browser.UserContext,
           ? defaultValue: text
         }
       </pre>
@@ -8471,13 +8471,16 @@ network.BaseParameters = (
     redirectCount: js-uint,
     request: network.RequestData,
     timestamp: js-uint,
-    ? userContext: browser.UserContext / null,
+    userContext: browser.UserContext / null,
     ? intercepts: [+network.Intercept]
 )
 </pre>
 
 The <code>network.BaseParameters</code> type is an abstract type representing
 the data that's common to all network events.
+
+Note: the <code>userContext</code> field is null if and only if the
+<code>context</code> field is null.
 
 Issue: Consider including the `sharedId` of the document node that initiated the
 request in addition to the context.
@@ -11922,7 +11925,7 @@ script.WindowRealmInfo = {
   script.BaseRealmInfo,
   type: "window",
   context: browsingContext.BrowsingContext,
-  ? userContext: browser.UserContext,
+  userContext: browser.UserContext,
   ? sandbox: text
 }
 
@@ -13081,6 +13084,10 @@ The <code>script.Source</code> type represents a <code>script.Realm</code> with
 an optional <code>browsingContext.BrowsingContext</code> and related
 <code>browser.UserContext</code> in which a script related event occurred.
 
+Note: the <code>context</code> and <code>userContext</code> fields are either
+both present, when the realm is associated with a [=/navigable=], or both
+omitted.
+
 <div algorithm>
 To <dfn>get the source</dfn> given |source realm|:
 
@@ -13097,7 +13104,8 @@ To <dfn>get the source</dfn> given |source realm|:
 
   1. Let |navigable id| be the [=navigable id=] for |navigable| if |navigable| is not null.
 
-  1. Let |user context id| be the [=user context id=] of |navigable|'s [=associated user context=].
+  1. Let |user context id| be the [=user context id=] of |navigable|'s
+     [=associated user context=] if |navigable| is not null.
 
   Otherwise let |navigable| be null.
 
@@ -13106,7 +13114,7 @@ To <dfn>get the source</dfn> given |source realm|:
    field set to |realm|, the <code>context</code> field set
    to |navigable id| if |navigable| is not null, or unset otherwise,
    and the <code>userContext</code> field set to |user context id| if
-   |navigable is not null, or unset otherwise.
+   |navigable| is not null, or unset otherwise.
 
 1. Return |source|.
 
@@ -15132,9 +15140,9 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
          input.FileDialogInfo = {
             context: browsingContext.BrowsingContext,
-            ? userContext: browser.UserContext,
-            ? element: script.SharedReference,
             multiple: bool,
+            userContext: browser.UserContext,
+            ? element: script.SharedReference,
          }
       </pre>
    </dd>


### PR DESCRIPTION
#1046 added `userContext` to the payloads of events that carry a browsing context, and to `browsingContext.CreateResult`, but marked it optional as a transition measure (#1071). The navigable, and therefore its associated user context, is always known in these algorithms, so the field is always set. Make it mandatory.

The download events splice in `browsingContext.BaseNavigationInfo` but copy fields out of the navigation info one at a time, so the second commit copies `userContext` across as well.

`browsingContext.CreateParameters.userContext` stays optional, since it is a command input and omitting it is meaningful. `script.Source.userContext` stays optional because its `context` field is optional too: a script related event can occur in a realm with no associated navigable.

This also covers the `browsingContext.CreateResult` change from #1122, which was closed in favour of doing it here.

Tests: web-platform-tests/wpt#61830

Fixes #1071

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
