### PR TITLE
Require sharedId on browsingContext.locateNodes result nodes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4472,7 +4472,7 @@ list of all nodes matching the specified locator.
    <dd>
     <pre class="cddl" data-cddl-module="local-cddl">
         browsingContext.LocateNodesResult = {
-            nodes: [ * script.NodeRemoteValue ]
+            nodes: [ * script.SharedNodeRemoteValue ]
         }
     </pre>
    </dd>
@@ -4734,6 +4734,14 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. Let |start node| be the result of [=trying=] to [=deserialize shared reference=] given
       |serialized start node|, |realm| and |session|.
 
+   1. If |start node|'s [=/node navigable=] is null, return [=error=] with
+      [=error code=] [=no such node=].
+
+      Note: This happens when the node was adopted into a document that is not
+      associated with a navigable, such as the associated inert template
+      document of a <{template}> element. Nodes located from such a start node
+      could not be serialized with a shared id.
+
    1. [=list/Append=] |start node| to |context nodes|.
 
 1. Assert [=list/size=] of |context nodes| is greater than 0.
@@ -4824,6 +4832,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
    1. Let |serialized node| be the result of [=serialize as a remote value=] with
       |result node|, |serialization options|, |result ownership|, a new [=/map=]
       as serialization internal map, |realm| and |session|.
+
+   1. Assert: |serialized node| [=map/contains=] "<code>sharedId</code>".
 
    1. [=list/Append=] |serialized node| to |serialized nodes|.
 
@@ -12247,6 +12257,21 @@ script.WindowProxyRemoteValue = {
 
 script.WindowProxyProperties = {
   context: browsingContext.BrowsingContext
+}
+</pre>
+
+A <code>script.SharedNodeRemoteValue</code> is a <code>script.NodeRemoteValue</code>
+that is known to carry a shared id. It is used for results of commands that
+serialize nodes in a context where [=get shared id for a node=] cannot return
+null.
+
+<pre class="cddl" data-cddl-module="local-cddl">
+script.SharedNodeRemoteValue = {
+  type: "node",
+  sharedId: script.SharedId,
+  ? handle: script.Handle,
+  ? internalId: script.InternalId,
+  ? value: script.NodeProperties,
 }
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -4739,7 +4739,7 @@ The [=remote end steps=] with |session| and |command parameters| are:
 
       Note: This happens when the node was adopted into a document that is not
       associated with a navigable, such as the associated inert template
-      document of a <{template}> element. Nodes located from such a start node
+      document of a <code>template</code> element. Nodes located from such a start node
       could not be serialized with a shared id.
 
    1. [=list/Append=] |start node| to |context nodes|.
@@ -4833,7 +4833,8 @@ The [=remote end steps=] with |session| and |command parameters| are:
       |result node|, |serialization options|, |result ownership|, a new [=/map=]
       as serialization internal map, |realm| and |session|.
 
-   1. Assert: |serialized node| [=map/contains=] "<code>sharedId</code>".
+   1. Assert: |serialized node| matches the <code>script.SharedNodeRemoteValue</code>
+      production.
 
    1. [=list/Append=] |serialized node| to |serialized nodes|.
 
@@ -12228,26 +12229,55 @@ script.HTMLCollectionRemoteValue = {
   ? value: script.ListRemoteValue,
 }
 
-script.NodeRemoteValue = {
+script.BaseNodeRemoteValue = (
   type: "node",
-  ? sharedId: script.SharedId,
   ? handle: script.Handle,
-  ? internalId: script.InternalId,
+  ? internalId: script.InternalId
+)
+
+script.NodeRemoteValue = {
+  script.BaseNodeRemoteValue,
+  ? sharedId: script.SharedId,
   ? value: script.NodeProperties,
 }
 
-script.NodeProperties = {
+script.BaseNodeProperties = (
   nodeType: js-uint,
   childNodeCount: js-uint,
   ? attributes: {*text => text},
-  ? children: [*script.NodeRemoteValue],
   ? localName: text,
   ? mode: "open" / "closed",
   ? namespaceURI: text,
-  ? nodeValue: text,
+  ? nodeValue: text
+)
+
+script.NodeProperties = {
+  script.BaseNodeProperties,
+  ? children: [*script.NodeRemoteValue],
   ? shadowRoot: script.NodeRemoteValue / null,
 }
+</pre>
 
+A <code>script.SharedNodeRemoteValue</code> is a <code>script.NodeRemoteValue</code>
+that is known to carry a shared id, recursively for any serialized children and
+shadow roots. It is used for results of commands that serialize nodes in a
+context where [=get shared id for a node=] cannot return null.
+
+<pre class="cddl" data-cddl-module="local-cddl">
+script.SharedNodeRemoteValue = {
+  script.BaseNodeRemoteValue,
+  sharedId: script.SharedId,
+  ? value: script.SharedNodeProperties,
+}
+
+script.SharedNodeProperties = {
+  script.BaseNodeProperties,
+  ? children: [*script.SharedNodeRemoteValue],
+  ? shadowRoot: script.SharedNodeRemoteValue / null,
+}
+</pre>
+
+<pre class="cddl" data-cddl-module="remote-cddl,local-cddl">
 script.WindowProxyRemoteValue = {
   type: "window",
   value: script.WindowProxyProperties,
@@ -12257,21 +12287,6 @@ script.WindowProxyRemoteValue = {
 
 script.WindowProxyProperties = {
   context: browsingContext.BrowsingContext
-}
-</pre>
-
-A <code>script.SharedNodeRemoteValue</code> is a <code>script.NodeRemoteValue</code>
-that is known to carry a shared id. It is used for results of commands that
-serialize nodes in a context where [=get shared id for a node=] cannot return
-null.
-
-<pre class="cddl" data-cddl-module="local-cddl">
-script.SharedNodeRemoteValue = {
-  type: "node",
-  sharedId: script.SharedId,
-  ? handle: script.Handle,
-  ? internalId: script.InternalId,
-  ? value: script.NodeProperties,
 }
 </pre>
 


### PR DESCRIPTION
`LocateNodesResult` types its nodes as `script.NodeRemoteValue`, where `sharedId` is optional. The command's algorithm guarantees more:

- result ownership is `"none"`, so `handle` is never created
- every located node is in a document with a navigable, so serialization always produces a shared id

So a conforming-by-the-CDDL response can carry no reference of any kind, which also strands `startNodes` — `script.SharedReference` requires `sharedId`, and a previous `locateNodes` result is its only source for a freshly located node. Safari does this today:

```ruby
forms = browsing_context.locate_nodes(
  context: driver.window_handle,
  locator: BrowsingContext::CssLocator.new(value: 'form'),
  max_node_count: 1
)
Script::SharedReference.new(shared_id: forms.nodes.first.shared_id)
# => ArgumentError: Selenium::WebDriver::BiDi::Protocol::Script::SharedReference#shared_id is required
#                   ./rb/lib/selenium/webdriver/bidi/serialization/record.rb:115:in `validate_values'
```

A client generated from the CDDL parses the browser response as valid; the error comes from trying to use it, which results in a confusing error.

Additionally, WPT already asserts `sharedId` on every `locate_nodes` result node, so this change makes the type say what the tests and conforming implementations already enforce.

Changes:

- `LocateNodesResult` now uses `script.SharedNodeRemoteValue`: `script.NodeRemoteValue` with `sharedId` required, named after `script.SharedReference`
- return `no such node` for a start node whose node navigable is null (e.g. adopted into a `<template>`'s inert content document) — it still deserializes, and the non-CSS strategies traverse its subtree, yielding nodes that would serialize without a shared id
- assert `sharedId` at serialization, following the `network.authRequired` assert

Notes:

- narrower than #868: only the result type of one command whose serialization inputs are fully pinned down


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver-bidi/pull/1156.html" title="Last updated on Sep 8, 2026, 2:44 PM UTC (4563d92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/1156/a7b8b67...titusfortner:4563d92.html" title="Last updated on Sep 8, 2026, 2:44 PM UTC (4563d92)">Diff</a>