### PR TITLE
Fix authChallenges field name in auth required assert

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10577,7 +10577,7 @@ steps given [=/request=] |request| and [=/response=] |response|:
 
   1. Let |response data| be the result of [=get the response data=] with |response|.
 
-  1. Assert: |response data| [=map/contains=] "<code>authChallenge</code>".
+  1. Assert: |response data| [=map/contains=] "<code>authChallenges</code>".
 
   1. Set the <code>response</code> field of |params| to |response data|.
 


### PR DESCRIPTION
Fixes a typo in the *handle auth required* steps: the assert checks the response data for an `authChallenge` key, but the field defined in `network.ResponseData` is `authChallenges`. The singular form is never set anywhere in the spec.

With the spelling fixed, the assert is accurate: these steps only run for 401 and 407 responses, and for those the response data always includes `authChallenges`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver-bidi/pull/1155.html" title="Last updated on Aug 27, 2026, 3:58 PM UTC (dd5c3ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1155/a7b8b67...titusfortner:dd5c3ee.html" title="Last updated on Aug 27, 2026, 3:58 PM UTC (dd5c3ee)">Diff</a>