### PR TITLE
Emit script.realmDestroyed when a worker event loop is destroyed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13942,7 +13942,7 @@ Define the following [=unloading document cleanup steps=] with |document|:
   1. Let |realm id| be the [=realm id=] for |realm|.
 
   1. Let |params| be a [=/map=] matching the <code>script.RealmDestroyedParameters</code>
-     production, with the <code>realm</code> field set of |realm id|.
+     production, with the <code>realm</code> field set to |realm id|.
 
   1. Let |body| be a [=/map=] matching the <code>script.RealmDestroyed</code>
      production, with the <code>params</code> field set to |params|.
@@ -13987,10 +13987,15 @@ worker=] algorithm:
 1. Let |realm id| be the [=realm id=] for |realm|.
 
 1. Let |params| be a [=/map=] matching the <code>script.RealmDestroyedParameters</code>
-   production, with the <code>realm</code> field set of |realm id|.
+   production, with the <code>realm</code> field set to |realm id|.
 
 1. Let |body| be a [=/map=] matching the <code>script.RealmDestroyed</code>
    production, with the <code>params</code> field set to |params|.
+
+1. For each |session| in the [=set of sessions for which an event is enabled=]
+   given "<code>script.realmDestroyed</code>" and |related navigables|:
+
+  1. [=Emit an event=] with |session| and |body|.
 
 </div>
 


### PR DESCRIPTION
Fixes #1147

The worker event loop branch of the [`script.realmDestroyed`](https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed) trigger built `params` and `body` but was missing the step that emits the event, so no event was sent when a worker event loop was destroyed. This adds it, copied from the document branch of the same algorithm.

Chrome and Firefox both already emit this event, naming the terminated worker's realm.

Also fixes two `field set of` typos in the same event definition, which should read `field set to`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AutomatedTester/webdriver-bidi/pull/1148.html" title="Last updated on Aug 18, 2026, 7:05 PM UTC (8c7d28d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1148/a8d59e7...AutomatedTester:8c7d28d.html" title="Last updated on Aug 18, 2026, 7:05 PM UTC (8c7d28d)">Diff</a>