### PR TITLE
List allowed media features in `emulation.setMediaFeaturesOverride`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6802,11 +6802,36 @@ allows overriding the values of various media features.
         ? userContexts: [+browser.UserContext],
       }
 
-      emulation.MediaFeatures = [emulation.MediaFeature]
-
-      emulation.MediaFeature = {
-         name: text
-         value: text
+      emulation.MediaFeatures = {
+        ? "any-hover": "none" / "hover" / null,
+        ? "any-pointer": "none" / "coarse" / "fine" / null,
+        ? "color": js-uint / null,
+        ? "color-gamut": "srgb" / "p3" / "rec2020" / null,
+        ? "color-index": js-uint / null,
+        ? "display-mode": "fullscreen" / "standalone" / "minimal-ui" / "browser" / "picture-in-picture" / null,
+        ? "dynamic-range": "standard" / "high" / null,
+        ? "environment-blending": "opaque" / "additive" / "subtractive" / null,
+        ? "forced-colors": "none" / "active" / null,
+        ? "grid": 0 / 1 / null,
+        ? "horizontal-viewport-segments": js-uint / null,
+        ? "hover": "none" / "hover" / null,
+        ? "inverted-colors": "none" / "inverted" / null,
+        ? "monochrome": js-uint / null,
+        ? "nav-controls": "none" / "back" / null,
+        ? "overflow-block": "none" / "scroll" / "optional-paged" / "paged" / null,
+        ? "overflow-inline": "none" / "scroll" / null,
+        ? "pointer": "none" / "coarse" / "fine" / null,
+        ? "prefers-color-scheme": "light" / "dark" / null,
+        ? "prefers-contrast": "no-preference" / "more" / "less" / "custom" / null,
+        ? "prefers-reduced-data": "no-preference" / "reduce" / null,
+        ? "prefers-reduced-motion": "no-preference" / "reduce" / null,
+        ? "prefers-reduced-transparency": "no-preference" / "reduce" / null,
+        ? "scan": "interlace" / "progressive" / null,
+        ? "scripting": "none" / "initial-only" / "enabled" / null,
+        ? "update": "none" / "slow" / "fast" / null,
+        ? "vertical-viewport-segments": js-uint / null,
+        ? "video-color-gamut": "srgb" / "p3" / "rec2020" / null,
+        ? "video-dynamic-range": "standard" / "high" / null,
       }
 
     </pre>


### PR DESCRIPTION
Follow-up after https://github.com/w3c/webdriver-bidi/pull/1076.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1149.html" title="Last updated on Aug 18, 2026, 12:18 PM UTC (0491906)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1149/f971275...0491906.html" title="Last updated on Aug 18, 2026, 12:18 PM UTC (0491906)">Diff</a>