### PR TITLE
Pass a new "hasPlannedNavigation" flag to the "browsingContext.contextCreated" event.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5691,30 +5691,41 @@ are:
       <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.ContextCreated = (
          method: "browsingContext.contextCreated",
-         params: browsingContext.Info
+         params: browsingContext.ContextCreatedParameters
         )
+
+        browsingContext.ContextCreatedParameters = {
+          ~browsingContext.Info,
+          hasImmediateNavigation: bool,
+        }
       </pre>
    </dd>
 </dl>
 
 <div algorithm>
 
-To <dfn>Recursively emit context created events</dfn> given |session| and |navigable|:
+To <dfn>Recursively emit context created events</dfn> given |session|, |navigable|,
+and |has immediate navigation|:
 
-1. [=Emit a context created event=] with |session| and |navigable|.
+1. [=Emit a context created event=] with |session|, |navigable|, and
+   |has immediate navigation|.
 
 1. For each child navigable, |child|, of |navigable|:
 
-  1. [=Recursively emit context created events=] given |session| and |child|.
+  1. [=Recursively emit context created events=] given |session|, |child|, and
+     |has immediate navigation|.
 
 </div>
 
 <div algorithm>
 
-To <dfn>Emit a context created event</dfn> given |session| and |navigable|:
+To <dfn>Emit a context created event</dfn> given |session|, |navigable|, and
+|has immediate navigation|:
 
 1. Let |params| be the result of [=get the navigable info=] given
    |navigable|, 0, and true.
+
+1. Set |params|["<code>hasImmediateNavigation</code>"] to |has immediate navigation|.
 
 1. Let |body| be a [=/map=] matching the
    <code>browsingContext.ContextCreated</code> production, with the
@@ -5729,7 +5740,7 @@ To <dfn>Emit a context created event</dfn> given |session| and |navigable|:
 
 The [=remote end event trigger=] is
 the <dfn export>WebDriver BiDi navigable created</dfn> steps given
-[=/navigable=] |navigable| and [=/navigable=] |opener navigable|:
+[=/navigable=] |navigable|, |has immediate navigation|, and [=/navigable=] |opener navigable|:
 
 1. Set |navigable|'s [=original opener=] to |opener navigable|,
    if |opener navigable| is provided.
@@ -5743,7 +5754,8 @@ the <dfn export>WebDriver BiDi navigable created</dfn> steps given
 1. For each |session| in the [=set of sessions for which an event is enabled=]
    given "<code>browsingContext.contextCreated</code>" and |related navigables|:
 
-  1. [=Emit a context created event=] given |session| and |navigable|.
+  1. [=Emit a context created event=] given |session|, |navigable|, and
+     |has immediate navigation|.
 
 </div>
 
@@ -5754,7 +5766,7 @@ The [=remote end subscribe steps=], with [=subscribe priority=] 1, given
 
 1. For each |navigable| in |navigables|:
 
-  1. [=Recursively emit context created events=] given |session| and |navigable|.
+  1. [=Recursively emit context created events=] given |session|, |navigable|, and false.
 
 </div>
 


### PR DESCRIPTION
Covers part of #832.
Introduce a new `hasPlannedNavigation` flag to the "browsingContext.contextCreated" event that should indicate if a browsing context will navigate from the `about:blank` page. For lazy iframes, it looks like the BiDi event happens too early, so we cannot identify if an iframe is in the viewport. So we probably will need an event to know when they're rendered in the viewport and another property for a `browsingContext.contextCreated` to indicate that it's a lazy iframe that will have to wait for another event.
The HTML spec part is https://github.com/whatwg/html/pull/12833.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver-bidi/pull/1151.html" title="Last updated on Sep 11, 2026, 1:48 PM UTC (ac74ddc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1151/f685b93...lutien:ac74ddc.html" title="Last updated on Sep 11, 2026, 1:48 PM UTC (ac74ddc)">Diff</a>