### PR TITLE
Add "imageSize" argument to "browsingContext.captureScreenshot" command.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -132,6 +132,8 @@ spec: CONSOLE; urlPrefix: https://console.spec.whatwg.org
 spec: ECMASCRIPT-I18N; urlPrefix: https://tc39.es/ecma402/
   type: dfn
     text: DefaultLocale; url: #sec-defaultlocale
+    text: finite; url: #finite
+    text: integral Number; url: #integral-number
     text: IsStructurallyValidLanguageTag; url: #sec-isstructurallyvalidlanguagetag
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
@@ -3983,6 +3985,19 @@ To <dfn>rectangle intersection</dfn> given |rect1| and |rect2|
 </div>
 
 <div algorithm>
+To <dfn>round a number</dfn> given |number|:
+
+1. If |number| is not [=finite=] or |number| is an [=integral Number=], return |number|.
+
+1. If |number| < 0.5𝔽 and |number| > +0𝔽, return +0𝔽.
+
+1. If |number| < -0𝔽 and n ≥ -0.5𝔽, return -0𝔽.
+
+1. Return the [=integral Number=] closest to |number|, preferring the Number closer to +∞ in the case of a tie.
+
+</div>
+
+<div algorithm>
 To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image size|:
 
 1. Let |ratio| be [=determine the device pixel ratio=] given |document|'s
@@ -4012,9 +4027,13 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
       height| is less than |scale|, set |scale| to |max height| divided by
       |framebuffer height|.
 
-1. Let |paint width| be the maximum of 1 and |framebuffer width| multiplied by |scale|, rounded to the nearest integer.
+1. Let |scale width| be [=round a number=] given |framebuffer width| multiplied by |scale| rounded to the nearest integer.
 
-1. Let |paint height| be the maximum of 1 and |framebuffer height| multiplied by |scale|, rounded to the nearest integer.
+1. Let |scale height| be [=round a number=] given |framebuffer height| multiplied by |scale| rounded to the nearest integer.
+
+1. Let |paint width| be the maximum of 1 and |scale width|.
+
+1. Let |paint height| be the maximum of 1 and |scale height|.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.
@@ -4036,15 +4055,24 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
    points (0, 0), (|framebuffer width|, 0), (|framebuffer width|,
    |framebuffer height|), and (0, |framebuffer height|).
 
-1. Invoke |canvas context|'s {{CanvasTransform/scale()}} method with
+1. Run the steps corresponding to the {{CanvasTransform/scale()}} method on |canvas context| with
    <var ignore>x</var> set to |paint width| divided by |framebuffer width|, and
    <var ignore>y</var> set to |paint height| divided by |framebuffer height|.
 
+   Note: Running these steps doesn't cause any script to execute.
+
 1. Complete implementation specific steps equivalent to painting the region of
    |document|'s framebuffer specified by |source rectangle| on the region of
-   |canvas context|'s [=output bitmap=] specified by |destination rectangle|,
-   after applying |canvas context|'s [=current transformation matrix=] to
-   |destination rectangle|.
+   |canvas context|'s [=output bitmap=] specified by |destination rectangle|.
+
+   When the dimensions of |destination rectangle| are smaller than |source rectangle|,
+   then the value painted at a point in the |destination rectangle| is computed
+   by filtering the data from |document|'s framebuffer. The user agent may use
+   any filtering algorithm (for example bilinear interpolation or nearest-neighbor).
+   When the filtering algorithm requires a pixel value from outside the framebuffer,
+   it must instead use the value from the nearest edge pixel. (That is, the filter uses "clamp-to-edge" behavior.)
+   When the filtering algorithm requires a pixel value from outside the |source rectangle|
+   but inside the framebuffer, then the value from the framebuffer must be used.
 
 1. Return |canvas|.
 

--- a/index.bs
+++ b/index.bs
@@ -226,6 +226,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: create a new top-level traversable; url: document-sequences.html#creating-a-new-top-level-traversable
+    text: current transformation matrix; url: canvas.html#current-transformation-matrix
     text: default script fetch options; url: webappapis.html#default-script-fetch-options
     text: default view; url: nav-history-apis.html#dom-document-defaultview
     text: descendant navigables; url: document-sequences.html#descendant-navigables
@@ -241,6 +242,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: navigation id; url: browsing-the-web.html#navigation-id
     text: ongoing-navigation; url: browsing-the-web.html#ongoing-navigation
     text: origin-clean; url: canvas.html#concept-canvas-origin-clean
+    text: output bitmap; url: canvas.html#output-bitmap
     text: parent; for:navigable; url: document-sequences.html#nav-parent
     text: prompt to unload; url: browsing-the-web.html#prompt-to-unload-a-document
     text: prompt; url: timers-and-user-prompts.html#dom-prompt
@@ -3880,8 +3882,8 @@ Base64-encoded string.
       }
 
       browsingContext.ImageSize = {
-         ? width: js-uint,
-         ? height: js-uint,
+         ? width: js-uint .gt 0,
+         ? height: js-uint .gt 0,
       }
 
       browsingContext.ClipRectangle = (
@@ -3986,6 +3988,12 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
 1. Let |ratio| be [=determine the device pixel ratio=] given |document|'s
    [=default view=].
 
+1. Let |framebuffer width| be |rect|'s [=width dimension=] multiplied by
+   |ratio|, so it matches the width of |rect| in device pixels.
+
+1. Let |framebuffer height| be |rect|'s [=height dimension=] multiplied by
+   |ratio|, so it matches the height of |rect| in device pixels.
+
 1. Let |paint width| be 0.
 
 1. Let |paint height| be 0.
@@ -4028,13 +4036,9 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
 
 1. Otherwise:
 
-   1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |ratio|,
-      rounded to the nearest integer, so it matches the width of |rect| in device
-      pixels.
+   1. Set |paint width| to |framebuffer width|, rounded to the nearest integer.
 
-   1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |ratio|,
-      rounded to the nearest integer, so it matches the height of |rect| in device
-      pixels.
+   1. Set |paint height| to |framebuffer height|, rounded to the nearest integer.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.
@@ -4044,16 +4048,29 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
 
 1. Set |canvas|'s [=context mode=] to [=2D=].
 
-1. Complete implementation specific steps equivalent to drawing the region of
-   the framebuffer representing the region of |document| covered by |rect| to
-   |canvas context|, scaling it as needed to cover |canvas context|, with
-   (|rect|'s [=x coordinate=], |rect|'s [=y coordinate=]) in
-   viewport coordinates corresponding to (0,0) in |canvas context| and (|rect|'s
-   [=x coordinate=] + |rect|'s [=width dimension=], |rect|'s
-   [=y coordinate=] + |rect|'s [=height dimension=]) corresponding to (|paint
-   width|, |paint height|).
+1. Let |source x| be |rect|'s [=x coordinate=] multiplied by |ratio|, and let
+   |source y| be |rect|'s [=y coordinate=] multiplied by |ratio|.
 
-1. Return [=canvas=].
+1. Let |source rectangle| be the rectangle whose corners are the four points
+   (|source x|, |source y|), (|source x| + |framebuffer width|, |source y|),
+   (|source x| + |framebuffer width|, |source y| + |framebuffer height|), and
+   (|source x|, |source y| + |framebuffer height|).
+
+1. Let |destination rectangle| be the rectangle whose corners are the four
+   points (0, 0), (|framebuffer width|, 0), (|framebuffer width|,
+   |framebuffer height|), and (0, |framebuffer height|).
+
+1. Invoke |canvas context|'s {{CanvasTransform/scale()}} method with
+   <var ignore>x</var> set to |paint width| divided by |framebuffer width|, and
+   <var ignore>y</var> set to |paint height| divided by |framebuffer height|.
+
+1. Complete implementation specific steps equivalent to painting the region of
+   |document|'s framebuffer specified by |source rectangle| on the region of
+   |canvas context|'s [=output bitmap=] specified by |destination rectangle|,
+   after applying |canvas context|'s [=current transformation matrix=] to
+   |destination rectangle|.
+
+1. Return |canvas|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -228,7 +228,6 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: create a classic script; url: webappapis.html#creating-a-classic-script
     text: create a new browsing context; url: browsers.html#creating-a-new-browsing-context
     text: create a new top-level traversable; url: document-sequences.html#creating-a-new-top-level-traversable
-    text: current transformation matrix; url: canvas.html#current-transformation-matrix
     text: default script fetch options; url: webappapis.html#default-script-fetch-options
     text: default view; url: nav-history-apis.html#dom-document-defaultview
     text: descendant navigables; url: document-sequences.html#descendant-navigables

--- a/index.bs
+++ b/index.bs
@@ -3871,11 +3871,17 @@ Base64-encoded string.
         ? origin: ("viewport" / "document") .default "viewport",
         ? format: browsingContext.ImageFormat,
         ? clip: browsingContext.ClipRectangle,
+        ? imageSize: browsingContext.ImageSize,
       }
 
       browsingContext.ImageFormat = {
          type: text,
          ? quality: 0.0..1.0,
+      }
+
+      browsingContext.ImageSize = {
+         ? width: js-uint,
+         ? height: js-uint,
       }
 
       browsingContext.ClipRectangle = (
@@ -3975,18 +3981,60 @@ To <dfn>rectangle intersection</dfn> given |rect1| and |rect2|
 </div>
 
 <div algorithm>
-To <dfn>render document to a canvas</dfn> given |document| and |rect|:
+To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image size|:
 
 1. Let |ratio| be [=determine the device pixel ratio=] given |document|'s
    [=default view=].
 
-1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |ratio|,
-   rounded to the nearest integer, so it matches the width of |rect| in device
-   pixels.
+1. Let |paint width| be 0.
 
-1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |ratio|,
-   rounded to the nearest integer, so it matches the height of |rect| in device
-   pixels.
+1. Let |paint height| be 0.
+
+1. If |image size| is not null:
+
+   1. Let |requested width| be the <code>width</code> field of |image size| if
+      present, or null otherwise.
+
+   1. Let |requested height| be the <code>height</code> field of |image size| if
+      present, or null otherwise.
+
+   1. Run the steps under the first matching condition:
+      <dl>
+        <dt>|requested width| is not null and |requested height| is not null:
+        <dd>
+        1. Set |paint width| to |requested width|.
+
+        1. Set |paint height| to |requested height|.
+
+        Note: In this case the aspect ratio of |rect| is not preserved unless it
+        happens to match the aspect ratio of the requested size.
+
+        <dt>|requested width| is not null:
+        <dd>
+        1. Set |paint width| to |requested width|.
+
+        1. Set |paint height| to |requested width| multiplied by |rect|'s [=height dimension=],
+           divided by |rect|'s [=width dimension=], rounded to the nearest integer, so that the
+           aspect ratio of |rect| is preserved.
+
+        <dt>|requested height| is not null:
+        <dd>
+        1. Set |paint height| to |requested height|.
+
+        1. Set |paint width| to |requested height| multiplied by |rect|'s [=width dimension=],
+           divided by |rect|'s [=height dimension=], rounded to the nearest integer, so that the
+           aspect ratio of |rect| is preserved.
+      </dl>
+
+1. Otherwise:
+
+   1. Let |paint width| be |rect|'s [=width dimension=] multiplied by |ratio|,
+      rounded to the nearest integer, so it matches the width of |rect| in device
+      pixels.
+
+   1. Let |paint height| be |rect|'s [=height dimension=] multiplied by |ratio|,
+      rounded to the nearest integer, so it matches the height of |rect| in device
+      pixels.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.
@@ -3998,8 +4046,8 @@ To <dfn>render document to a canvas</dfn> given |document| and |rect|:
 
 1. Complete implementation specific steps equivalent to drawing the region of
    the framebuffer representing the region of |document| covered by |rect| to
-   |canvas context|, such that each pixel in the framebuffer corresponds to a pixel in
-   |canvas context| with (|rect|'s [=x coordinate=], |rect|'s [=y coordinate=]) in
+   |canvas context|, scaling it as needed to cover |canvas context|, with
+   (|rect|'s [=x coordinate=], |rect|'s [=y coordinate=]) in
    viewport coordinates corresponding to (0,0) in |canvas context| and (|rect|'s
    [=x coordinate=] + |rect|'s [=width dimension=], |rect|'s
    [=y coordinate=] + |rect|'s [=height dimension=]) corresponding to (|paint
@@ -4135,7 +4183,11 @@ The [=remote end steps=] with <var ignore>session</var> and |command parameters|
 1. If |rect|'s [=width dimension=] is 0 or |rect|'s [=height dimension=] is 0,
    return [=error=] with error code [=unable to capture screen=].
 
-1. Let |canvas| be [=render document to a canvas=] with |document| and |rect|.
+1. Let |image size| be the value of the <code>imageSize</code> field of |command
+   parameters| if present, or null otherwise.
+
+1. Let |canvas| be [=render document to a canvas=] with |document|, |rect| and
+   |image size|.
 
 1. Let |format| be the <code>format</code> field of |command parameters|.
 

--- a/index.bs
+++ b/index.bs
@@ -4055,20 +4055,6 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
    points (0, 0), (|framebuffer width|, 0), (|framebuffer width|,
    |framebuffer height|), and (0, |framebuffer height|).
 
-1. Run the steps corresponding to the {{CanvasTransform/scale()}} method on |canvas context| with
-   <var ignore>x</var> set to |paint width| divided by |framebuffer width|, and
-   <var ignore>y</var> set to |paint height| divided by |framebuffer height|.
-
-   Note: Running these steps doesn't cause any script to execute.
-
-   Note: |scale| can't be used directly here because |paint width| and |paint
-   height| are |framebuffer width| and |framebuffer height| multiplied by
-   |scale| and then rounded to an integer and clamped to a minimum of 1. The
-   canvas therefore has slightly different effective scaling factors, which can
-   also differ between the two axes. Deriving each factor from the corresponding
-   canvas dimension ensures that |destination rectangle| exactly covers the
-   canvas, with no unpainted edge or content painted outside it.
-
 1. Complete implementation specific steps equivalent to painting the region of
    |document|'s framebuffer specified by |source rectangle| on the region of
    |canvas context|'s [=output bitmap=] specified by |destination rectangle|.

--- a/index.bs
+++ b/index.bs
@@ -3882,8 +3882,8 @@ Base64-encoded string.
       }
 
       browsingContext.ImageSize = {
-         ? maxWidth: js-uint .gt 0,
-         ? maxHeight: js-uint .gt 0,
+         ? maxWidth: (js-uint .gt 1),
+         ? maxHeight: (js-uint .gt 1),
       }
 
       browsingContext.ClipRectangle = (
@@ -4012,9 +4012,9 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
       height| is less than |scale|, set |scale| to |max height| divided by
       |framebuffer height|.
 
-1. Let |paint width| be |framebuffer width| multiplied by |scale|, rounded to the nearest integer.
+1. Let |paint width| be the maximum of 1 and |framebuffer width| multiplied by |scale|, rounded to the nearest integer.
 
-1. Let |paint height| be |framebuffer height| multiplied by |scale|, rounded to the nearest integer.
+1. Let |paint height| be the maximum of 1 and |framebuffer height| multiplied by |scale|, rounded to the nearest integer.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.

--- a/index.bs
+++ b/index.bs
@@ -3882,8 +3882,8 @@ Base64-encoded string.
       }
 
       browsingContext.ImageSize = {
-         ? width: js-uint .gt 0,
-         ? height: js-uint .gt 0,
+         ? maxWidth: js-uint .gt 0,
+         ? maxHeight: js-uint .gt 0,
       }
 
       browsingContext.ClipRectangle = (
@@ -3994,51 +3994,27 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
 1. Let |framebuffer height| be |rect|'s [=height dimension=] multiplied by
    |ratio|, so it matches the height of |rect| in device pixels.
 
-1. Let |paint width| be 0.
-
-1. Let |paint height| be 0.
+1. Let |scale| be 1.
 
 1. If |image size| is not null:
 
-   1. Let |requested width| be the <code>width</code> field of |image size| if
+   1. Let |max width| be the <code>maxWidth</code> field of |image size| if
       present, or null otherwise.
 
-   1. Let |requested height| be the <code>height</code> field of |image size| if
+   1. Let |max height| be the <code>maxHeight</code> field of |image size| if
       present, or null otherwise.
 
-   1. Run the steps under the first matching condition:
-      <dl>
-        <dt>|requested width| is not null and |requested height| is not null:
-        <dd>
-        1. Set |paint width| to |requested width|.
+   1. If |max width| is not null and |max width| divided by |framebuffer width|
+      is less than |scale|, set |scale| to |max width| divided by |framebuffer
+      width|.
 
-        1. Set |paint height| to |requested height|.
+   1. If |max height| is not null and |max height| divided by |framebuffer
+      height| is less than |scale|, set |scale| to |max height| divided by
+      |framebuffer height|.
 
-        Note: In this case the aspect ratio of |rect| is not preserved unless it
-        happens to match the aspect ratio of the requested size.
+1. Let |paint width| be |framebuffer width| multiplied by |scale|, rounded to the nearest integer.
 
-        <dt>|requested width| is not null:
-        <dd>
-        1. Set |paint width| to |requested width|.
-
-        1. Set |paint height| to |requested width| multiplied by |rect|'s [=height dimension=],
-           divided by |rect|'s [=width dimension=], rounded to the nearest integer, so that the
-           aspect ratio of |rect| is preserved.
-
-        <dt>|requested height| is not null:
-        <dd>
-        1. Set |paint height| to |requested height|.
-
-        1. Set |paint width| to |requested height| multiplied by |rect|'s [=width dimension=],
-           divided by |rect|'s [=height dimension=], rounded to the nearest integer, so that the
-           aspect ratio of |rect| is preserved.
-      </dl>
-
-1. Otherwise:
-
-   1. Set |paint width| to |framebuffer width|, rounded to the nearest integer.
-
-   1. Set |paint height| to |framebuffer height|, rounded to the nearest integer.
+1. Let |paint height| be |framebuffer height| multiplied by |scale|, rounded to the nearest integer.
 
 1. Let |canvas| be a new {{HTMLCanvasElement}} with {{HTMLCanvasElement/width}} |paint
    width| and {{HTMLCanvasElement/height}} |paint height|.

--- a/index.bs
+++ b/index.bs
@@ -4061,6 +4061,14 @@ To <dfn>render document to a canvas</dfn> given |document|, |rect| and |image si
 
    Note: Running these steps doesn't cause any script to execute.
 
+   Note: |scale| can't be used directly here because |paint width| and |paint
+   height| are |framebuffer width| and |framebuffer height| multiplied by
+   |scale| and then rounded to an integer and clamped to a minimum of 1. The
+   canvas therefore has slightly different effective scaling factors, which can
+   also differ between the two axes. Deriving each factor from the corresponding
+   canvas dimension ensures that |destination rectangle| exactly covers the
+   canvas, with no unpainted edge or content painted outside it.
+
 1. Complete implementation specific steps equivalent to painting the region of
    |document|'s framebuffer specified by |source rectangle| on the region of
    |canvas context|'s [=output bitmap=] specified by |destination rectangle|.


### PR DESCRIPTION
Covers the resizing item in #1134.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1145.html" title="Last updated on Aug 11, 2026, 2:14 PM UTC (6b9be43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1145/6a2835c...lutien:6b9be43.html" title="Last updated on Aug 11, 2026, 2:14 PM UTC (6b9be43)">Diff</a>