### PR TITLE
Fix broken links to viewport concepts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -287,12 +287,10 @@ spec: CSSOM-VIEW; urlPrefix: https://drafts.csswg.org/cssom-view/
   type: dfn
     text: CSS pixel; url: #dom-window-devicepixelratio
     text: evaluate media queries and report changes; url: #evaluate-media-queries-and-report-changes
-    text: layout viewport; url: #layout-viewport
     text: scroll height; url: #dom-element-scrollheight
     text: scroll width; url: #dom-element-scrollwidth
     text: visual viewport page left; url: #dom-visualviewport-pageleft
     text: visual viewport page top; url: #dom-visualviewport-pagetop
-    text: visual viewport; url: #visual-viewport
     text: web-exposed available screen area; url: #web-exposed-available-screen-area
     text: web-exposed screen area; url: #web-exposed-screen-area
 spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
@@ -331,7 +329,6 @@ spec: MEDIAQUERIES4; urlPrefix: https://drafts.csswg.org/mediaqueries-4/
   type: dfn
     text: resolution media feature; url: #resolution
     text: media type; url: #media-type
-    text: media feature; url: #media-features
     text: mf-name; url: #typedef-mf-name
 spec: RFC9110; urlPrefix: https://httpwg.org/specs/rfc9110.html
   type: dfn


### PR DESCRIPTION
Some terms were moved from CSSOM View to CSS Viewport. Also, "media feature" is now defined as a singular. This fixes the broken links by letting Bikeshed sort things out on its own.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/1153.html" title="Last updated on Aug 25, 2026, 10:13 AM UTC (588e940)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1153/f685b93...588e940.html" title="Last updated on Aug 25, 2026, 10:13 AM UTC (588e940)">Diff</a>