### PR TITLE
Editorial: correct typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5656,7 +5656,7 @@ The <dfn export>WebDriver BiDi page show</dfn> steps given <var
 ignore>context</var> and [=WebDriver BiDi navigation status|navigation status=] |navigation status|
 are:
 
-Issue: Do we want to expose a `browsingContext.pageShow event? In that case we'd
+Issue: Do we want to expose a `browsingContext.pageShow` event? In that case we'd
 need to call this whenever `pageshow` is going to be emitted, not just on
 bfcache restore, and also add the persisted status to the data.
 


### PR DESCRIPTION
Insert omitted backtick


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jugglinmike/webdriver-bidi/pull/1150.html" title="Last updated on Aug 21, 2026, 6:04 PM UTC (80c3a2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1150/1e5e36c...jugglinmike:80c3a2e.html" title="Last updated on Aug 21, 2026, 6:04 PM UTC (80c3a2e)">Diff</a>